### PR TITLE
docs: correct builder method names in examples

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -302,7 +302,7 @@ warrant = (Warrant.builder()
     })
     .ttl(3600)
     .holder(keypair.public_key)
-    .build(keypair))
+    .issue(keypair))
 
 # Issuer warrant with builder
 issuer = (Warrant.builder()
@@ -329,7 +329,7 @@ issuer = (Warrant.builder()
 | `.constraint_bound(field, value)` | Add constraint bound |
 | `.max_issue_depth(n)` | Max delegation depth |
 | `.preview()` | Preview configuration before building |
-| `.build(keypair)` | Build and sign the warrant |
+| `.issue(keypair)` | Issue and sign the warrant |
 
 #### Instance Properties
 
@@ -465,7 +465,7 @@ builder = warrant.attenuate()
 | `ttl(seconds)` | `AttenuationBuilder` | Set shorter TTL |
 | `terminal()` | `AttenuationBuilder` | Make warrant terminal (no further delegation) |
 | `diff()` | `str` | Preview changes (human-readable) |
-| `build(keypair, parent_keypair)` | `Warrant` | Build and sign the warrant |
+| `delegate_to(keypair, parent_keypair)` | `Warrant` | Issue child with receipt |
 
 #### Example
 
@@ -474,7 +474,7 @@ builder = warrant.attenuate()
 child = (parent.attenuate()
     .with_capability("read_file", {"path": Exact("/data/q3.pdf")})
     .holder(worker_kp.public_key)
-    .build(worker_kp, parent_kp))
+    .delegate_to(worker_kp, parent_kp))
 ```
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,7 +68,7 @@ warrant = (Warrant.builder()
     })
     .holder(keypair.public_key)
     .ttl(3600)
-    .build(keypair))
+    .issue(keypair))
 ```
 
 ### 2. Attenuate (Delegate with Narrower Scope)
@@ -86,7 +86,7 @@ worker_warrant = (warrant.attenuate()
         "replicas": Range.max_value(10),     # Reduced to 10 replicas
     })
     .holder(worker_keypair.public_key)
-    .build(worker_keypair, keypair))  # Child signs, parent authorizes
+    .delegate_to(worker_keypair, keypair))  # Child signs, parent authorizes
 ```
 
 ### 3. Authorize an Action


### PR DESCRIPTION
Align quickstart and API reference to use issue/delegate_to instead of outdated build calls.