### PR TITLE
Fix editable install error by upgrading pip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Thank you for your interest in contributing to Tenuo! We welcome contributions f
     ```bash
     python3 -m venv .venv
     source .venv/bin/activate
+    pip install --upgrade pip
     cd tenuo-python
     pip install -e ".[dev]"
     ```


### PR DESCRIPTION
This PR adds pip install --upgrade pip after activation and before installing the package. Python 3.9.6 ships with pip 21.2.4, which doesn't support editable installs with pyproject.toml-only projects using maturin (requires PEP 660 support in pip 23.0+).


<img width="947" height="130" alt="Screenshot 2026-01-14 at 9 52 25 PM" src="https://github.com/user-attachments/assets/4c562a5e-cff8-4b6a-bd40-709f80880875" />
