### PR TITLE
refactor(crewai): use native hooks API for cleaner integration

### DIFF
--- a/tenuo-python/tests/test_crewai.py
+++ b/tenuo-python/tests/test_crewai.py
@@ -1099,33 +1099,6 @@ class TestWarrantDelegator:
             )
 
 
-@pytest.mark.skip(reason="seal() removed in hooks API refactoring")
-class TestSealMode:
-    """Tests for seal mode (on-the-wire verification)."""
-
-    def test_seal_builder_method(self):
-        """GuardBuilder has seal() method."""
-        builder = GuardBuilder()
-        assert hasattr(builder, "seal")
-
-        # Fluent API
-        result = builder.seal()
-        assert result is builder
-
-    def test_seal_mode_passed_to_guard(self):
-        """Seal mode is passed to built guard."""
-        guard_sealed = GuardBuilder().seal().build()
-        guard_unsealed = GuardBuilder().build()
-
-        assert guard_sealed._seal_mode is True
-        assert guard_unsealed._seal_mode is False
-
-    def test_seal_disabled_by_default(self):
-        """Seal mode is disabled by default."""
-        guard = GuardBuilder().allow("test", arg=Wildcard()).build()
-        assert guard._seal_mode is False
-
-
 class TestPhase5GuardedStep:
     """Tests for @guarded_step decorator (Phase 5)."""
 

--- a/tenuo-python/tests/test_crewai_adversarial.py
+++ b/tenuo-python/tests/test_crewai_adversarial.py
@@ -458,67 +458,6 @@ class TestAuditIntegrity:
         assert result is None
 
 
-# =============================================================================
-# 8. Seal Mode (On-the-Wire Protection)
-# =============================================================================
-
-
-@pytest.mark.skip(reason="seal() removed in hooks API refactoring - framework-level hooks replace tool sealing")
-class TestSealMode:
-    """
-    Tests ensuring seal mode prevents original tool bypass.
-    This is critical for "on-the-wire" verification.
-    """
-
-    def test_seal_mode_blocks_original_tool(self):
-        """
-        Invariant: After sealing, original tool cannot be called.
-        """
-        original_tool = RealTool(name="read")
-
-        guard = (GuardBuilder()
-            .allow("read", path=Wildcard())
-            .seal()
-            .build())
-
-        # Protect with seal mode - this modifies original_tool in place
-        guard.protect(original_tool)
-
-        # Original tool should now raise RuntimeError when called
-        with pytest.raises(RuntimeError, match="sealed by Tenuo guard"):
-            original_tool._run(path="/data/file.txt")
-
-    def test_seal_mode_disabled_allows_original(self):
-        """
-        When seal mode is disabled, original tool still works.
-        """
-        original_tool = RealTool(name="read")
-
-        guard = (GuardBuilder()
-            .allow("read", path=Wildcard())
-            # No .seal() call
-            .build())
-
-        assert guard._seal_mode is False
-
-        # Protect without seal (default)
-        guard.protect(original_tool)
-
-        # Original should still work (no seal)
-        result = original_tool._run(path="/data/file.txt")
-        assert result is not None
-
-    def test_guard_has_seal_mode_attribute(self):
-        """
-        Guard has seal_mode accessible for inspection.
-        """
-        guard_sealed = GuardBuilder().seal().build()
-        guard_unsealed = GuardBuilder().build()
-
-        assert guard_sealed._seal_mode is True
-        assert guard_unsealed._seal_mode is False
-
-
 class TestSecurityRegressions:
     """
     Regression tests for critical security vulnerabilities.
@@ -545,31 +484,6 @@ class TestSecurityRegressions:
         # MUST return denial, not None
         assert isinstance(result, DenialResult)
         assert result.error_code == "WARRANT_EXPIRED"
-
-    @pytest.mark.skip(reason="seal() removed in hooks API refactoring - framework-level hooks replace tool sealing")
-    def test_seal_fails_closed_on_immutable_tool(self):
-        """
-        REGRESSION: Seal mode must raise if tool is immutable.
-        Previously: Logged warning and continued with unprotected bypass.
-        """
-        from tenuo.crewai import ConfigurationError
-
-        # Create an immutable-like tool (RealTool is a BaseTool)
-        class LockedTool(RealTool):
-            def __setattr__(self, key, value):
-                if key in ("_run", "func"):
-                    raise AttributeError(f"{key} is read-only")
-                super().__setattr__(key, value)
-
-        immutable_tool = LockedTool(name="read")
-
-        guard = (GuardBuilder()
-            .allow("read", path=Wildcard())
-            .seal()  # Enable seal mode
-            .build())
-
-        with pytest.raises(ConfigurationError, match="Cannot seal tool"):
-            guard.protect(immutable_tool)
 
     def test_namespace_injection_rejected(self):
         """


### PR DESCRIPTION
## Summary

- Refactors CrewAI integration to use native `before_tool_call` hooks instead of tool wrapping
- More idiomatic integration that works at the framework level
- Fixes hook return values and exception handling for proper blocking

## Changes

**Core API (`tenuo/crewai.py`):**
- Add `register()` - Install guard as global `before_tool_call` hook
- Add `unregister()` - Remove the global hook  
- Add `as_hook()` - Get hook function for crew-scoped registration
- Add `authorize_hook()` - Direct authorization from hook context
- Add `HOOKS_AVAILABLE` flag to check CrewAI version compatibility
- Remove `protect()`, `protect_all()`, `protect_tool()`, `protect_agent()`
- Remove seal mode (not needed - hooks intercept at framework level)

**New Usage Pattern:**
```python
guard = (GuardBuilder()
    .allow("read_file", path=Subpath("/data"))
    .on_denial("raise")
    .build())

guard.register()  # ALL tool calls now go through authorization
crew.kickoff()
guard.unregister()
```

**Examples Updated:**
- `quickstart.py` - Shows hooks API usage
- `demo_live.py` - Uses `guard.register()` for real LLM demo  
- `demo_simple.py` - Manual authorization pattern + red BLOCKED color
- `hierarchical_delegation.py` - Removed seal() references

## Test plan

- [x] `python quickstart.py` - passes
- [x] `python demo_simple.py` - passes, blocks unauthorized access
- [x] `python demo_live.py` - blocks injection attack with real LLM
- [x] `python research_team_demo.py --attacks` - all 4 attacks blocked
- [x] `ruff check` - no lint errors
- [x] `./scripts/check.sh` - all checks pass

## Breaking Changes

- `protect()` and `protect_all()` removed - use `guard.register()` instead
- `protect_tool()` and `protect_agent()` removed
- `seal()` method removed


Made with [Cursor](https://cursor.com)