### PR TITLE
release: v0.1.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.9] - 2026-02-17
+
+### Added
+- **Temporal distributed deployment**: Header propagation via outbound interceptor — works when client and worker are separate processes
+- **`AuthorizedWorkflow`**: Base class with fail-fast validation and automatic PoP
+- **`TenuoClientInterceptor`**: Client-side warrant header injection
+- **Live integration tests**: 36 tests including 5 against an in-process Temporal server
+- **Examples**: `authorized_workflow_demo.py`, `multi_warrant.py`, `delegation.py`
+
+### Fixed
+- Broken header propagation in distributed Temporal deployments
+- AWS/GCP key resolver tests on CI without cloud SDKs installed
+- mypy errors for optional dependencies (`temporalio`, `google.adk`, `agents`)
+
 ## [0.1.0-beta.8] - 2026-02-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ This runs the [orchestrator -> worker -> authorizer demo](https://tenuo.ai/demo.
 **Official Images** on [Docker Hub](https://hub.docker.com/u/tenuo):
 
 ```bash
-docker pull tenuo/authorizer:0.1.0-beta.8  # Sidecar for warrant verification
-docker pull tenuo/control:0.1.0-beta.8     # Control plane (demo/reference)
+docker pull tenuo/authorizer:0.1.0-beta.9  # Sidecar for warrant verification
+docker pull tenuo/control:0.1.0-beta.9     # Control plane (demo/reference)
 ```
 
 **Helm Chart**:
@@ -339,7 +339,7 @@ Building a sidecar or gateway? Use the core directly:
 
 ```toml
 [dependencies]
-tenuo = "0.1.0-beta.8"
+tenuo = "0.1.0-beta.9"
 ```
 
 See [docs.rs/tenuo](https://docs.rs/tenuo) for Rust API.

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Agent Capability Flow Control - Rust core library"

--- a/tenuo-python/Cargo.lock
+++ b/tenuo-python/Cargo.lock
@@ -1290,7 +1290,7 @@ checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "base64",
  "cel-interpreter",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-python"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "pyo3",
  "tenuo",

--- a/tenuo-python/Cargo.toml
+++ b/tenuo-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-python"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Capability tokens for AI agents - Python SDK"

--- a/tenuo-python/pyproject.toml
+++ b/tenuo-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tenuo"
-version = "0.1.0b8"
+version = "0.1.0b9"
 description = "Capability tokens for AI agents - Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tenuo-python/tenuo/__init__.py
+++ b/tenuo-python/tenuo/__init__.py
@@ -245,4 +245,4 @@ __all__ = [
     "Keyring",
 ]
 
-__version__ = "0.1.0b8"
+__version__ = "0.1.0b9"

--- a/tenuo-wasm/Cargo.lock
+++ b/tenuo-wasm/Cargo.lock
@@ -1282,7 +1282,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "base64",
  "cel-interpreter",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-wasm"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/tenuo-wasm/Cargo.toml
+++ b/tenuo-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-wasm"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "WASM bindings for Tenuo"


### PR DESCRIPTION
## Summary
- Bump version to `0.1.0-beta.9` across all crates and Python package
- Add CHANGELOG entry for Temporal distributed deployment, AuthorizedWorkflow, live tests, and bug fixes

## Changelog
See [CHANGELOG.md](CHANGELOG.md#010-beta9---2026-02-17)
