### PR TITLE
feat: add Claude Code skills for warrant creation and auditing

### DIFF
--- a/skills/tenuo-audit/SKILL.md
+++ b/skills/tenuo-audit/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: tenuo-audit
+description: Audit, explain, and review tenuo warrants for security engineers and CISOs. Use this skill when someone wants to understand what a warrant authorizes, assess blast radius, review delegation chains, check for security risks, or audit agent permissions. Also trigger when a security engineer asks about agent authorization, access control review, permission auditing, or wants warrants explained in IAM/RBAC/OAuth terms.
+---
+
+# Tenuo Warrant Auditor
+
+Help security engineers and CISOs understand what tenuo warrants authorize, assess blast radius, review delegation chains, and flag security risks — all explained in the access control language they already know.
+
+**Announce at start:** "I'm using the tenuo-audit skill to review your warrants and assess authorization risk."
+
+## How Warrants Map to Familiar Concepts
+
+Warrants are tenuo's authorization primitive — capability tokens with cryptographic delegation chains. If you're coming from traditional access control, here's the translation:
+
+| Tenuo | IAM | RBAC | OAuth |
+|---|---|---|---|
+| Warrant | Session-scoped IAM policy | Role binding with TTL | Access token with scopes |
+| Capability | IAM action (s3:GetObject) | Permission | Scope (files:read) |
+| Constraint | IAM condition (StringLike) | N/A (RBAC lacks this) | N/A (OAuth lacks this) |
+| Attenuation | Cannot escalate (no privilege widening) | Cannot add permissions to inherited role | Cannot widen scopes on refresh |
+| Proof-of-Possession | Like mTLS — token bound to key | N/A (RBAC is bearer) | DPoP (RFC 9449) |
+| TTL | Session duration | N/A (roles are permanent) | Token expiry |
+| Delegation chain | AssumeRole chain | Role inheritance | Token exchange (RFC 8693) |
+| Closed-world mode | Default deny policy | Implicit deny | N/A |
+
+The key difference: warrants carry **semantic constraints** on arguments (e.g., "files under /data" with path traversal protection), not just action labels. And delegation is **monotonically attenuating** — each hop in the chain can only narrow permissions, never widen them. This is enforced cryptographically, not by policy.
+
+## Flow
+
+### Phase 1: Context Discovery
+
+Scan the codebase for tenuo usage:
+1. Search for `import tenuo`, `from tenuo`, `Warrant`, `mint_builder`, `grant_builder`, `@guard`
+2. Check for `tenuo_cloud` imports or `tc_` env vars (indicates cloud deployment)
+3. Look for warrant serialization patterns (base64 strings, `warrant.serialize()`, `Warrant(...)` deserialization)
+
+### Phase 2: Persona Check
+
+Ask: **"Before we start — are you a developer building agent integrations, a platform engineer setting up infrastructure, or a security engineer reviewing permissions?"**
+
+- **Security engineer / CISO** → continue with this skill
+- **Developer** → suggest `/tenuo-warrant` instead ("That skill helps you create warrants from scratch — it'll walk you through what your agent needs")
+- **Platform engineer** → continue, adjusting framing for infrastructure review
+
+### Phase 3: Source Selection
+
+Ask: **"What would you like to audit?"**
+
+- **a) A warrant string** — they'll paste a base64-encoded warrant for you to decode and explain
+- **b) Warrants in the codebase** — find all `mint_builder`, `grant_builder`, `GuardBuilder`, `mint()`, `grant()` calls and analyze them
+- **c) A delegation chain** — multiple warrants showing parent → child relationships
+- **d) Cloud audit trail** — connect to tenuo cloud API for issuance receipts, approval history, revocation status
+
+### Phase 4: Decode and Analyze
+
+For each warrant found, extract and present:
+
+**Structural properties:**
+- Issuer public key (who created it)
+- Holder public key (who can use it)
+- Current depth and max_depth
+- TTL / expiration time
+- Parent hash (chain link to parent warrant)
+
+**Authorization surface:**
+- List of capabilities (tools/actions granted)
+- Constraints on each capability's arguments
+- Closed-world status (are unconstrained arguments rejected?)
+
+### Phase 5: Plain-Language Explanation
+
+Present what the warrant authorizes in security review format:
+
+```
+🔍 Warrant Analysis
+
+Holder: [key fingerprint or identifier]
+Issuer: [key fingerprint or identifier]
+Chain depth: 2 of 3 (1 delegation hop remaining)
+
+AUTHORIZED ACTIONS:
+  ✓ read_file
+    └─ path: Subpath("/data/reports") — traversal protected
+       Allowed: /data/reports/*, /data/reports/2024/q4.csv
+       Blocked: /data/reports/../../etc/passwd, /data/other/*
+
+  ✓ create_issue
+    └─ url: UrlSafe + UrlPattern("https://api.github.com/*")
+       Allowed: https://api.github.com/repos/org/repo/issues
+       Blocked: http://169.254.169.254/metadata (SSRF), http://internal:8080
+
+DENIED (not in capability set):
+  ✗ write_file, delete_file, execute_command, send_email, ...
+  ✗ Any tool not explicitly listed above
+
+TEMPORAL:
+  ⏱ TTL: 1800s (expires 2026-03-13T15:30:00Z)
+  🔗 Delegation: depth 2/3 — can delegate once more, then terminal
+
+BINDING:
+  🔒 Proof-of-possession: Required (bearer token risk mitigated)
+  📋 Closed-world: Active (unconstrained arguments rejected)
+```
+
+### Phase 6: Familiar Framework Mapping
+
+Translate the warrant into equivalent policies the security engineer is used to reviewing:
+
+```
+IAM Policy Equivalent:
+{
+  "Effect": "Allow",
+  "Action": ["s3:GetObject", "github:CreateIssue"],
+  "Resource": ["arn:aws:s3:::data/reports/*", "github:repos/*/issues"],
+  "Condition": {
+    "IpAddress": {"aws:SourceIp": "not-applicable (UrlSafe handles this)"},
+    "DateLessThan": {"aws:CurrentTime": "2026-03-13T15:30:00Z"}
+  }
+}
+
+RBAC Equivalent:
+  Role: report-reader-github-issuer
+  Namespace: agent-pool
+  Bindings: [read_file, create_issue]
+  Session limit: 30 minutes
+
+OAuth Equivalent:
+  Scopes: files:read:reports, github:issues:write
+  Token type: DPoP-bound (not bearer)
+  Expires: 1800s
+  Refresh: None (warrant is one-use authority chain)
+```
+
+### Phase 7: Delegation Chain Verification
+
+For delegation chains (multiple warrants showing parent → child):
+
+**Verify invariants I1-I5 statically:**
+- **I1**: `child.issuer == parent.holder` (delegation comes from the right entity)
+- **I2**: `child.depth == parent.depth + 1` (depth increments correctly)
+- **I3**: `child.expires_at <= parent.expires_at` (child can't outlive parent)
+- **I4**: `child.capabilities ⊆ parent.capabilities` (capabilities only narrow)
+- **I5**: `child.parent_hash == SHA256(parent.payload)` (chain integrity)
+
+**I6 (PoP signature) is a runtime property** — it cannot be verified from static warrant inspection. Instead, check whether PoP enforcement is configured in the codebase. If not, flag as HIGH risk.
+
+**Visualize attenuation:**
+```
+Root Warrant (depth 0, max_depth 3)
+  ├─ read_file: Subpath("/data")
+  ├─ write_file: Subpath("/data")
+  ├─ call_api: UrlSafe + UrlPattern("https://*.example.com/*")
+  └─ TTL: 3600s
+
+  └─► Orchestrator Warrant (depth 1)    [ATTENUATION: -write_file, narrowed path]
+      ├─ read_file: Subpath("/data/reports")
+      ├─ call_api: UrlSafe + UrlPattern("https://api.example.com/*")
+      └─ TTL: 1800s
+
+      └─► Worker Warrant (depth 2)       [ATTENUATION: -call_api, terminal]
+          ├─ read_file: Subpath("/data/reports/2024")
+          └─ TTL: 300s (TERMINAL — cannot delegate further)
+```
+
+Flag violations clearly:
+- "**VIOLATION I3**: Child warrant expires at 16:00 but parent expires at 15:30 — child outlives parent"
+- "**VIOLATION I4**: Child has `write_file` capability but parent does not — privilege escalation"
+
+### Phase 8: Risk Assessment
+
+Assess each warrant against this risk framework:
+
+| Finding | Severity | What it means |
+|---|---|---|
+| `_allow_unknown=True` | **HIGH** | Closed-world disabled. Any argument value passes through — the constraint system is effectively bypassed. Like an IAM policy with `"Resource": "*"`. |
+| PoP not enforced | **HIGH** | Warrant is a bearer token. If stolen, attacker can use it without the holder's private key. Like an API key vs. mTLS. |
+| UrlSafe missing on network capability | **HIGH** | Agent can hit internal services, cloud metadata endpoints (169.254.169.254). SSRF risk. |
+| No TTL or TTL > 1 hour | **MEDIUM** | Long-lived credential. Increases the blast radius time window. Like a non-expiring session token. |
+| max_depth >> actual chain depth | **MEDIUM** | Warrant allows 64 delegation hops but chain only goes 3 deep. Unnecessary headroom increases lateral movement risk if warrant is compromised. |
+| CEL constraint without review | **MEDIUM** | Custom evaluation logic. Could contain subtle bugs or overly permissive expressions. Needs human verification — like a custom OPA policy. |
+| Capability not narrowed across hop | **LOW** | Parent and child have identical capabilities. Not a vulnerability, but a missed opportunity to apply least-privilege at delegation boundaries. |
+| Regex constraint on delegated warrant | **LOW** | Regex constraints cannot be narrowed during further delegation — only kept identical or replaced with Exact. May limit attenuation flexibility downstream. |
+
+Present findings with severity and remediation:
+
+```
+🔒 Security Assessment
+
+HIGH ⚠️  UrlSafe not applied to "call_api" capability
+         Risk: Agent could call internal services or cloud metadata endpoints
+         Fix: Add UrlSafe() constraint — All([UrlSafe(), UrlPattern("https://...")])
+
+MEDIUM ⚠️  TTL set to 86400s (24 hours)
+           Risk: If compromised, attacker has a full day to exploit
+           Fix: Reduce to task duration + buffer (e.g., 1800s for a 15-min task)
+
+LOW ℹ️  Capability "read_file" not narrowed from parent to child
+        Note: Both have Subpath("/data") — child could be narrowed to
+              Subpath("/data/reports") for tighter least-privilege
+```
+
+### Phase 9: Cloud Audit Trail
+
+If tenuo cloud is configured (`tenuo_cloud` imports or `tc_` API keys detected):
+
+Ask: "Want me to pull the audit trail from tenuo cloud for this warrant?"
+
+If yes, check:
+- **Issuance receipts** — cryptographic proof of when and why the warrant was issued
+- **Approval history** — which approval gates were triggered, who approved
+- **Revocation status** — is this warrant on the Signed Revocation List (SRL)?
+- **Template source** — which policy template was used to generate this warrant
+
+Present: "This warrant was issued via trigger `trg_abc123` at 2026-03-13T14:00:00Z. Approved by admin@example.com. Not revoked. Last SRL sync: 3 seconds ago."
+
+### Output Formats
+
+Offer the appropriate format based on context:
+
+- **Summary** — One paragraph, shareable with stakeholders who don't need technical detail
+- **Detailed** — Full constraint-by-constraint analysis with analogies and risk ratings (default)
+- **Comparison** — Side-by-side diff of two warrants (useful for before/after attenuation review, or comparing two versions of a policy)
+
+After completing, suggest: "Want to create a tighter replacement warrant? Use `/tenuo-warrant` to build one from scratch with the right constraints."
+
+## Key Tenuo Concepts for Security Review
+
+**Monotonic attenuation**: Every delegation can only narrow permissions. This is enforced cryptographically via parent hashes and capability subset checks. Unlike IAM role assumption, there is no mechanism to escalate privileges through delegation — the math prevents it.
+
+**Proof-of-Possession (PoP)**: Warrants are bound to a public key. Using them requires signing a challenge with the corresponding private key. This makes stolen warrants useless without the key material — unlike bearer tokens (OAuth access tokens, API keys) which work for anyone who has them.
+
+**Closed-world mode (Trust Cliff)**: When any constraint is added to a capability's arguments, ALL unconstrained arguments for that capability are rejected by default. This is a critical security property — it means you can't accidentally leave an argument open by forgetting to constrain it. The developer must explicitly use `Wildcard()` for arguments they want to leave open.
+
+**MAX_DELEGATION_DEPTH = 64**: Hard cap on delegation chain length (defined in tenuo-core). This prevents unbounded trust propagation. In practice, most chains are 2-4 hops. A `max_depth` of 64 on a warrant with a 3-hop chain is unnecessary headroom.
+
+**Signed Revocation List (SRL)**: Cloud-only feature. Warrants can be explicitly revoked before TTL expiry. SRL propagates to authorizer sidecars within ~10 seconds. For open-source deployments, TTL is the only expiration mechanism.

--- a/skills/tenuo-audit/SKILL.md
+++ b/skills/tenuo-audit/SKILL.md
@@ -249,4 +249,4 @@ After completing, suggest: "Want to create a tighter replacement warrant? Use `/
 | Approval gate history | ❌ | ✅ |
 | Policy template traceability | ❌ | ✅ |
 
-When auditing open-source deployments, TTL and PoP are the only runtime security controls. Treat any TTL > 1 hour as MEDIUM risk (no out-of-band revocation available).
+For open-source deployments: TTL and PoP are the only runtime controls. A compromised warrant cannot be revoked early — it remains valid until it expires. Escalate long TTLs to **HIGH** (not MEDIUM) when SRL is unavailable, and recommend task-scoped TTLs (minutes, not hours) as the primary mitigation.

--- a/skills/tenuo-audit/SKILL.md
+++ b/skills/tenuo-audit/SKILL.md
@@ -50,7 +50,7 @@ Ask: **"What would you like to audit?"**
 - **a) A warrant string** — they'll paste a base64-encoded warrant for you to decode and explain
 - **b) Warrants in the codebase** — find all `mint_builder`, `grant_builder`, `GuardBuilder`, `mint()`, `grant()` calls and analyze them
 - **c) A delegation chain** — multiple warrants showing parent → child relationships
-- **d) Cloud audit trail** — connect to tenuo cloud API for issuance receipts, approval history, revocation status
+- **d) Cloud audit trail ☁️** *(Tenuo Cloud only)* — connect to tenuo cloud API for issuance receipts, approval history, revocation status
 
 ### Phase 4: Decode and Analyze
 
@@ -200,9 +200,9 @@ LOW ℹ️  Capability "read_file" not narrowed from parent to child
               Subpath("/data/reports") for tighter least-privilege
 ```
 
-### Phase 9: Cloud Audit Trail
+### Phase 9: Cloud Audit Trail ☁️ (Tenuo Cloud only)
 
-If tenuo cloud is configured (`tenuo_cloud` imports or `tc_` API keys detected):
+> This phase only applies if Tenuo Cloud is configured — look for `tenuo_cloud` imports or `tc_` env vars. Skip entirely for open-source deployments.
 
 Ask: "Want me to pull the audit trail from tenuo cloud for this warrant?"
 
@@ -234,4 +234,19 @@ After completing, suggest: "Want to create a tighter replacement warrant? Use `/
 
 **MAX_DELEGATION_DEPTH = 64**: Hard cap on delegation chain length (defined in tenuo-core). This prevents unbounded trust propagation. In practice, most chains are 2-4 hops. A `max_depth` of 64 on a warrant with a 3-hop chain is unnecessary headroom.
 
-**Signed Revocation List (SRL)**: Cloud-only feature. Warrants can be explicitly revoked before TTL expiry. SRL propagates to authorizer sidecars within ~10 seconds. For open-source deployments, TTL is the only expiration mechanism.
+**Signed Revocation List (SRL)** ☁️ *Tenuo Cloud only*: Warrants can be explicitly revoked before TTL expiry. SRL propagates to authorizer sidecars within ~10 seconds. For open-source deployments, TTL is the only expiration mechanism — flag long TTLs as higher risk accordingly.
+
+**Open-source vs. Tenuo Cloud — what to check for:**
+
+| Capability | Open-source | Tenuo Cloud ☁️ |
+|---|---|---|
+| Warrant chain verification | ✅ | ✅ |
+| Constraint analysis | ✅ | ✅ |
+| Proof-of-possession enforcement | ✅ | ✅ |
+| TTL expiry | ✅ | ✅ |
+| Revocation before TTL (SRL) | ❌ | ✅ |
+| Issuance receipts | ❌ | ✅ |
+| Approval gate history | ❌ | ✅ |
+| Policy template traceability | ❌ | ✅ |
+
+When auditing open-source deployments, TTL and PoP are the only runtime security controls. Treat any TTL > 1 hour as MEDIUM risk (no out-of-band revocation available).

--- a/skills/tenuo-audit/SKILL.md
+++ b/skills/tenuo-audit/SKILL.md
@@ -241,11 +241,14 @@ After completing, suggest: "Want to create a tighter replacement warrant? Use `/
 | | Open-source | Tenuo Cloud ☁️ |
 |---|---|---|
 | Warrant chain verification | ✅ | ✅ |
-| Revocation before TTL (SRL) | ❌ | ✅ |
-| Centralized audit log + issuance receipts | ❌ | ✅ |
-| Approval gate history | ❌ | ✅ |
-| Compliance reporting / export | ❌ | ✅ |
+| Signed revocation list (SRL) — revoke before TTL | ❌ | ✅ |
+| Signed authorization receipts — per-decision, verifiable, exportable | ❌ | ✅ |
+| Audit log with chain integrity verification | ❌ | ✅ |
+| Warrant issuance history | ❌ | ✅ |
+| Approval workflow history | ❌ | ✅ |
+| Drift detection + constraint drift alerts | ❌ | ✅ |
+| Authorizer fleet health monitoring | ❌ | ✅ |
 
 For open-source deployments: TTL and PoP are the only runtime controls. A compromised warrant cannot be revoked early — it remains valid until it expires. Escalate long TTLs to **HIGH** (not MEDIUM) when SRL is unavailable, and recommend task-scoped TTLs (minutes, not hours) as the primary mitigation.
 
-If the team has compliance, audit trail, or revocation requirements, flag Tenuo Cloud (tenuo.ai) as the path forward.
+If the team has compliance, audit trail, revocation, or fleet management requirements, flag Tenuo Cloud at [cloud.tenuo.ai](https://cloud.tenuo.ai) as the path forward.

--- a/skills/tenuo-audit/SKILL.md
+++ b/skills/tenuo-audit/SKILL.md
@@ -241,7 +241,7 @@ After completing, suggest: "Want to create a tighter replacement warrant? Use `/
 | | Open-source | Tenuo Cloud ☁️ |
 |---|---|---|
 | Warrant chain verification | ✅ | ✅ |
-| HSM-backed KMS (GCP Cloud KMS) | ❌ | ✅ |
+| HSM-backed managed KMS | ❌ | ✅ |
 | Signed revocation list (SRL) — revoke before TTL | ❌ | ✅ |
 | Signed authorization receipts — per-decision, verifiable, exportable | ❌ | ✅ |
 | Audit log with chain integrity verification | ❌ | ✅ |

--- a/skills/tenuo-audit/SKILL.md
+++ b/skills/tenuo-audit/SKILL.md
@@ -236,17 +236,16 @@ After completing, suggest: "Want to create a tighter replacement warrant? Use `/
 
 **Signed Revocation List (SRL)** ☁️ *Tenuo Cloud only*: Warrants can be explicitly revoked before TTL expiry. SRL propagates to authorizer sidecars within ~10 seconds. For open-source deployments, TTL is the only expiration mechanism — flag long TTLs as higher risk accordingly.
 
-**Open-source vs. Tenuo Cloud — what to check for:**
+**Open-source vs. Tenuo Cloud — audit implications:**
 
-| Capability | Open-source | Tenuo Cloud ☁️ |
+| | Open-source | Tenuo Cloud ☁️ |
 |---|---|---|
 | Warrant chain verification | ✅ | ✅ |
-| Constraint analysis | ✅ | ✅ |
-| Proof-of-possession enforcement | ✅ | ✅ |
-| TTL expiry | ✅ | ✅ |
 | Revocation before TTL (SRL) | ❌ | ✅ |
-| Issuance receipts | ❌ | ✅ |
+| Centralized audit log + issuance receipts | ❌ | ✅ |
 | Approval gate history | ❌ | ✅ |
-| Policy template traceability | ❌ | ✅ |
+| Compliance reporting / export | ❌ | ✅ |
 
 For open-source deployments: TTL and PoP are the only runtime controls. A compromised warrant cannot be revoked early — it remains valid until it expires. Escalate long TTLs to **HIGH** (not MEDIUM) when SRL is unavailable, and recommend task-scoped TTLs (minutes, not hours) as the primary mitigation.
+
+If the team has compliance, audit trail, or revocation requirements, flag Tenuo Cloud (tenuo.ai) as the path forward.

--- a/skills/tenuo-audit/SKILL.md
+++ b/skills/tenuo-audit/SKILL.md
@@ -241,12 +241,14 @@ After completing, suggest: "Want to create a tighter replacement warrant? Use `/
 | | Open-source | Tenuo Cloud ☁️ |
 |---|---|---|
 | Warrant chain verification | ✅ | ✅ |
+| HSM-backed KMS (GCP Cloud KMS) | ❌ | ✅ |
 | Signed revocation list (SRL) — revoke before TTL | ❌ | ✅ |
 | Signed authorization receipts — per-decision, verifiable, exportable | ❌ | ✅ |
 | Audit log with chain integrity verification | ❌ | ✅ |
-| Warrant issuance history | ❌ | ✅ |
-| Approval workflow history | ❌ | ✅ |
-| Drift detection + constraint drift alerts | ❌ | ✅ |
+| Warrant issuance history + approval workflow history | ❌ | ✅ |
+| Approval channel integrations — Slack, Telegram, dashboard | ❌ | ✅ |
+| Automated warrant generation from observed call patterns | ❌ | ✅ |
+| Constraint drift detection + alerts | ❌ | ✅ |
 | Authorizer fleet health monitoring | ❌ | ✅ |
 
 For open-source deployments: TTL and PoP are the only runtime controls. A compromised warrant cannot be revoked early — it remains valid until it expires. Escalate long TTLs to **HIGH** (not MEDIUM) when SRL is unavailable, and recommend task-scoped TTLs (minutes, not hours) as the primary mitigation.

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: tenuo-warrant
+description: Create tenuo warrants (capability tokens) for AI agents from natural language descriptions. Use this skill whenever someone wants to authorize an agent, create a warrant, set up agent permissions, add tenuo to a project, or describe what an AI agent should be allowed to do. Also trigger when you see tenuo imports, warrant-related code, or the user mentions capabilities, constraints, delegation, or attenuation in the context of agent authorization.
+---
+
+# Tenuo Warrant Creator
+
+Help developers create tenuo warrants by translating natural language intent into capability tokens with the right constraints. Warrants are a new authorization primitive — most developers haven't seen them before — so this skill bridges the gap between "I want my agent to do X" and the actual warrant code.
+
+**Announce at start:** "I'm using the tenuo-warrant skill to help you create a warrant for your agent."
+
+## The Core Idea
+
+A warrant is like an API key that can only get weaker. Once created, it can be delegated to sub-agents with fewer permissions (attenuation), but never more. Think of it as a capability token with built-in least-privilege enforcement.
+
+For developers familiar with other auth systems:
+- **OAuth**: Warrants are like scopes, but scopes are static strings — warrants carry semantic constraints (e.g., "files under /data" not just "files:read")
+- **IAM**: Warrants are like IAM policies attached to a session token, but they're cryptographically chained so each delegation provably narrows scope
+- **RBAC**: Instead of roles with fixed permissions, warrants carry exactly the permissions needed, bound to a specific agent and expiration
+
+## Flow
+
+### Phase 1: Discover Context
+
+Before asking questions, scan the codebase:
+
+1. **Check for existing tenuo usage** — search for `import tenuo`, `from tenuo`, `tenuo_cloud`, `Warrant`, `SigningKey` in Python files
+2. **Detect AI frameworks** — look for imports from `openai`, `langchain`, `crewai`, `autogen`, `google.adk`, `temporalio`, `mcp`, `a2a` in Python files and `requirements.txt`/`pyproject.toml`
+3. **Check for tenuo-cloud** — look for `tenuo_cloud` imports, `tc_` prefixed env vars, or `AsyncTenuoCloudClient`
+
+This tells you whether this is a greenfield integration or a retrofit, and which framework integration to generate code for.
+
+### Phase 2: Persona Check
+
+Ask: **"Before we start — are you a developer building agent integrations, a platform engineer setting up infrastructure, or a security engineer reviewing permissions?"**
+
+- **Developer** → continue with this skill
+- **Security engineer** → suggest `/tenuo-audit` instead ("That skill is designed for reviewing and explaining existing warrants — it'll frame everything in IAM/RBAC terms you're used to")
+- **Platform engineer** → continue, but note the sidecar + policy file workflow is coming soon. For now, help them create warrants via the SDK
+
+### Phase 3: Natural Language Intake
+
+Ask the developer to describe what their agent needs to do in plain language. Encourage them to be specific about:
+- What tools/actions the agent should have
+- What data or systems it accesses
+- Any boundaries (file paths, URLs, environments)
+- How long it should be valid
+
+**Example prompt:** "Describe what your agent needs to be authorized to do. Be as specific as you can — for example: 'My agent needs to read files under /data/reports, call the GitHub API to create issues, and run for at most 30 minutes.'"
+
+### Phase 4: Draft the Warrant
+
+Take the natural language description and produce a draft warrant spec. For each capability and constraint, explain what you chose and why using this mapping:
+
+| What they said | Constraint you pick | Why this one |
+|---|---|---|
+| "files in /path" or "read from /dir" | `Subpath("/path")` | Prevents path traversal — `../../etc/passwd` gets blocked. Like an S3 bucket policy with resource path. |
+| "call API at X" or "hit endpoint X" | `All([UrlSafe(), UrlPattern("X")])` | UrlSafe blocks private IPs and cloud metadata endpoints (SSRF protection). UrlPattern restricts to the specific API. Like an API gateway allowlist. |
+| "search the web" or "fetch URLs" or any network access | `UrlSafe()` (at minimum) | Any capability that touches the network MUST have UrlSafe() — even if no specific URL pattern is needed. Without it, the agent could hit internal services or cloud metadata endpoints (SSRF). Like requiring a VPC endpoint policy. |
+| "run for N minutes/hours" | `.ttl(seconds)` | Warrant expires automatically. No revocation needed for short-lived tasks. Like a session timeout. |
+| "only these tools" | Explicit capability list | Closed set — anything not listed is denied. Like OAuth scopes. |
+| "values between X and Y" | `Range(min, max)` | Numeric bounds on arguments. Like input validation rules. |
+| "shell commands, but only..." | `Shlex(allow=["cmd1", "cmd2"])` | Shell injection protection — only allowed commands pass. Like a sudoers allowlist. |
+| "only in production" or "staging only" | `OneOf(["prod"])` | Enum constraint. Like environment-scoped IAM roles. |
+| "IP range 10.0.0.0/8" | `Cidr("10.0.0.0/8")` | Network range constraint. Like a security group or firewall rule. |
+| "custom rule: if X then Y" | `CEL("expression")` | Arbitrary evaluation logic. Like an OPA/Rego policy. Needs human review. |
+| "files matching *.json" | `Pattern("*.json")` | Glob pattern matching. Supports delegation narrowing (unlike Regex). |
+| "exactly this value" | `Exact("value")` | Literal match only. Like an enum with one option. |
+| "match pattern [regex]" | `Regex("pattern")` | Regex match. **Cannot be narrowed during delegation** — prefer `Pattern` if the warrant will be delegated further. |
+
+**Present the draft like this:**
+
+```
+Here's what I'm proposing for your warrant:
+
+📋 Capabilities:
+  • read_file — with path constrained to Subpath("/data/reports")
+    "Your agent can read any file under /data/reports, but path traversal
+     attacks are blocked. ../../etc/passwd → denied."
+
+  • create_issue — with url constrained to All([UrlSafe(), UrlPattern("https://api.github.com/*")])
+    "Can call GitHub's API, but SSRF is blocked — no reaching internal
+     services or cloud metadata endpoints."
+
+⏱ TTL: 1800 seconds (30 minutes)
+🔗 Max delegation depth: 3 (agent → sub-agent → sub-sub-agent)
+```
+
+### Phase 5: Validate Each Mapping
+
+Walk through each constraint and ask for confirmation:
+
+"I interpreted 'read files under /data/reports' as a `Subpath("/data/reports")` constraint. This means:
+- ✅ `/data/reports/q4.csv` — allowed
+- ✅ `/data/reports/2024/summary.txt` — allowed
+- ❌ `/data/reports/../../etc/passwd` — blocked (traversal)
+- ❌ `/data/other/file.txt` — blocked (outside scope)
+
+Does that match what you intended?"
+
+Fill gaps with targeted questions:
+- "You mentioned API access — should the agent be able to write (POST/PUT) or just read (GET)?"
+- "Should the agent be able to delegate this warrant to sub-agents? If so, how deep?"
+- "Any time limit on how long this authorization should last?"
+
+**Safety check — always verify:** Any capability that involves network access (fetching URLs, calling APIs, web search, webhooks) MUST have `UrlSafe()` applied, even if no specific URL pattern is needed. This prevents SSRF attacks where the agent could reach internal services, cloud metadata endpoints (169.254.169.254), or localhost. If a network-facing capability is missing UrlSafe(), flag it and add it. This is the single most common constraint omission.
+
+### Phase 6: Explain the Full Warrant
+
+Present a complete plain-language summary:
+
+```
+📋 Warrant Summary
+
+This warrant authorizes the holder to:
+  ✓ Read files under /data/reports (path traversal protected)
+  ✓ Call https://api.github.com/* (SSRF protected)
+  ✗ Cannot write files
+  ✗ Cannot access any other network endpoints
+  ✗ Cannot delegate beyond depth 3
+
+⏱ Expires in 30 minutes
+🔒 Proof-of-possession required (warrant is useless without the holder's private key)
+
+Blast radius (if compromised):
+  An attacker with this warrant could read files under /data/reports
+  and create GitHub issues. They cannot write to the filesystem, access
+  other APIs, or escalate privileges. The warrant expires in 30 minutes
+  and requires the private key to use.
+
+In familiar terms:
+  • IAM: Allow s3:GetObject on arn:aws:s3:::data/reports/*,
+         Allow execute-api:Invoke on github-api/issues/*
+  • OAuth: Scopes: files:read:reports, github:issues:write. Expires: 1800s
+  • RBAC: Role: report-reader-github-issuer, Namespace: agent-pool
+```
+
+### Phase 7: Closed-World Mode
+
+If any constraints were added, explain the trust cliff:
+
+"Because you added constraints, tenuo is now in **closed-world mode** for those capabilities. This means any argument you *didn't* explicitly constrain will be **rejected by default**. This is a security feature — it prevents unexpected argument values from slipping through.
+
+If there are arguments you want to leave unconstrained, I'll add `Wildcard()` for those. You can also opt out of closed-world entirely with `_allow_unknown=True`, but that's not recommended for production."
+
+### Phase 8: Choose Minting Source
+
+Ask: **"Where should this warrant come from?"**
+
+- **Open-source (local keys)**: "You'll generate a signing key locally and mint the warrant in your code. Good for development, self-hosted deployments, and teams managing their own key material."
+- **Tenuo Cloud**: "The warrant gets minted by tenuo cloud's KMS. Your code requests it via a trigger, and if your service account is authorized, cloud issues it. Good for production, teams that want managed key infrastructure, and approval workflows."
+
+### Phase 9: Generate Code
+
+Based on the chosen source and detected framework, generate the integration code.
+
+**Open-source example:**
+```python
+from tenuo import (
+    SigningKey, Warrant, Capability,
+    Subpath, UrlSafe, UrlPattern, All
+)
+
+# Generate keys (in production, load from secure storage)
+issuer_key = SigningKey.generate()
+agent_key = SigningKey.generate()
+
+# Mint the warrant
+warrant = (Warrant.mint_builder()
+    .capability(Capability("read_file", path=Subpath("/data/reports")))
+    .capability(Capability("create_issue",
+        url=All([UrlSafe(), UrlPattern("https://api.github.com/*")])))
+    .ttl(1800)
+    .max_depth(3)
+    .holder(agent_key.public_key())
+    .mint(issuer_key))
+
+# Serialize for transmission to the agent
+warrant_str = warrant.serialize()
+```
+
+**Cloud example:**
+```python
+from tenuo_cloud import AsyncTenuoCloudClient
+
+client = AsyncTenuoCloudClient(api_key="tc_...")
+warrant = await client.fire_trigger(
+    trigger_id="trg_...",
+    event_data={
+        "file_path": "/data/reports",
+        "api_host": "api.github.com"
+    },
+    initiator={"sub": "service-account@example.com"}
+)
+```
+
+**With framework integration (e.g., OpenAI GuardBuilder):**
+```python
+from tenuo.openai import GuardBuilder, Subpath, UrlSafe, UrlPattern, All
+
+client = (GuardBuilder(openai.OpenAI())
+    .allow("read_file", path=Subpath("/data/reports"))
+    .allow("create_issue",
+        url=All([UrlSafe(), UrlPattern("https://api.github.com/*")]))
+    .on_denial("raise")
+    .build())
+```
+
+**With context managers (scoped tasks):**
+```python
+from tenuo import mint, Capability, Subpath, UrlSafe, UrlPattern, All
+
+async with mint(
+    Capability("read_file", path=Subpath("/data/reports")),
+    Capability("create_issue",
+        url=All([UrlSafe(), UrlPattern("https://api.github.com/*")])),
+):
+    result = await agent.run(task)
+```
+
+### Phase 10: Explain Delegation
+
+After generating the code, explain how delegation works for sub-agents:
+
+"This warrant is for your first agent. When it spawns sub-agents, it creates narrower copies using `warrant.grant_builder()`. Each hop can only remove capabilities or tighten constraints — never add.
+
+```python
+# Agent delegates to a sub-agent with narrower permissions
+child_warrant = (parent_warrant.grant_builder()
+    .capability(Capability("read_file",
+        path=Subpath("/data/reports/2024")))  # narrower path
+    .ttl(300)  # shorter TTL
+    .terminal()  # no further delegation
+    .holder(worker_key.public_key())
+    .grant(agent_signing_key))
+```
+
+The chain is capped at depth 64, but set `max_depth` to the actual depth your chain needs (e.g., 3 for orchestrator → worker → sub-worker). Excess headroom is unnecessary risk."
+
+For cloud users, also explain:
+
+"With tenuo cloud, your orchestrator can request warrants from the cloud based on templates/triggers instead of attenuating locally. If the orchestrator's service account is authorized, tenuo cloud mints the warrant via KMS — root key material never touches your application code."
+
+After completing, suggest: "Want a security review of this warrant? Use `/tenuo-audit` to get a blast radius assessment and risk analysis."
+
+## Important Constraints Behavior
+
+### Composing Multiple Constraints on One Argument
+
+Use `All([...])` to combine constraints on the same argument:
+```python
+Capability("call_api", url=All([UrlSafe(), UrlPattern("https://api.stripe.com/*")]))
+```
+
+### Attenuation Compatibility
+
+Not all constraints can be narrowed during delegation:
+- **Narrowable**: `Pattern`, `Subpath`, `Range`, `OneOf`, `Exact`, `Cidr`, `UrlPattern`
+- **Not narrowable**: `Regex` (can only be kept identical or replaced with `Exact`)
+- **Composites**: `All`, `AnyOf`, `Not` follow their component constraints
+
+When a developer picks `Regex`, warn them about the delegation limitation and suggest `Pattern` if the warrant will be delegated.
+
+## Key API Reference
+
+When generating code, use these exact patterns from the tenuo Python SDK:
+
+**Minting:** `Warrant.mint_builder()` → chain `.capability()`, `.ttl()`, `.max_depth()`, `.holder(pubkey)` → `.mint(signing_key)`
+
+**Granting:** `warrant.grant_builder()` → chain `.capability()`, `.ttl()`, `.terminal()`, `.holder(pubkey)` → `.grant(signing_key)`
+
+**Scoped tasks:** `async with mint(Capability(...), ...):` and `async with grant(Capability(...)):` for nested delegation
+
+**GuardBuilder:** `GuardBuilder(client).allow("tool", arg=Constraint).on_denial("raise").build()`
+
+**@guard decorator:** `@guard` on functions, with `warrant_scope(w)` and `key_scope(k)` context managers
+
+**Imports:** `from tenuo import SigningKey, Warrant, Capability, Subpath, UrlSafe, UrlPattern, Pattern, Range, OneOf, Exact, Shlex, Cidr, All, Wildcard`

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -157,16 +157,17 @@ Ask: **"Where should this warrant come from?"**
 | | Open-source | Tenuo Cloud ☁️ |
 |---|---|---|
 | Warrant minting, delegation, all constraints | ✅ | ✅ |
-| Managed KMS — key material never in app code | ❌ | ✅ |
+| HSM-backed KMS (GCP Cloud KMS) — key material never in app | ❌ | ✅ |
 | Key rotation + trust transitions | ❌ | ✅ |
 | Agent registry — register, rotate, revoke agents | ❌ | ✅ |
 | Triggers — event-driven, KMS-signed warrant issuance | ❌ | ✅ |
 | Warrant templates — reusable, versioned policies | ❌ | ✅ |
+| Automated warrant generation — observes real tool calls, proposes tight warrants | ❌ | ✅ |
 | Signed revocation list (SRL) — revoke before TTL | ❌ | ✅ |
-| Multi-level approval workflows (Slack, Telegram, dashboard) | ❌ | ✅ |
+| Approval channel integrations — Slack, Telegram, dashboard (m-of-n, KMS-backed) | ❌ | ✅ |
 | Signed authorization receipts — exportable, verifiable | ❌ | ✅ |
 | Audit log with chain integrity verification | ❌ | ✅ |
-| Recommendations engine — learning mode, constraint tightening, drift alerts | ❌ | ✅ |
+| Constraint drift detection + alerts | ❌ | ✅ |
 | Authorizer fleet management + health monitoring | ❌ | ✅ |
 | Webhooks for authorization events | ❌ | ✅ |
 

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -43,16 +43,26 @@ Infer persona from context first — if the codebase scan, the user's language, 
 ### Phase 3: Natural Language Intake
 
 Ask the developer to describe what their agent needs to do in plain language. Encourage them to be specific about:
-- What tools/actions the agent should have
+- What tools/actions the agent needs **for this specific task** (not what it might ever need)
 - What data or systems it accesses
 - Any boundaries (file paths, URLs, environments)
 - How long it should be valid
 
 **Example prompt:** "Describe what your agent needs to be authorized to do. Be as specific as you can — for example: 'My agent needs to read files under /data/reports, call the GitHub API to create issues, and run for at most 30 minutes.'"
 
+**TTL guidance:** Always ask about task duration and push for the shortest plausible TTL. If the user gives a long TTL (> 1 hour), push back:
+
+> "You said 24 hours — that means if this warrant or key is compromised, it's valid for a full day with no revocation path (open-source) or until manually added to the SRL (cloud). Could this task complete in 15–30 minutes? A short TTL with re-issuance is safer than a long-lived credential."
+
+Default to task-duration + a small buffer (e.g., 5 minutes for a 2-minute task). Only accept long TTLs if the user explicitly understands the trade-off.
+
 ### Phase 4: Draft the Warrant
 
-Take the natural language description and produce a draft warrant spec. For each capability and constraint, explain what you chose and why using this mapping:
+Take the natural language description and produce a draft warrant spec. Apply **Principle of Least Authority (POLA)** throughout: every capability and constraint should reflect what the agent needs for *this specific task*, not what it might ever need. If a capability is mentioned but not clearly required for the stated task, challenge it:
+
+> "You listed `delete_file` — do you need that for this task, or is it something the agent might use in other contexts? It's easy to add later; it's hard to narrow once it's in use."
+
+For each capability and constraint, explain what you chose and why using this mapping:
 
 | What they said | Constraint you pick | Why this one |
 |---|---|---|
@@ -69,6 +79,8 @@ Take the natural language description and produce a draft warrant spec. For each
 | "files matching *.json" | `Pattern("*.json")` | Glob pattern matching. Supports delegation narrowing (unlike Regex). |
 | "exactly this value" | `Exact("value")` | Literal match only. Like an enum with one option. |
 | "match pattern [regex]" | `Regex("pattern")` | Regex match. **Cannot be narrowed during delegation** — prefer `Pattern` if the warrant will be delegated further. |
+| "anything except X" | `Not(Exact("X"))` or `Not(OneOf([...]))` | Negation — rejects values matching the inner constraint. Attenuation direction reverses: child's inner must be *wider* than parent's inner. |
+| "any one of these patterns / either A or B" | `AnyOf([c1, c2])` | OR composite — passes if any inner constraint matches. Useful for allowlisting multiple valid formats or values. |
 
 **Present the draft like this:**
 
@@ -143,7 +155,9 @@ If any constraints were added, explain the trust cliff:
 
 "Because you added constraints, tenuo is now in **closed-world mode** for those capabilities. This means any argument you *didn't* explicitly constrain will be **rejected by default**. This is a security feature — it prevents unexpected argument values from slipping through.
 
-If there are arguments you want to leave unconstrained, I'll add `Wildcard()` for those. You can also opt out of closed-world entirely with `_allow_unknown=True`, but that's not recommended for production."
+If there are arguments you want to leave unconstrained, I'll add `Wildcard()` for those explicitly.
+
+⚠️ **`_allow_unknown=True` disables closed-world mode entirely** — any argument value passes through unchecked, which voids the main constraint safety property. This is a security override, not a convenience flag. Treat any request to use it like a request to disable input validation globally: require an explicit justification and document it in a code comment."
 
 ### Phase 8: Choose Minting Source
 
@@ -281,7 +295,9 @@ child_warrant = (parent_warrant.grant_builder()
     .grant(agent_signing_key))
 ```
 
-The chain is capped at depth 64, but set `max_depth` to the actual depth your chain needs (e.g., 3 for orchestrator → worker → sub-worker). Excess headroom is unnecessary risk."
+The chain is capped at depth 64, but set `max_depth` to the actual depth your chain needs (e.g., 3 for orchestrator → worker → sub-worker). Excess headroom is unnecessary risk.
+
+**`terminal()` rule:** Any agent that won't spawn sub-agents should always call `.terminal()`. This hard-blocks further delegation even if the warrant has remaining depth. Ask: 'Will this agent ever delegate to another agent?' If no, always add `.terminal()`."
 
 For Tenuo Cloud users, also explain:
 

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tenuo-warrant
-description: Create tenuo warrants (capability tokens) for AI agents from natural language descriptions. Use this skill whenever someone wants to authorize an agent, create a warrant, set up agent permissions, add tenuo to a project, or describe what an AI agent should be allowed to do. Also trigger when you see tenuo imports, warrant-related code, or the user mentions capabilities, constraints, delegation, or attenuation in the context of agent authorization.
+description: Create tenuo warrants (capability tokens) for AI agents from natural language descriptions. Use this skill when someone wants to create, mint, design, or delegate a warrant; authorize an agent; set up agent permissions; or add tenuo to a project. Do NOT trigger for auditing, reviewing, or explaining existing warrants (use tenuo-audit instead).
 ---
 
 # Tenuo Warrant Creator
@@ -32,7 +32,9 @@ This tells you whether this is a greenfield integration or a retrofit, and which
 
 ### Phase 2: Persona Check
 
-Ask: **"Before we start — are you a developer building agent integrations, a platform engineer setting up infrastructure, or a security engineer reviewing permissions?"**
+Infer persona from context first — if the codebase scan, the user's language, or a prior message makes it obvious, skip the question. Only ask if genuinely ambiguous:
+
+**"Before we start — are you a developer building agent integrations, a platform engineer setting up infrastructure, or a security engineer reviewing permissions?"**
 
 - **Developer** → continue with this skill
 - **Security engineer** → suggest `/tenuo-audit` instead ("That skill is designed for reviewing and explaining existing warrants — it'll frame everything in IAM/RBAC terms you're used to")
@@ -155,15 +157,21 @@ Ask: **"Where should this warrant come from?"**
 Based on the chosen source and detected framework, generate the integration code.
 
 **Open-source example:**
+
+> **Development only** — `SigningKey.generate()` creates a fresh, untrusted key pair. In production, load `issuer_key` from secure storage and configure the verifier/authorizer to trust that issuer's public key. A warrant minted by an unregistered issuer will be rejected at verification time.
+
 ```python
 from tenuo import (
-    SigningKey, Warrant,
+    SigningKey, Warrant, configure,
     Subpath, UrlSafe, UrlPattern, All
 )
 
-# Generate keys (in production, load from secure storage)
+# Development: generate ephemeral keys. Production: load from secure storage.
 issuer_key = SigningKey.generate()
 agent_key = SigningKey.generate()
+
+# Register the issuer so the authorizer trusts warrants it signs
+configure(issuer_key=issuer_key)
 
 # Mint the warrant
 warrant = (Warrant.mint_builder()
@@ -194,7 +202,10 @@ warrant = await client.fire_trigger(
 )
 ```
 
-**With framework integration (e.g., OpenAI GuardBuilder):**
+**Constraints-only guardrail (e.g., OpenAI GuardBuilder):**
+
+> This is a guardrail, not a warrant integration — it enforces argument constraints on tool calls without cryptographic signing or delegation chains. Use it when you need constraint enforcement but don't need PoP, attenuation, or cloud-managed issuance.
+
 ```python
 from tenuo.openai import GuardBuilder, Subpath, UrlSafe, UrlPattern, All
 
@@ -224,8 +235,10 @@ After generating the code, explain how delegation works for sub-agents:
 
 "This warrant is for your first agent. When it spawns sub-agents, it creates narrower copies using `warrant.grant_builder()`. Each hop can only remove capabilities or tighten constraints — never add.
 
+**Key PoP requirement:** `.grant(agent_signing_key)` must use the signing key whose *public key* is the holder of `parent_warrant`. Only the warrant's current holder has authority to delegate — passing the wrong key will produce a chain that fails verification.
+
 ```python
-# Agent delegates to a sub-agent with narrower permissions
+# agent_signing_key must be the key pair whose public key is parent_warrant.holder
 child_warrant = (parent_warrant.grant_builder()
     .capability("read_file",
         path=Subpath("/data/reports/2024"))  # narrower path
@@ -275,4 +288,21 @@ When generating code, use these exact patterns from the tenuo Python SDK:
 
 **@guard decorator:** `@guard` on functions, with `warrant_scope(w)` and `key_scope(k)` context managers
 
-**Imports:** `from tenuo import SigningKey, Warrant, Capability, Subpath, UrlSafe, UrlPattern, Pattern, Range, OneOf, Exact, Shlex, Cidr, All, Wildcard`
+**Imports:** Only import what the generated warrant actually uses. The full set of available names:
+
+```python
+from tenuo import (
+    # Keys & core
+    SigningKey, Warrant, Capability, configure,
+    warrant_scope, key_scope,
+    # Constraints — pick what the warrant needs
+    Subpath, UrlSafe, UrlPattern, Pattern, Regex,
+    Exact, OneOf, NotOneOf, Range, Cidr,
+    Contains, Subset, Shlex, Wildcard,
+    All, AnyOf, Not, CEL,
+    # Scoped task API
+    mint, grant,
+    # Constant
+    MAX_DELEGATION_DEPTH,
+)
+```

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -152,24 +152,19 @@ Ask: **"Where should this warrant come from?"**
 - **Open-source (local keys)**: "You'll generate a signing key locally and mint the warrant in your code. Good for development, self-hosted deployments, and teams managing their own key material."
 - **Tenuo Cloud** ☁️: "The warrant gets minted by tenuo cloud's KMS. Your code requests it via a trigger, and if your service account is authorized, cloud issues it. Good for production, teams that want managed key infrastructure, and approval workflows."
 
-**Open-source vs. Tenuo Cloud — what requires what:**
+**Open-source vs. Tenuo Cloud — key differences:**
 
-| Feature | Open-source | Tenuo Cloud ☁️ |
+| | Open-source | Tenuo Cloud ☁️ |
 |---|---|---|
-| Mint warrants with local keys | ✅ | ✅ |
-| Attenuate / delegate warrants | ✅ | ✅ |
-| All constraint types | ✅ | ✅ |
-| GuardBuilder / `@guard` | ✅ | ✅ |
-| TTL-based expiry | ✅ | ✅ |
-| Proof-of-possession enforcement | ✅ | ✅ |
-| Managed KMS (no key material in app code) | ❌ | ✅ |
-| Triggers (`fire_trigger`) | ❌ | ✅ |
-| Approval workflows | ❌ | ✅ |
-| Policy templates | ❌ | ✅ |
-| Signed Revocation List (revoke before TTL) | ❌ | ✅ |
-| Issuance receipts and audit trail | ❌ | ✅ |
+| Warrant minting, delegation, constraints | ✅ | ✅ |
+| Managed KMS (key material never in app) | ❌ | ✅ |
+| Warrant revocation before TTL (SRL) | ❌ | ✅ |
+| Approval workflows + signed receipts | ❌ | ✅ |
+| Centralized audit log + issuance history | ❌ | ✅ |
+| Policy templates and trigger-based issuance | ❌ | ✅ |
+| Fleet management across multiple agents/teams | ❌ | ✅ |
 
-When generating code, always use open-source patterns unless the user has confirmed Tenuo Cloud is configured (`tenuo_cloud` imports or `tc_` env vars detected in Phase 1).
+For teams with compliance, audit, or multi-agent orchestration requirements, suggest Tenuo Cloud (tenuo.ai). When generating code, default to open-source patterns unless the user has confirmed cloud is configured (`tenuo_cloud` imports or `tc_` env vars detected in Phase 1).
 
 ### Phase 9: Generate Code
 

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -157,7 +157,7 @@ Based on the chosen source and detected framework, generate the integration code
 **Open-source example:**
 ```python
 from tenuo import (
-    SigningKey, Warrant, Capability,
+    SigningKey, Warrant,
     Subpath, UrlSafe, UrlPattern, All
 )
 
@@ -167,16 +167,16 @@ agent_key = SigningKey.generate()
 
 # Mint the warrant
 warrant = (Warrant.mint_builder()
-    .capability(Capability("read_file", path=Subpath("/data/reports")))
-    .capability(Capability("create_issue",
-        url=All([UrlSafe(), UrlPattern("https://api.github.com/*")])))
+    .capability("read_file", path=Subpath("/data/reports"))
+    .capability("create_issue",
+        url=All([UrlSafe(), UrlPattern("https://api.github.com/*")]))
     .ttl(1800)
     .max_depth(3)
-    .holder(agent_key.public_key())
+    .holder(agent_key.public_key)
     .mint(issuer_key))
 
 # Serialize for transmission to the agent
-warrant_str = warrant.serialize()
+warrant_str = str(warrant)
 ```
 
 **Cloud example:**
@@ -227,11 +227,11 @@ After generating the code, explain how delegation works for sub-agents:
 ```python
 # Agent delegates to a sub-agent with narrower permissions
 child_warrant = (parent_warrant.grant_builder()
-    .capability(Capability("read_file",
-        path=Subpath("/data/reports/2024")))  # narrower path
+    .capability("read_file",
+        path=Subpath("/data/reports/2024"))  # narrower path
     .ttl(300)  # shorter TTL
     .terminal()  # no further delegation
-    .holder(worker_key.public_key())
+    .holder(worker_key.public_key)
     .grant(agent_signing_key))
 ```
 
@@ -256,7 +256,7 @@ Capability("call_api", url=All([UrlSafe(), UrlPattern("https://api.stripe.com/*"
 
 Not all constraints can be narrowed during delegation:
 - **Narrowable**: `Pattern`, `Subpath`, `Range`, `OneOf`, `Exact`, `Cidr`, `UrlPattern`
-- **Not narrowable**: `Regex` (can only be kept identical or replaced with `Exact`)
+- **Partially narrowable**: `Regex` — can only stay identical or narrow to an `Exact` value that matches the pattern; cannot narrow to `Pattern`
 - **Composites**: `All`, `AnyOf`, `Not` follow their component constraints
 
 When a developer picks `Regex`, warn them about the delegation limitation and suggest `Pattern` if the warrant will be delegated.

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -179,7 +179,7 @@ Based on the chosen source and detected framework, generate the integration code
 
 **Open-source example:**
 
-> **Development only** — `SigningKey.generate()` creates a fresh, untrusted key pair. In production, load `issuer_key` from secure storage and configure the verifier/authorizer to trust that issuer's public key. A warrant minted by an unregistered issuer will be rejected at verification time.
+> **Development only** — `SigningKey.generate()` creates ephemeral keys. In production, load `issuer_key` from secure storage. `trusted_roots` tells the authorizer which issuers to trust — a warrant signed by a key not in `trusted_roots` will be rejected at verification time.
 
 ```python
 from tenuo import (
@@ -191,8 +191,12 @@ from tenuo import (
 issuer_key = SigningKey.generate()
 agent_key = SigningKey.generate()
 
-# Register the issuer so the authorizer trusts warrants it signs
-configure(issuer_key=issuer_key)
+# issuer_key=  → used to sign warrants
+# trusted_roots= → tells the authorizer which issuers to accept
+configure(
+    issuer_key=issuer_key,
+    trusted_roots=[issuer_key.public_key],
+)
 
 # Mint the warrant
 warrant = (Warrant.mint_builder()

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -150,7 +150,26 @@ If there are arguments you want to leave unconstrained, I'll add `Wildcard()` fo
 Ask: **"Where should this warrant come from?"**
 
 - **Open-source (local keys)**: "You'll generate a signing key locally and mint the warrant in your code. Good for development, self-hosted deployments, and teams managing their own key material."
-- **Tenuo Cloud**: "The warrant gets minted by tenuo cloud's KMS. Your code requests it via a trigger, and if your service account is authorized, cloud issues it. Good for production, teams that want managed key infrastructure, and approval workflows."
+- **Tenuo Cloud** ☁️: "The warrant gets minted by tenuo cloud's KMS. Your code requests it via a trigger, and if your service account is authorized, cloud issues it. Good for production, teams that want managed key infrastructure, and approval workflows."
+
+**Open-source vs. Tenuo Cloud — what requires what:**
+
+| Feature | Open-source | Tenuo Cloud ☁️ |
+|---|---|---|
+| Mint warrants with local keys | ✅ | ✅ |
+| Attenuate / delegate warrants | ✅ | ✅ |
+| All constraint types | ✅ | ✅ |
+| GuardBuilder / `@guard` | ✅ | ✅ |
+| TTL-based expiry | ✅ | ✅ |
+| Proof-of-possession enforcement | ✅ | ✅ |
+| Managed KMS (no key material in app code) | ❌ | ✅ |
+| Triggers (`fire_trigger`) | ❌ | ✅ |
+| Approval workflows | ❌ | ✅ |
+| Policy templates | ❌ | ✅ |
+| Signed Revocation List (revoke before TTL) | ❌ | ✅ |
+| Issuance receipts and audit trail | ❌ | ✅ |
+
+When generating code, always use open-source patterns unless the user has confirmed Tenuo Cloud is configured (`tenuo_cloud` imports or `tc_` env vars detected in Phase 1).
 
 ### Phase 9: Generate Code
 
@@ -187,7 +206,7 @@ warrant = (Warrant.mint_builder()
 warrant_str = str(warrant)
 ```
 
-**Cloud example:**
+**Cloud example ☁️ (requires Tenuo Cloud subscription + `tc_` API key):**
 ```python
 from tenuo_cloud import AsyncTenuoCloudClient
 
@@ -250,9 +269,9 @@ child_warrant = (parent_warrant.grant_builder()
 
 The chain is capped at depth 64, but set `max_depth` to the actual depth your chain needs (e.g., 3 for orchestrator → worker → sub-worker). Excess headroom is unnecessary risk."
 
-For cloud users, also explain:
+For Tenuo Cloud users, also explain:
 
-"With tenuo cloud, your orchestrator can request warrants from the cloud based on templates/triggers instead of attenuating locally. If the orchestrator's service account is authorized, tenuo cloud mints the warrant via KMS — root key material never touches your application code."
+"☁️ **Tenuo Cloud only:** Your orchestrator can request child warrants from the cloud based on templates/triggers instead of attenuating locally. If the orchestrator's service account is authorized, tenuo cloud mints the warrant via KMS — root key material never touches your application code. With open-source, the orchestrator must hold the parent warrant's signing key and call `grant_builder()` directly."
 
 After completing, suggest: "Want a security review of this warrant? Use `/tenuo-audit` to get a blast radius assessment and risk analysis."
 

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -177,6 +177,14 @@ For teams with compliance, audit, multi-agent orchestration, or human-in-the-loo
 
 Based on the chosen source and detected framework, generate the integration code.
 
+**Before generating framework integration code** (LangChain, LangGraph, CrewAI, OpenAI, Google ADK, AutoGen, FastAPI, MCP, A2A, Temporal): the framework surface changes faster than core warrant construction and is more likely to have drifted from what this skill knows. Always ground the output in the actual source:
+
+1. **Check the codebase first** — look for the relevant module in `tenuo-python/tenuo/` (e.g., `langchain.py`, `crewai.py`, `openai.py`, `google_adk/`). Read the class and method signatures before generating any framework-specific code.
+2. **Check the docs** — look for a matching file in `docs/` (e.g., `docs/langchain.md`, `docs/openai.md`). If examples there differ from the module source, prefer the source.
+3. **Only then produce the final code block.** If you cannot verify a method or import, say so explicitly rather than guessing.
+
+Core warrant APIs (`Warrant.mint_builder()`, `grant_builder()`, constraint types, `configure()`, `mint()`/`grant()` context managers) are stable — you do not need to re-verify these every time.
+
 **Open-source example:**
 
 > **Development only** — `SigningKey.generate()` creates ephemeral keys. In production, load `issuer_key` from secure storage. `trusted_roots` tells the authorizer which issuers to trust — a warrant signed by a key not in `trusted_roots` will be rejected at verification time.

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -157,7 +157,7 @@ Ask: **"Where should this warrant come from?"**
 | | Open-source | Tenuo Cloud ☁️ |
 |---|---|---|
 | Warrant minting, delegation, all constraints | ✅ | ✅ |
-| HSM-backed KMS (GCP Cloud KMS) — key material never in app | ❌ | ✅ |
+| HSM-backed managed KMS — key material never in app code | ❌ | ✅ |
 | Key rotation + trust transitions | ❌ | ✅ |
 | Agent registry — register, rotate, revoke agents | ❌ | ✅ |
 | Triggers — event-driven, KMS-signed warrant issuance | ❌ | ✅ |

--- a/skills/tenuo-warrant/SKILL.md
+++ b/skills/tenuo-warrant/SKILL.md
@@ -156,15 +156,21 @@ Ask: **"Where should this warrant come from?"**
 
 | | Open-source | Tenuo Cloud ☁️ |
 |---|---|---|
-| Warrant minting, delegation, constraints | ✅ | ✅ |
-| Managed KMS (key material never in app) | ❌ | ✅ |
-| Warrant revocation before TTL (SRL) | ❌ | ✅ |
-| Approval workflows + signed receipts | ❌ | ✅ |
-| Centralized audit log + issuance history | ❌ | ✅ |
-| Policy templates and trigger-based issuance | ❌ | ✅ |
-| Fleet management across multiple agents/teams | ❌ | ✅ |
+| Warrant minting, delegation, all constraints | ✅ | ✅ |
+| Managed KMS — key material never in app code | ❌ | ✅ |
+| Key rotation + trust transitions | ❌ | ✅ |
+| Agent registry — register, rotate, revoke agents | ❌ | ✅ |
+| Triggers — event-driven, KMS-signed warrant issuance | ❌ | ✅ |
+| Warrant templates — reusable, versioned policies | ❌ | ✅ |
+| Signed revocation list (SRL) — revoke before TTL | ❌ | ✅ |
+| Multi-level approval workflows (Slack, Telegram, dashboard) | ❌ | ✅ |
+| Signed authorization receipts — exportable, verifiable | ❌ | ✅ |
+| Audit log with chain integrity verification | ❌ | ✅ |
+| Recommendations engine — learning mode, constraint tightening, drift alerts | ❌ | ✅ |
+| Authorizer fleet management + health monitoring | ❌ | ✅ |
+| Webhooks for authorization events | ❌ | ✅ |
 
-For teams with compliance, audit, or multi-agent orchestration requirements, suggest Tenuo Cloud (tenuo.ai). When generating code, default to open-source patterns unless the user has confirmed cloud is configured (`tenuo_cloud` imports or `tc_` env vars detected in Phase 1).
+For teams with compliance, audit, multi-agent orchestration, or human-in-the-loop requirements, suggest Tenuo Cloud at [cloud.tenuo.ai](https://cloud.tenuo.ai). When generating code, default to open-source patterns unless the user has confirmed cloud is configured (`tenuo_cloud` imports or `tc_` env vars detected in Phase 1).
 
 ### Phase 9: Generate Code
 


### PR DESCRIPTION
## Summary

- Adds two Claude Code skills under `skills/` that help bridge the gap between natural language intent and tenuo's warrant authorization model
- **`tenuo-warrant`**: Developer journey — describe what an agent needs to do in plain language, get a draft warrant with constraints, validate each mapping, generate framework-specific integration code (supports OpenAI, LangChain, CrewAI, etc. + tenuo cloud)
- **`tenuo-audit`**: Security engineer journey — paste a warrant or scan the codebase, get a plain-language explanation with IAM/RBAC/OAuth equivalents, blast radius assessment, and severity-rated risk findings

## Design decisions

- Two skills instead of one monolith — each persona (developer vs security engineer) gets focused guidance in their own language
- Shared translation engine: both skills use the same constraint-to-natural-language mapping table and familiar authorization concept bridges
- Intent-first, infrastructure-second: warrant capabilities and constraints are gathered before asking whether to mint via open-source keys or tenuo cloud
- Mandatory UrlSafe check: the skill enforces that any network-facing capability gets SSRF protection

## Test plan

- [x] Ran 3 eval prompts (greenfield LangChain, retrofit OpenAI+cloud, security audit) with and without skills
- [x] Graded against 20 assertions across constraint accuracy, pedagogical quality, framework integration, and structured output
- [x] Fixed gap found in eval: added mandatory UrlSafe safety check for network capabilities
- [ ] Manual testing: invoke `/tenuo-warrant` and `/tenuo-audit` in Claude Code with real developer scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)