### PR TITLE
Thread Rust-computed request_hash through MCP approval wire protocol

### DIFF
--- a/tenuo-python/tenuo/mcp/client.py
+++ b/tenuo-python/tenuo/mcp/client.py
@@ -632,10 +632,13 @@ class SecureMCPClient:
                         if _tenuo_code == -32002:
                             from .server import MCPApprovalRequired
                             _msg = _safe_mcp_tool_error_message(raw_content, tool_name)
+                            _tenuo_block = (structured or {}).get("tenuo") or {}
+                            _rh = _tenuo_block.get("request_hash") if isinstance(_tenuo_block, dict) else None
                             raise MCPApprovalRequired(
                                 tool_name=tool_name,
                                 message=_msg,
                                 raw_error=structured,
+                                request_hash=_rh,
                             )
                         if raise_on_tool_error:
                             raise MCPToolCallError(

--- a/tenuo-python/tenuo/mcp/fastmcp_middleware.py
+++ b/tenuo-python/tenuo/mcp/fastmcp_middleware.py
@@ -123,15 +123,16 @@ class _VerifierDenialToolReturn:
 def _denial_tool_return(verification: MCPVerificationResult) -> _VerifierDenialToolReturn:
     code = verification.jsonrpc_error_code or -32001
     message = verification.denial_reason or "Authorization denied"
+    tenuo_block: dict[str, Any] = {
+        "code": code,
+        "message": message,
+    }
+    if verification.request_hash:
+        tenuo_block["request_hash"] = verification.request_hash
     call = mt.CallToolResult(
         content=[TextContent(type="text", text=message)],
         isError=True,
-        structuredContent={
-            "tenuo": {
-                "code": code,
-                "message": message,
-            }
-        },
+        structuredContent={"tenuo": tenuo_block},
     )
     return _VerifierDenialToolReturn(call)
 

--- a/tenuo-python/tenuo/mcp/server.py
+++ b/tenuo-python/tenuo/mcp/server.py
@@ -186,6 +186,13 @@ class MCPVerificationResult:
     - ``-32002`` — Approval required (approval gate triggered)
     """
 
+    request_hash: Optional[str] = field(default=None)
+    """Rust-computed request hash (hex), populated when an approval gate fires (``-32002``).
+
+    Clients need this to submit the correct hash to the approval service without
+    re-deriving it from ``(warrant_id, tool, args, holder_key)``.
+    """
+
     @property
     def is_approval_required(self) -> bool:
         """``True`` when an approval gate fired and approvals must be supplied."""
@@ -208,11 +215,17 @@ class MCPVerificationResult:
         Only meaningful when ``allowed`` is ``False``::
 
             return {"jsonrpc": "2.0", "id": req_id, "error": result.to_jsonrpc_error()}
+
+        When ``request_hash`` is present (``-32002``), the hash is included in
+        ``error.data`` so clients can pass it to the approval service directly.
         """
-        return {
+        error: Dict[str, Any] = {
             "code": self.jsonrpc_error_code or -32001,
             "message": self.denial_reason or "Authorization denied",
         }
+        if self.request_hash:
+            error["data"] = {"request_hash": self.request_hash}
+        return error
 
 
 class MCPAuthorizationError(Exception):
@@ -257,10 +270,23 @@ class MCPApprovalRequired(MCPAuthorizationError):
         *,
         result: Optional[MCPVerificationResult] = None,
         raw_error: Optional[Any] = None,
+        request_hash: Optional[str] = None,
     ) -> None:
         self.tool_name = tool_name
         self.raw_error = raw_error
+        self.request_hash = request_hash
         if result is not None:
+            if request_hash and not result.request_hash:
+                result = MCPVerificationResult(
+                    allowed=result.allowed,
+                    tool=result.tool,
+                    clean_arguments=result.clean_arguments,
+                    constraints=result.constraints,
+                    warrant_id=result.warrant_id,
+                    denial_reason=result.denial_reason,
+                    jsonrpc_error_code=result.jsonrpc_error_code,
+                    request_hash=request_hash,
+                )
             super().__init__(result)
         else:
             _result = MCPVerificationResult(
@@ -270,6 +296,7 @@ class MCPApprovalRequired(MCPAuthorizationError):
                 constraints={},
                 denial_reason=message,
                 jsonrpc_error_code=-32002,
+                request_hash=request_hash,
             )
             super().__init__(_result)
 
@@ -677,7 +704,7 @@ class MCPVerifier:
                 constraints=constraints,
                 warrant_id=warrant_id,
             )
-        except ApprovalGateTriggered:
+        except ApprovalGateTriggered as gate_exc:
             logger.info(
                 "Approval required for '%s' (warrant=%s) — approvals required",
                 tool_name,
@@ -689,6 +716,7 @@ class MCPVerifier:
                 clean_arguments=clean_arguments,
                 constraints=constraints,
                 warrant_id=warrant_id,
+                request_hash=gate_exc.request_hash or None,
                 denial_reason=(
                     f"Approval required for '{tool_name}'. "
                     "Re-submit the call with approvals in _meta.tenuo.approvals."

--- a/tenuo-python/tests/adapters/test_mcp.py
+++ b/tenuo-python/tests/adapters/test_mcp.py
@@ -762,6 +762,49 @@ class TestCallToolIsErrorHandling:
         assert ri.value.result.is_approval_required
 
     @pytest.mark.asyncio
+    async def test_approval_required_extracts_request_hash(self):
+        from mcp.types import CallToolResult, TextContent
+
+        from tenuo.mcp.server import MCPApprovalRequired
+
+        client = _make_client()
+        client.session.call_tool = AsyncMock(
+            return_value=CallToolResult(
+                content=[TextContent(type="text", text="Approval required")],
+                isError=True,
+                structuredContent={
+                    "tenuo": {
+                        "code": -32002,
+                        "message": "Approval required",
+                        "request_hash": "deadbeef1234",
+                    }
+                },
+            )
+        )
+        with pytest.raises(MCPApprovalRequired) as ri:
+            await client.call_tool("t", {}, warrant_context=False)
+        assert ri.value.request_hash == "deadbeef1234"
+        assert ri.value.result.request_hash == "deadbeef1234"
+
+    @pytest.mark.asyncio
+    async def test_approval_required_no_hash_when_absent(self):
+        from mcp.types import CallToolResult, TextContent
+
+        from tenuo.mcp.server import MCPApprovalRequired
+
+        client = _make_client()
+        client.session.call_tool = AsyncMock(
+            return_value=CallToolResult(
+                content=[TextContent(type="text", text="Approval required")],
+                isError=True,
+                structuredContent={"tenuo": {"code": -32002, "message": "Approval required"}},
+            )
+        )
+        with pytest.raises(MCPApprovalRequired) as ri:
+            await client.call_tool("t", {}, warrant_context=False)
+        assert ri.value.request_hash is None
+
+    @pytest.mark.asyncio
     async def test_raise_on_tool_error_false_returns_content(self):
         from mcp.types import CallToolResult, TextContent
 

--- a/tenuo-python/tests/adapters/test_mcp_server.py
+++ b/tenuo-python/tests/adapters/test_mcp_server.py
@@ -165,6 +165,39 @@ class TestMCPVerificationResult:
         )
         assert result.is_approval_required is False
 
+    def test_request_hash_field_defaults_to_none(self):
+        result = MCPVerificationResult(
+            allowed=False,
+            tool="read_file",
+            clean_arguments={},
+            constraints={},
+        )
+        assert result.request_hash is None
+
+    def test_request_hash_in_to_jsonrpc_error(self):
+        result = MCPVerificationResult(
+            allowed=False,
+            tool="transfer",
+            clean_arguments={},
+            constraints={},
+            jsonrpc_error_code=-32002,
+            request_hash="abcd1234",
+        )
+        err = result.to_jsonrpc_error()
+        assert err["code"] == -32002
+        assert err["data"]["request_hash"] == "abcd1234"
+
+    def test_to_jsonrpc_error_no_data_when_no_hash(self):
+        result = MCPVerificationResult(
+            allowed=False,
+            tool="read_file",
+            clean_arguments={},
+            constraints={},
+            jsonrpc_error_code=-32001,
+        )
+        err = result.to_jsonrpc_error()
+        assert "data" not in err
+
 
 class TestMCPAuthorizationError:
     def test_carries_result(self):
@@ -472,6 +505,32 @@ class TestApprovalGateTriggered:
         assert result.is_approval_required
         assert result.jsonrpc_error_code == -32002
         assert "approvals" in (result.denial_reason or "").lower()
+        assert result.request_hash is not None, "request_hash must be populated from Rust"
+        assert len(result.request_hash) > 0
+
+    def test_gate_request_hash_in_jsonrpc_error(
+        self,
+        issuer_key: SigningKey,
+        agent_key: SigningKey,
+    ):
+        approver_key = SigningKey.generate()
+        authorizer = Authorizer(trusted_roots=[issuer_key.public_key])
+
+        warrant = Warrant.issue(
+            issuer_key,
+            capabilities={"transfer": {}},
+            holder=agent_key.public_key,
+            approval_gates={"transfer": None},
+            required_approvers=[approver_key.public_key],
+            min_approvals=1,
+        )
+        arguments, meta = _make_arguments(warrant, agent_key, "transfer", {"amount": 100})
+
+        result = MCPVerifier(authorizer=authorizer).verify("transfer", arguments, meta=meta)
+        err = result.to_jsonrpc_error()
+        assert err["code"] == -32002
+        assert "data" in err
+        assert err["data"]["request_hash"] == result.request_hash
 
     def test_gate_satisfied_with_valid_approval(
         self,


### PR DESCRIPTION
## Summary

- **Problem**: When an MCP approval gate fires (`-32002`), the Rust-computed `request_hash` from `ApprovalGateTriggered` was discarded by `MCPVerifier.verify()`. Clients had no way to obtain the correct hash for submitting approvals to the approval service without re-deriving it from `(warrant_id, tool, args, holder_key)`.

- **Fix**: Thread `request_hash` through the full server → wire → client path:
  1. `MCPVerificationResult` — new `request_hash: Optional[str]` field
  2. `MCPVerifier.verify()` — captures `gate_exc.request_hash` on `-32002`
  3. `to_jsonrpc_error()` — includes hash in `error.data` for JSON-RPC consumers
  4. `_denial_tool_return` (fastmcp_middleware) — includes hash in `structuredContent.tenuo`
  5. `MCPApprovalRequired` — accepts and stores `request_hash` parameter
  6. `SecureMCPClient.call_tool()` — extracts hash from `structuredContent.tenuo`

- After this change, `CloudMCPApprovalClient` can do:
  ```python
  request_hash_hex = getattr(approval_exc, "request_hash", None)
  request_hash_bytes = bytes.fromhex(request_hash_hex) if request_hash_hex else None
  ```

## Test plan

- [x] `MCPVerificationResult.request_hash` defaults to `None`
- [x] `to_jsonrpc_error()` includes `data.request_hash` when present, omits `data` when absent
- [x] `MCPVerifier.verify()` populates `request_hash` from `ApprovalGateTriggered` exception
- [x] Gate result's `to_jsonrpc_error()` round-trips the hash
- [x] `SecureMCPClient` extracts `request_hash` from `structuredContent.tenuo`
- [x] `SecureMCPClient` sets `request_hash=None` when hash is absent from wire
- [x] All 85 MCP tests pass