### PR TITLE
Fix production readiness blockers across MCP, Temporal, ADK, LangGraph

### DIFF
--- a/tenuo-python/tenuo/google_adk/guard.py
+++ b/tenuo-python/tenuo/google_adk/guard.py
@@ -403,7 +403,7 @@ class TenuoGuard:
                         logger.warning(
                             "encode_warrant_stack failed; warrant stack will be missing "
                             "from control plane event for '%s'",
-                            tool_name,
+                            skill_name,
                             exc_info=True,
                         )
                     self._control_plane.emit_for_enforcement(

--- a/tenuo-python/tenuo/google_adk/guard.py
+++ b/tenuo-python/tenuo/google_adk/guard.py
@@ -193,8 +193,12 @@ class TenuoGuard:
         self._owns_audit_log = False
         self._audit_log: Any = None
         if isinstance(audit_log, str):
-            self._audit_log = open(audit_log, "a")  # noqa: SIM115
-            self._owns_audit_log = True
+            try:
+                self._audit_log = open(audit_log, "a")  # noqa: SIM115
+                self._owns_audit_log = True
+            except Exception:
+                logger.error("Failed to open audit log file %r", audit_log, exc_info=True)
+                raise
         else:
             self._audit_log = audit_log
 
@@ -396,7 +400,12 @@ class TenuoGuard:
                         from tenuo_core import encode_warrant_stack
                         _warrant_stack = encode_warrant_stack([bound_warrant.warrant])
                     except Exception:
-                        pass
+                        logger.warning(
+                            "encode_warrant_stack failed; warrant stack will be missing "
+                            "from control plane event for '%s'",
+                            tool_name,
+                            exc_info=True,
+                        )
                     self._control_plane.emit_for_enforcement(
                         result, chain_result=result.chain_result,
                         latency_us=latency_us,
@@ -782,13 +791,29 @@ class TenuoGuard:
                 self._audit_log.write(json.dumps(record) + "\n")
                 self._audit_log.flush()
         except Exception as e:
-            # Fallback to standard logging if audit fails
-            logger.error(f"Failed to write audit log: {e}", exc_info=True)
+            logger.error(
+                "Audit event lost for tool '%s': %s. "
+                "Authorization decision was %s but cannot be recorded.",
+                tool_name,
+                e,
+                event,
+                exc_info=True,
+            )
 
     def close(self):
         """Clean up resources (e.g., audit log file handle)."""
         if self._owns_audit_log and hasattr(self._audit_log, "close"):
             self._audit_log.close()
+
+    def __del__(self):
+        """Safety net: close audit file handle if caller forgot close()/context manager."""
+        if getattr(self, "_owns_audit_log", False) and hasattr(
+            getattr(self, "_audit_log", None), "close"
+        ):
+            try:
+                self._audit_log.close()
+            except Exception:
+                pass
 
     def __enter__(self):
         return self

--- a/tenuo-python/tenuo/langgraph.py
+++ b/tenuo-python/tenuo/langgraph.py
@@ -403,7 +403,7 @@ class TenuoMiddleware(AgentMiddleware if MIDDLEWARE_AVAILABLE else object):  # t
         """Shared authorization logic for sync tool calls."""
         import time
 
-        request_id = str(uuid.uuid4())[:8]
+        request_id = str(uuid.uuid4())
         tool_call = request.tool_call
         tool_name = tool_call.get("name", "unknown")
         tool_args = tool_call.get("args", {})
@@ -501,7 +501,7 @@ class TenuoMiddleware(AgentMiddleware if MIDDLEWARE_AVAILABLE else object):  # t
         """Shared authorization logic for async tool calls."""
         import time
 
-        request_id = str(uuid.uuid4())[:8]
+        request_id = str(uuid.uuid4())
         tool_call = request.tool_call
         tool_name = tool_call.get("name", "unknown")
         tool_args = tool_call.get("args", {})
@@ -641,6 +641,12 @@ def _get_bound_warrant(
 
     # Auto-inflate from string (Base64) if needed (for serialization safety)
     if isinstance(warrant, str):
+        _MAX_WARRANT_B64 = 64 * 1024
+        if len(warrant) > _MAX_WARRANT_B64:
+            raise ConfigurationError(
+                f"Warrant string is {len(warrant)} bytes, exceeding the "
+                f"{_MAX_WARRANT_B64} byte safety limit. Possible corruption or attack."
+            )
         try:
             warrant = Warrant.from_base64(warrant)
         except Exception as e:
@@ -912,7 +918,7 @@ class TenuoToolNode(ToolNode if LANGGRAPH_AVAILABLE else object):  # type: ignor
             """Sync authorization wrapper passed to ToolNode."""
             import time
 
-            request_id = str(uuid.uuid4())[:8]
+            request_id = str(uuid.uuid4())
             tool_call = request.tool_call
             tool_name = tool_call.get("name", "unknown")
             tool_args = tool_call.get("args", {})
@@ -964,7 +970,7 @@ class TenuoToolNode(ToolNode if LANGGRAPH_AVAILABLE else object):  # type: ignor
             """Async authorization wrapper passed to ToolNode."""
             import time
 
-            request_id = str(uuid.uuid4())[:8]
+            request_id = str(uuid.uuid4())
             tool_call = request.tool_call
             tool_name = tool_call.get("name", "unknown")
             tool_args = tool_call.get("args", {})

--- a/tenuo-python/tenuo/mcp/client.py
+++ b/tenuo-python/tenuo/mcp/client.py
@@ -7,6 +7,7 @@ Wraps the MCP Python SDK to add cryptographic authorization for tool calls.
 import asyncio
 import base64
 import logging
+import random
 import sys
 import time
 from contextlib import AsyncExitStack, asynccontextmanager
@@ -201,6 +202,7 @@ class SecureMCPClient:
         self._tools: Optional[List[MCPTool]] = None
         self._wrapped_tools: Dict[str, Callable] = {}
         self._connect_lock = asyncio.Lock()
+        self._reconnect_delay: float = 0.0
 
         # Load MCP config if provided
         self.mcp_config = None
@@ -369,13 +371,26 @@ class SecureMCPClient:
             return True
         return False
 
+    _RECONNECT_BASE_DELAY = 0.5
+    _RECONNECT_MAX_DELAY = 30.0
+
     async def _reconnect(self) -> None:
         """Close the current session and reconnect using the same configuration.
 
         Serialized by the connect lock so that concurrent callers that both
-        see a connection error don't race through teardown/setup.
+        see a connection error don't race through teardown/setup.  Uses
+        exponential backoff with jitter to avoid hammering a down server.
         """
         async with self._connect_lock:
+            if self._reconnect_delay > 0:
+                jittered = self._reconnect_delay * (0.5 + random.random())
+                logger.info(
+                    "MCP reconnect backoff: %.1fs before retry to %s",
+                    jittered,
+                    self.url or self.command,
+                )
+                await asyncio.sleep(jittered)
+
             logger.info("MCP session lost; reconnecting to %s...", self.url or self.command)
             try:
                 await self.exit_stack.aclose()
@@ -385,7 +400,15 @@ class SecureMCPClient:
             self.session = None
             self._tools = None
             self._wrapped_tools = {}
-            await self._connect_unlocked()
+            try:
+                await self._connect_unlocked()
+                self._reconnect_delay = 0.0
+            except Exception:
+                self._reconnect_delay = min(
+                    max(self._reconnect_delay, self._RECONNECT_BASE_DELAY) * 2,
+                    self._RECONNECT_MAX_DELAY,
+                )
+                raise
 
     async def get_tools(self) -> List[MCPTool]:
         """
@@ -470,7 +493,11 @@ class SecureMCPClient:
                 result = self.compiled_config.extract_constraints(tool_name, arguments)
                 extraction_args = result.constraints
             except Exception:
-                pass
+                logger.warning(
+                    "Constraint extraction failed for '%s'; falling back to raw arguments",
+                    tool_name,
+                    exc_info=True,
+                )
 
         # Use unified enforcement logic
         enforcement: EnforcementResult = enforce_tool_call(
@@ -483,7 +510,11 @@ class SecureMCPClient:
             try:
                 self._control_plane.emit_for_enforcement(enforcement, chain_result=enforcement.chain_result)
             except Exception:
-                pass
+                logger.warning(
+                    "Control plane emission failed for '%s'; audit event lost",
+                    tool_name,
+                    exc_info=True,
+                )
 
         if enforcement.allowed:
             return ValidationResult.ok()

--- a/tenuo-python/tenuo/temporal.py
+++ b/tenuo-python/tenuo/temporal.py
@@ -740,7 +740,15 @@ class KeyResolver(ABC):
             # We're in a running loop (e.g., Temporal workflow)
             # Must use thread pool to avoid "loop already running" error
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                return pool.submit(self._resolve_in_new_loop, key_id).result()
+                try:
+                    return pool.submit(self._resolve_in_new_loop, key_id).result(
+                        timeout=30,
+                    )
+                except concurrent.futures.TimeoutError:
+                    raise KeyResolutionError(
+                        f"Key resolution timed out after 30s for key_id={key_id!r}. "
+                        "Check network connectivity to the key store."
+                    )
         except RuntimeError:
             # No running loop - safe to create one
             return self._resolve_in_new_loop(key_id)


### PR DESCRIPTION
## Summary

Addresses the blockers identified in the production readiness assessment:

**MCP client** (`tenuo/mcp/client.py`):
- Silent audit loss: control plane emission failures now `logger.warning` instead of bare `pass`
- Silent config errors: constraint extraction failures now `logger.warning` instead of bare `pass`
- No reconnect backoff: `_reconnect()` now uses exponential backoff with jitter (0.5s base, 30s max, resets on successful reconnect)

**Temporal** (`tenuo/temporal.py`):
- Hung key resolution: `pool.submit().result()` in `resolve_sync()` now has a 30s timeout; raises `KeyResolutionError` on timeout instead of blocking the activity indefinitely

**Google ADK** (`tenuo/google_adk/guard.py`):
- File handle leak: `open()` in `__init__` is now wrapped in try/except (logs + re-raises)
- `__del__` safety net added to close the file handle if the caller forgets `close()` or the context manager
- Audit write failures now log the tool name and decision type for easier diagnosis
- `encode_warrant_stack` failure now `logger.warning` instead of bare `pass`

**LangGraph** (`tenuo/langgraph.py`):
- Unbounded warrant allocation: `Warrant.from_base64()` now guarded by a 64KB size cap (matches MCP server limit)
- Weak audit correlation: `request_id` now uses full `uuid4()` instead of truncated 8-char prefix

## Test plan

- [x] 85 MCP tests pass (including reconnect, approval, control plane emission tests)
- [x] 88 Temporal tests pass
- [x] 147 ADK/Google tests pass
- [x] 179 LangChain/LangGraph tests pass
- [x] No lint errors