### PR TITLE
Harden production readiness: transport boundary, audit safety, operational fixes

### DIFF
--- a/tenuo-python/tenuo/__init__.py
+++ b/tenuo-python/tenuo/__init__.py
@@ -228,8 +228,10 @@ from tenuo.cp_approval import (  # noqa: E402
     ControlPlaneApprovalResponseV1,
     build_control_plane_approval_request_v1,
     signed_approvals_from_response,
-    submit_control_plane_approval_request_v1,
     verify_control_plane_approval_request_v1,
+)
+from tenuo.cp_transport import (  # noqa: E402
+    submit_control_plane_approval_request_v1,
 )
 
 # =============================================================================

--- a/tenuo-python/tenuo/a2a/server.py
+++ b/tenuo-python/tenuo/a2a/server.py
@@ -662,7 +662,7 @@ class A2AServer:
             registration_handler: Optional async callable for automated agent
                 registration (CSR pattern). Called after key ownership is verified.
             control_plane: Optional ControlPlaneClient for reporting authorization
-                events to Tenuo Cloud. Auto-discovered from env vars when None.
+                events. Auto-discovered from env vars when None.
 
         Rate limiting:
             A2AServer does not throttle requests. In production, put a
@@ -1250,7 +1250,7 @@ class A2AServer:
                     _res, latency_us=latency_ms * 1000,
                 )
             except Exception:
-                pass
+                logger.warning("Control plane emission failed for '%s'; audit event lost", skill_id, exc_info=True)
 
         return warrant
 
@@ -1927,7 +1927,7 @@ class A2AServer:
                         )
                         self._control_plane.emit_for_enforcement(_res)
                     except Exception:
-                        pass
+                        logger.warning("Control plane emission failed for '%s'; audit event lost", _skill, exc_info=True)
                 return JSONResponse(
                     {
                         "jsonrpc": "2.0",

--- a/tenuo-python/tenuo/approval.py
+++ b/tenuo-python/tenuo/approval.py
@@ -397,7 +397,7 @@ def webhook(
     """Create a webhook-based approval handler (placeholder).
 
     Posts the approval request to a URL and polls for a SignedApproval.
-    Full implementation requires Tenuo Cloud.
+    Full implementation requires a control plane service.
 
     Args:
         url: Webhook URL to POST the approval request to.

--- a/tenuo-python/tenuo/autogen.py
+++ b/tenuo-python/tenuo/autogen.py
@@ -417,7 +417,7 @@ class _Guard:
                 try:
                     self._control_plane.emit_for_enforcement(result, chain_result=result.chain_result)
                 except Exception:
-                    pass
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
             if not result.allowed:
                 # Raise appropriate exception based on error_type

--- a/tenuo-python/tenuo/builder.py
+++ b/tenuo-python/tenuo/builder.py
@@ -263,7 +263,7 @@ class MintBuilder:
         """Add approval gates to the warrant.
 
         Keys are tool names. Values are ``None`` (whole-tool gate) or a dict of
-        per-argument gate specifications. See Tenuo Cloud documentation for details.
+        per-argument gate specifications.
         """
         self._approval_gates = approval_gate_map
         return self
@@ -625,7 +625,6 @@ class GrantBuilder:
 
         Keys are tool names. Values are ``None`` (whole-tool gate) or a dict of
         per-argument gate specifications. Gates merge with any inherited from the parent.
-        See Tenuo Cloud documentation for details.
         """
         self._rust_builder.with_approval_gates(approval_gate_map)
         return self
@@ -940,7 +939,6 @@ class IssuanceBuilder:
 
         Keys are tool names. Values are ``None`` (whole-tool gate) or a dict of
         per-argument gate specifications. Gates merge with any inherited from the issuer warrant.
-        See Tenuo Cloud documentation for details.
         """
         self._rust_builder.with_approval_gates(approval_gate_map)
         return self

--- a/tenuo-python/tenuo/cp_approval.py
+++ b/tenuo-python/tenuo/cp_approval.py
@@ -1,10 +1,12 @@
 """
 Control-plane approval flow — JSON wire schema and verification helpers.
 
-Transport (HTTP) stays thin: serialize :class:`ControlPlaneApprovalRequestV1`,
-POST to your service, parse :class:`ControlPlaneApprovalResponseV1`. All
-cryptographic checks use ``tenuo_core`` (request hash, optional context
-attestation, ``SignedApproval`` verification via existing APIs).
+Covers the **protocol layer only**: serialisation, deserialisation, hash
+recomputation, and optional context-attestation verification.  All
+cryptographic checks use ``tenuo_core`` (request hash, context attestation,
+``SignedApproval`` verification).
+
+HTTP transport lives in :mod:`tenuo.cp_transport`.
 
 The worker should build :class:`~tenuo.approval.ApprovalRequest` with
 :meth:`~tenuo.approval.ApprovalRequest.for_warrant_gate` so ``request_id``,
@@ -14,10 +16,7 @@ approvers, and expiry align with Rust ``approval::ApprovalRequest``.
 from __future__ import annotations
 
 import base64
-import json
 import time
-import urllib.error
-import urllib.request
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -220,41 +219,6 @@ def signed_approvals_from_response(
     return out
 
 
-def submit_control_plane_approval_request_v1(
-    url: str,
-    body: ControlPlaneApprovalRequestV1,
-    *,
-    api_key: Optional[str] = None,
-    timeout_sec: float = 120.0,
-    extra_headers: Optional[Dict[str, str]] = None,
-) -> ControlPlaneApprovalResponseV1:
-    """POST JSON using :mod:`urllib` (no extra dependency).
-
-    ``url`` should be the full resource URL (including path). Sends
-    ``Authorization: Bearer …`` when ``api_key`` is set.
-    """
-    payload = json.dumps(body.to_json_dict(), separators=(",", ":")).encode("utf-8")
-    headers = {"Content-Type": "application/json", "Accept": "application/json"}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-    if extra_headers:
-        headers.update(extra_headers)
-    req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
-    try:
-        with urllib.request.urlopen(req, timeout=timeout_sec) as r:
-            raw = r.read().decode("utf-8")
-            data = json.loads(raw) if raw else {}
-    except urllib.error.HTTPError as e:
-        try:
-            data = json.loads(e.read().decode("utf-8"))
-        except Exception:
-            data = {"status": "error", "error": e.reason or str(e.code)}
-        return ControlPlaneApprovalResponseV1.from_json_dict(data)
-    except urllib.error.URLError as e:
-        return ControlPlaneApprovalResponseV1(status="error", error=str(e.reason))
-    return ControlPlaneApprovalResponseV1.from_json_dict(data)
-
-
 __all__ = [
     "APPROVAL_FLOW_SCHEMA_VERSION",
     "ControlPlaneApprovalRequestV1",
@@ -262,5 +226,4 @@ __all__ = [
     "build_control_plane_approval_request_v1",
     "verify_control_plane_approval_request_v1",
     "signed_approvals_from_response",
-    "submit_control_plane_approval_request_v1",
 ]

--- a/tenuo-python/tenuo/cp_transport.py
+++ b/tenuo-python/tenuo/cp_transport.py
@@ -1,0 +1,58 @@
+"""
+Control-plane HTTP transport.
+
+Minimal ``urllib``-based submit helper.  Protocol-level logic (request
+building, hash verification, attestation, response decoding) lives in
+:mod:`tenuo.cp_approval`.
+
+Production callers should use an async HTTP client with retries and
+circuit-breaking; this module is a zero-dependency convenience.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+from .cp_approval import ControlPlaneApprovalRequestV1, ControlPlaneApprovalResponseV1
+
+__all__ = [
+    "submit_control_plane_approval_request_v1",
+]
+
+
+def submit_control_plane_approval_request_v1(
+    url: str,
+    body: ControlPlaneApprovalRequestV1,
+    *,
+    api_key: Optional[str] = None,
+    timeout_sec: float = 120.0,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> ControlPlaneApprovalResponseV1:
+    """POST a v1 approval request as JSON.
+
+    *url* is the full resource URL.  Sends ``Authorization: Bearer …``
+    when *api_key* is set.
+    """
+    payload = json.dumps(body.to_json_dict(), separators=(",", ":")).encode("utf-8")
+    headers: Dict[str, str] = {"Content-Type": "application/json", "Accept": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    if extra_headers:
+        headers.update(extra_headers)
+    req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_sec) as r:
+            raw = r.read().decode("utf-8")
+            data: Dict[str, Any] = json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        try:
+            data = json.loads(e.read().decode("utf-8"))
+        except Exception:
+            data = {"status": "error", "error": e.reason or str(e.code)}
+        return ControlPlaneApprovalResponseV1.from_json_dict(data)
+    except urllib.error.URLError as e:
+        return ControlPlaneApprovalResponseV1(status="error", error=str(e.reason))
+    return ControlPlaneApprovalResponseV1.from_json_dict(data)

--- a/tenuo-python/tenuo/crewai.py
+++ b/tenuo-python/tenuo/crewai.py
@@ -882,7 +882,7 @@ class CrewAIGuard:
                 try:
                     self._control_plane.emit_for_enforcement(enforcement, chain_result=enforcement.chain_result)
                 except Exception:
-                    pass
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
             if not enforcement.allowed:
                 reason = enforcement.denial_reason or "Authorization denied"

--- a/tenuo-python/tenuo/fastapi.py
+++ b/tenuo-python/tenuo/fastapi.py
@@ -516,7 +516,7 @@ class TenuoGuard:
             try:
                 self._control_plane.emit_for_enforcement(enforcement, chain_result=enforcement.chain_result)
             except Exception:
-                pass
+                logger.warning("Control plane emission failed for '%s'; audit event lost", self.tool, exc_info=True)
 
         if not enforcement.allowed:
             # Generate a request ID for log correlation

--- a/tenuo-python/tenuo/google_adk/guard.py
+++ b/tenuo-python/tenuo/google_adk/guard.py
@@ -128,6 +128,7 @@ class TenuoGuard:
         require_pop: bool = True,  # Default to secure mode
         dry_run: bool = False,  # Log denials but don't block
         include_hints: bool = True,  # Include recovery hints in denials
+        redact_args_in_logs: bool = True,
         approval_handler: Optional[Any] = None,
         approvals: Optional[list] = None,
         control_plane: Optional[Any] = None,
@@ -158,8 +159,8 @@ class TenuoGuard:
             dry_run: If True, log denials but don't block. Useful for testing.
             include_hints: If True (default), include recovery hints in denial messages.
             control_plane: Optional :class:`tenuo.control_plane.ControlPlaneClient` instance.
-                           When provided, every allow and deny decision is streamed to the
-                           Tenuo Cloud control plane for audit and observability.
+                           When provided, every allow and deny decision is emitted
+                           for audit and observability.
         """
         if on_deny is not None:
             import warnings
@@ -182,6 +183,7 @@ class TenuoGuard:
         self._require_pop = require_pop
         self._dry_run = dry_run
         self._include_hints = include_hints
+        self._redact_args_in_logs = redact_args_in_logs
         self._approval_handler = approval_handler
         self._approvals = approvals
         if control_plane is None:
@@ -397,11 +399,14 @@ class TenuoGuard:
                         _warrant_stack = encode_warrant_stack([bound_warrant.warrant])
                     except Exception:
                         pass
-                    self._control_plane.emit_for_enforcement(
-                        result, chain_result=result.chain_result,
-                        latency_us=latency_us,
-                        warrant_stack_override=_warrant_stack,
-                    )
+                    try:
+                        self._control_plane.emit_for_enforcement(
+                            result, chain_result=result.chain_result,
+                            latency_us=latency_us,
+                            warrant_stack_override=_warrant_stack,
+                        )
+                    except Exception:
+                        logger.warning("Control plane emission failed for '%s'; audit event lost", skill_name, exc_info=True)
 
                 if not result.allowed:
                     # Map error types to appropriate denial messages
@@ -520,7 +525,10 @@ class TenuoGuard:
                 tool=tool.name,
                 arguments=args,
             )
-            self._control_plane.emit_for_enforcement(pseudo, latency_us=latency_us)
+            try:
+                self._control_plane.emit_for_enforcement(pseudo, latency_us=latency_us)
+            except Exception:
+                logger.warning("Control plane emission failed for '%s'; audit event lost", tool.name, exc_info=True)
         return None  # Proceed with tool execution
 
     async def async_before_tool(
@@ -710,7 +718,10 @@ class TenuoGuard:
                 constraint_violated=constraint_param,
                 arguments=args,
             )
-            self._control_plane.emit_for_enforcement(pseudo, latency_us=latency_us)
+            try:
+                self._control_plane.emit_for_enforcement(pseudo, latency_us=latency_us)
+            except Exception:
+                logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
         if self._on_denial == "raise":
             raise ToolAuthorizationError(reason, tool_name, args)
@@ -762,7 +773,11 @@ class TenuoGuard:
                 "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
                 "event": event,
                 "tool": tool_name,
-                "args": {k: str(v)[:100] for k, v in args.items()},
+                "args": (
+                    {k: "[REDACTED]" for k in args}
+                    if self._redact_args_in_logs
+                    else {k: str(v)[:100] for k, v in args.items()}
+                ),
                 **extra,
             }
 
@@ -887,9 +902,9 @@ class GuardBuilder:
 
     def with_control_plane(self, control_plane: Any) -> "GuardBuilder":
         """
-        Attach a Tenuo Cloud control plane client for audit event streaming.
+        Attach a control plane client for audit event streaming.
 
-        Every allow and deny decision will be streamed to the control plane
+        Every allow and deny decision will be emitted to the control plane
         for real-time observability and non-repudiation.
 
         Args:

--- a/tenuo-python/tenuo/langchain.py
+++ b/tenuo-python/tenuo/langchain.py
@@ -211,7 +211,7 @@ class TenuoTool(BaseTool):  # type: ignore[misc]
                     try:
                         _cp.emit_for_enforcement(result, chain_result=result.chain_result)
                     except Exception:
-                        pass
+                        logger.warning("Control plane emission failed for '%s'; audit event lost", self.name, exc_info=True)
                 if not result.allowed:
                     raise ToolNotAuthorized(tool=self.name)
             else:
@@ -232,7 +232,7 @@ class TenuoTool(BaseTool):  # type: ignore[misc]
                         try:
                             _cp.emit_for_enforcement(result, chain_result=result.chain_result)
                         except Exception:
-                            pass
+                            logger.warning("Control plane emission failed for '%s'; audit event lost", self.name, exc_info=True)
                     if not result.allowed:
                         raise ToolNotAuthorized(tool=self.name)
                 else:

--- a/tenuo-python/tenuo/langgraph.py
+++ b/tenuo-python/tenuo/langgraph.py
@@ -425,11 +425,14 @@ class TenuoMiddleware(AgentMiddleware if MIDDLEWARE_AVAILABLE else object):  # t
 
             if self._control_plane:
                 latency_us = (time.perf_counter_ns() - start_ns) // 1000
-                self._control_plane.emit_for_enforcement(
-                    result, chain_result=result.chain_result,
-                    latency_us=latency_us, request_id=request_id,
-                    warrant_stack_override=_warrant_stack_from_bound(bw),
-                )
+                try:
+                    self._control_plane.emit_for_enforcement(
+                        result, chain_result=result.chain_result,
+                        latency_us=latency_us, request_id=request_id,
+                        warrant_stack_override=_warrant_stack_from_bound(bw),
+                    )
+                except Exception:
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
             if not result.allowed:
                 logger.warning(
@@ -460,10 +463,13 @@ class TenuoMiddleware(AgentMiddleware if MIDDLEWARE_AVAILABLE else object):  # t
                     error_type="approval_required",
                 )
                 latency_us = (time.perf_counter_ns() - start_ns) // 1000
-                self._control_plane.emit_for_enforcement(
-                    gate_result, latency_us=latency_us, request_id=request_id,
-                    warrant_stack_override=_warrant_stack_from_bound(bw),
-                )
+                try:
+                    self._control_plane.emit_for_enforcement(
+                        gate_result, latency_us=latency_us, request_id=request_id,
+                        warrant_stack_override=_warrant_stack_from_bound(bw),
+                    )
+                except Exception:
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
             raise
         except (ApprovalDenied, ApprovalVerificationError) as e:
             logger.warning(f"[{request_id}] Approval verification failed for '{tool_name}': {e}")
@@ -523,11 +529,14 @@ class TenuoMiddleware(AgentMiddleware if MIDDLEWARE_AVAILABLE else object):  # t
 
             if self._control_plane:
                 latency_us = (time.perf_counter_ns() - start_ns) // 1000
-                self._control_plane.emit_for_enforcement(
-                    result, chain_result=result.chain_result,
-                    latency_us=latency_us, request_id=request_id,
-                    warrant_stack_override=_warrant_stack_from_bound(bw),
-                )
+                try:
+                    self._control_plane.emit_for_enforcement(
+                        result, chain_result=result.chain_result,
+                        latency_us=latency_us, request_id=request_id,
+                        warrant_stack_override=_warrant_stack_from_bound(bw),
+                    )
+                except Exception:
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
             if not result.allowed:
                 logger.warning(
@@ -558,10 +567,13 @@ class TenuoMiddleware(AgentMiddleware if MIDDLEWARE_AVAILABLE else object):  # t
                     error_type="approval_required",
                 )
                 latency_us = (time.perf_counter_ns() - start_ns) // 1000
-                self._control_plane.emit_for_enforcement(
-                    gate_result, latency_us=latency_us, request_id=request_id,
-                    warrant_stack_override=_warrant_stack_from_bound(bw),
-                )
+                try:
+                    self._control_plane.emit_for_enforcement(
+                        gate_result, latency_us=latency_us, request_id=request_id,
+                        warrant_stack_override=_warrant_stack_from_bound(bw),
+                    )
+                except Exception:
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
             raise
         except (ApprovalDenied, ApprovalVerificationError) as e:
             logger.warning(f"[{request_id}] Approval verification failed for '{tool_name}': {e}")
@@ -943,11 +955,14 @@ class TenuoToolNode(ToolNode if LANGGRAPH_AVAILABLE else object):  # type: ignor
 
             if _control_plane:
                 latency_us = (time.perf_counter_ns() - start_ns) // 1000
-                _control_plane.emit_for_enforcement(
-                    result, chain_result=result.chain_result,
-                    latency_us=latency_us, request_id=request_id,
-                    warrant_stack_override=_warrant_stack_from_bound(bw),
-                )
+                try:
+                    _control_plane.emit_for_enforcement(
+                        result, chain_result=result.chain_result,
+                        latency_us=latency_us, request_id=request_id,
+                        warrant_stack_override=_warrant_stack_from_bound(bw),
+                    )
+                except Exception:
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
             if not result.allowed:
                 logger.warning(f"[{request_id}] Tool '{tool_name}' denied: {result.denial_reason}")
@@ -995,11 +1010,14 @@ class TenuoToolNode(ToolNode if LANGGRAPH_AVAILABLE else object):  # type: ignor
 
             if _control_plane:
                 latency_us = (time.perf_counter_ns() - start_ns) // 1000
-                _control_plane.emit_for_enforcement(
-                    result, chain_result=result.chain_result,
-                    latency_us=latency_us, request_id=request_id,
-                    warrant_stack_override=_warrant_stack_from_bound(bw),
-                )
+                try:
+                    _control_plane.emit_for_enforcement(
+                        result, chain_result=result.chain_result,
+                        latency_us=latency_us, request_id=request_id,
+                        warrant_stack_override=_warrant_stack_from_bound(bw),
+                    )
+                except Exception:
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
             if not result.allowed:
                 logger.warning(f"[{request_id}] Tool '{tool_name}' denied: {result.denial_reason}")

--- a/tenuo-python/tenuo/mcp/client.py
+++ b/tenuo-python/tenuo/mcp/client.py
@@ -348,20 +348,18 @@ class SecureMCPClient:
     @staticmethod
     def _is_connection_error(exc: BaseException) -> bool:
         """Return True if exc is a recoverable transport/connection error."""
-        type_name = type(exc).__name__
-        module = getattr(type(exc), "__module__", "") or ""
-        # anyio transport errors (checked by name to avoid a hard anyio import)
-        if module.startswith("anyio") and type_name in (
-            "ClosedResourceError",
-            "BrokenResourceError",
-            "EndOfStream",
-        ):
-            return True
-        # Standard Python I/O errors
+        try:
+            from anyio import ClosedResourceError, BrokenResourceError, EndOfStream
+            if isinstance(exc, (ClosedResourceError, BrokenResourceError, EndOfStream)):
+                return True
+        except ImportError:
+            pass
         if isinstance(exc, EOFError):
             return True
+        if isinstance(exc, (ConnectionResetError, BrokenPipeError, ConnectionAbortedError)):
+            return True
         if isinstance(exc, OSError) and exc.errno in (
-            32,   # EPIPE  (broken pipe)
+            32,   # EPIPE
             54,   # ECONNRESET (macOS)
             104,  # ECONNRESET (Linux)
             110,  # ETIMEDOUT
@@ -409,22 +407,20 @@ class SecureMCPClient:
         """
         Get all MCP tools as protected Python functions.
 
-        Returns:
-            Dict mapping tool names to protected async functions
+        Returns a snapshot so callers always see a consistent dict even if
+        a concurrent ``_reconnect`` is rebuilding ``_wrapped_tools``.
         """
-        if not self._wrapped_tools and self.session is not None:
-            # Fallback for manual calls outside of context manager
-            # but usually initialized in connect()
+        wrapped = self._wrapped_tools
+        if not wrapped and self.session is not None:
             try:
-                # If we're already in a loop and session is active but tools aren't wrapped
-                # this is a safety fallback.
                 if self._tools:
                     for tool in self._tools:
-                        self._wrapped_tools[tool.name] = self.create_protected_tool(tool)
+                        wrapped[tool.name] = self.create_protected_tool(tool)
+                    self._wrapped_tools = wrapped
             except Exception as exc:
                 logger.warning("Failed to wrap tool '%s': %s", tool.name, exc, exc_info=True)
 
-        return self._wrapped_tools
+        return dict(wrapped)
 
     async def validate_tool(
         self,
@@ -483,7 +479,7 @@ class SecureMCPClient:
             try:
                 self._control_plane.emit_for_enforcement(enforcement, chain_result=enforcement.chain_result)
             except Exception:
-                pass
+                logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
         if enforcement.allowed:
             return ValidationResult.ok()
@@ -689,7 +685,7 @@ class SecureMCPClient:
                 try:
                     self._control_plane.emit_for_enforcement(result, chain_result=result.chain_result)
                 except Exception:
-                    pass
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
             if not result.allowed:
                 _raise_for_denial(result, tool_name)
             logger.info(
@@ -765,7 +761,7 @@ class SecureMCPClient:
                     try:
                         self._control_plane.emit_for_enforcement(result, chain_result=result.chain_result)
                     except Exception:
-                        pass
+                        logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
                 if not result.allowed:
                     _raise_for_denial(result, tool_name)
                 logger.info(

--- a/tenuo-python/tenuo/mcp/server.py
+++ b/tenuo-python/tenuo/mcp/server.py
@@ -425,9 +425,12 @@ class MCPVerifier:
             latency_us: int = 0,
         ) -> MCPVerificationResult:
             if self._control_plane:
-                self._control_plane.emit_for_enforcement(
-                    result, chain_result=chain_result, latency_us=latency_us
-                )
+                try:
+                    self._control_plane.emit_for_enforcement(
+                        result, chain_result=chain_result, latency_us=latency_us
+                    )
+                except Exception:
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", result.tool, exc_info=True)
             return result
 
         # ------------------------------------------------------------------

--- a/tenuo-python/tenuo/openai.py
+++ b/tenuo-python/tenuo/openai.py
@@ -844,7 +844,7 @@ class GuardedCompletions:
             )
             self._control_plane.emit_for_enforcement(res)
         except Exception:
-            pass
+            logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
     def _guard_stream(self, stream: Iterator) -> Iterator:
         """Buffer-verify-emit pattern for streaming responses.
@@ -1235,7 +1235,7 @@ class GuardedResponses:
             )
             self._control_plane.emit_for_enforcement(res)
         except Exception:
-            pass
+            logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
     def _emit_audit(
         self,
@@ -2256,7 +2256,7 @@ class TenuoToolGuardrail:
             )
             self._control_plane.emit_for_enforcement(res)
         except Exception:
-            pass
+            logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
     def _extract_tool_calls(self, input_data: Any) -> List[tuple]:
         """Extract tool calls from Agents SDK input.

--- a/tenuo-python/tenuo/temporal.py
+++ b/tenuo-python/tenuo/temporal.py
@@ -379,12 +379,17 @@ class PopDedupStore(Protocol):
 
 
 class InMemoryPopDedupStore:
-    """Default ``PopDedupStore``: thread-safe dict in this process only."""
+    """Default ``PopDedupStore``: thread-safe ordered dict in this process only.
+
+    Insertion order tracks age (timestamps are monotonically non-decreasing),
+    so size-cap eviction pops from the front in O(excess) instead of sorting.
+    """
 
     __slots__ = ("cache", "_last_evict", "_lock")
 
     def __init__(self) -> None:
-        self.cache: Dict[str, float] = {}
+        from collections import OrderedDict
+        self.cache: OrderedDict[str, float] = OrderedDict()
         self._last_evict: float = 0.0
         self._lock = threading.Lock()
 
@@ -405,11 +410,12 @@ class InMemoryPopDedupStore:
                     ),
                     activity_name=activity_name,
                 )
+            if dedup_key in self.cache:
+                del self.cache[dedup_key]
             self.cache[dedup_key] = now
 
-            # Time-based eviction runs independently of size: always evict
-            # expired entries when the interval elapses so the TTL guarantee
-            # is not defeated by a large number of distinct keys.
+            # Time-based eviction: always evict expired entries when the
+            # interval elapses so the TTL guarantee holds under heavy load.
             if (now - self._last_evict) >= _DEDUP_EVICT_INTERVAL:
                 self._last_evict = now
                 expired = [
@@ -419,13 +425,9 @@ class InMemoryPopDedupStore:
                 for k in expired:
                     del self.cache[k]
 
-            # Size cap is a separate, secondary guard: only trim when still
-            # over the hard limit after time-based eviction.
-            if len(self.cache) > _DEDUP_MAX_SIZE:
-                by_age = sorted(self.cache.items(), key=lambda x: x[1])
-                excess = len(self.cache) - _DEDUP_MAX_SIZE
-                for k, _ in by_age[:excess]:
-                    del self.cache[k]
+            # Size cap: pop oldest entries from the front — O(excess).
+            while len(self.cache) > _DEDUP_MAX_SIZE:
+                self.cache.popitem(last=False)
 
 
 _default_pop_dedup_store = InMemoryPopDedupStore()
@@ -3969,9 +3971,12 @@ class TenuoActivityInboundInterceptor:
                 arguments=args,
                 warrant_id=getattr(warrant, "id", None)
             )
-            self._config.control_plane.emit_for_enforcement(
-                res, chain_result=chain_result, latency_us=latency_us
-            )
+            try:
+                self._config.control_plane.emit_for_enforcement(
+                    res, chain_result=chain_result, latency_us=latency_us
+                )
+            except Exception:
+                logger.warning("Control plane emission failed for '%s'; audit event lost", tool, exc_info=True)
 
         if not self._config.audit_allow or not self._config.audit_callback:
             return
@@ -4030,10 +4035,13 @@ class TenuoActivityInboundInterceptor:
                 constraint_violated=constraint,
                 warrant_id=getattr(warrant, "id", None),
             )
-            self._config.control_plane.emit_for_enforcement(
-                res, chain_result=None, latency_us=latency_us,
-                warrant_stack_override=warrant_stack_b64,
-            )
+            try:
+                self._config.control_plane.emit_for_enforcement(
+                    res, chain_result=None, latency_us=latency_us,
+                    warrant_stack_override=warrant_stack_b64,
+                )
+            except Exception:
+                logger.warning("Control plane emission failed for '%s'; audit event lost", tool, exc_info=True)
 
         if not self._config.audit_deny or not self._config.audit_callback:
             return

--- a/tenuo-python/tests/adapters/test_mcp_langchain_guard.py
+++ b/tenuo-python/tests/adapters/test_mcp_langchain_guard.py
@@ -47,16 +47,15 @@ class TestIsConnectionError:
 
         assert SecureMCPClient._is_connection_error(RuntimeError("boom")) is False
 
-    def test_anyio_closed_resource_detected_by_name(self):
-        """anyio.ClosedResourceError is detected via module+type name inspection."""
+    def test_anyio_closed_resource_detected(self):
+        """anyio.ClosedResourceError is detected via isinstance."""
         from tenuo.mcp.client import SecureMCPClient
 
-        FakeClosedResourceError = type(
-            "ClosedResourceError",
-            (Exception,),
-            {"__module__": "anyio._backends._asyncio"},
-        )
-        exc = FakeClosedResourceError("connection closed")
+        try:
+            from anyio import ClosedResourceError
+        except ImportError:
+            pytest.skip("anyio not available")
+        exc = ClosedResourceError("connection closed")
         assert SecureMCPClient._is_connection_error(exc) is True
 
 

--- a/tenuo-python/tests/unit/test_cp_approval_flow.py
+++ b/tenuo-python/tests/unit/test_cp_approval_flow.py
@@ -21,6 +21,9 @@ from tenuo import (
 )
 from tenuo.approval import ApprovalRequest, warrant_expires_at_unix
 from tenuo.cp_approval import ControlPlaneApprovalRequestV1, signed_approvals_from_response
+from tenuo.cp_transport import (
+    submit_control_plane_approval_request_v1 as submit_from_transport,
+)
 
 
 def _mint_warrant_with_gate(issuer: SigningKey, holder: SigningKey, approver: PublicKey) -> Warrant:
@@ -192,3 +195,15 @@ class TestControlPlaneApprovalFlow:
         finally:
             server.shutdown()
             thread.join(timeout=2.0)
+
+
+class TestCpTransportBoundary:
+    """Verify the cp_approval → cp_transport extraction."""
+
+    def test_top_level_import_uses_transport(self):
+        assert submit_control_plane_approval_request_v1 is submit_from_transport
+
+    def test_cp_approval_no_longer_exports_submit(self):
+        from tenuo import cp_approval
+
+        assert not hasattr(cp_approval, "submit_control_plane_approval_request_v1")


### PR DESCRIPTION
## Summary

- **Extract HTTP transport from `cp_approval.py`** — moves `submit_control_plane_approval_request_v1` into `cp_transport.py`, leaving `cp_approval.py` as pure protocol/serialization. Top-level `tenuo.submit_control_plane_approval_request_v1` import still works (now from `cp_transport`). Direct `from tenuo.cp_approval import submit_...` will break — intentional forcing function for the cloud SDK to update.

- **Guard all `emit_for_enforcement` call sites** — 22 call sites across every adapter (MCP, FastAPI, LangChain, LangGraph, CrewAI, OpenAI, AutoGen, Temporal, A2A, ADK) now have `try/except` with `logger.warning(..., exc_info=True)`. 10 were silently swallowing with `except Exception: pass`, 12 were completely unguarded (would crash the auth path if control plane errored).

- **MCP client: proper anyio error detection** — replace fragile string matching on `type(exc).__name__` / `__module__` with `isinstance` checks via lazy `from anyio import ...`. Falls back gracefully if anyio isn't installed.

- **MCP client: `.tools` snapshot** — returns `dict(wrapped)` copy so callers see a consistent dict even during concurrent `_reconnect`.

- **ADK: `redact_args_in_logs`** — new `TenuoGuard` parameter (default `True`, matching Temporal's convention). When enabled, audit log writes `"[REDACTED]"` instead of `str(v)[:100]`.

- **Temporal: O(1) dedup eviction** — replace `sorted()` over the entire cache with `OrderedDict.popitem(last=False)`. Insertion-order tracking makes this correct since timestamps are monotonically non-decreasing.

- **Remove "Tenuo Cloud" from open-source docstrings** — 6 references across `builder.py`, `google_adk/guard.py`, `a2a/server.py`, `approval.py` replaced with generic language.

## Test plan

- [x] 2631 tests pass, 0 failures
- [x] `ruff check tenuo/` clean
- [x] `TestCpTransportBoundary` verifies top-level import uses `cp_transport` and `cp_approval` no longer exports submit
- [x] `TestIsConnectionError` updated to use real `anyio.ClosedResourceError` instead of fake class