### PR TITLE
Release 0.1.0-beta.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-beta.19] - 2026-04-10
+
 ### Security
 
+- **Guarded telemetry emissions** — all `emit_for_enforcement` calls across every adapter are now wrapped in `try/except` with `logger.warning` so a control-plane outage cannot crash the authorization path.
+- **MCP client connection detection** — replaced fragile string-matching on exception class names with proper `isinstance` checks.
 - **Explorer** — Vite updated to 8.0.8+ (addresses GHSA-p9ff-h696-f583, GHSA-v2wj-q39q-566r, GHSA-4w7w-66w2-5vf9).
+
+### Added
+
+- **MCP `request_hash` threading** — Rust-computed approval request hash flows through `MCPVerificationResult`, the JSON-RPC error payload, and `MCPApprovalRequired` so clients can correlate approvals end-to-end.
+- **`tenuo.cp_transport`** — HTTP submission extracted from `tenuo.cp_approval`; core is now pure protocol/serialization.
+- **ADK `redact_args_in_logs`** — `TenuoGuard` can redact tool arguments in audit logs to prevent PII leakage.
+- **Property-based test suite** — 20+ Hypothesis test modules covering enforcement, FFI boundaries, MCP, Temporal, FastAPI, LangChain/LangGraph, A2A, and agent frameworks.
+
+### Changed
+
+- **MCP client reconnect** — exponential backoff with jitter instead of immediate retry; `.tools` returns a snapshot for thread safety.
+- **Temporal dedup cache** — `OrderedDict`-backed eviction (O(1) amortized); `resolve_sync` has a 30 s timeout.
+- **LangGraph** — warrant deserialization capped at 64 KB; request IDs use full UUIDs.
+- Removed stale "Tenuo Cloud" references from open-source docstrings.
 
 ## [0.1.0-beta.18] - 2026-04-09
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2026 Tenuo Contributors
+Copyright (c) 2025-2026 Tenuo Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Tenuo Contributors
+Copyright (c) 2024-2026 Tenuo Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ This runs the [orchestrator -> worker -> authorizer demo](https://tenuo.ai/demo.
 **Official Images** on [Docker Hub](https://hub.docker.com/u/tenuo):
 
 ```bash
-docker pull tenuo/authorizer:0.1.0-beta.14  # Sidecar for warrant verification
-docker pull tenuo/control:0.1.0-beta.14     # Control plane (demo/reference)
+docker pull tenuo/authorizer:0.1.0-beta.19  # Sidecar for warrant verification
+docker pull tenuo/control:0.1.0-beta.19     # Control plane (demo/reference)
 ```
 
 **Helm Chart**:
@@ -371,7 +371,7 @@ What you get in Rust:
 
 ```toml
 [dependencies]
-tenuo = "0.1.0-beta.18"
+tenuo = "0.1.0-beta.19"
 ```
 
 Use the Rust API when you need a language-native enforcement boundary

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "axum",
  "base64",

--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Agent Capability Flow Control - Rust core library"

--- a/tenuo-python/Cargo.lock
+++ b/tenuo-python/Cargo.lock
@@ -2236,7 +2236,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "axum",
  "base64",
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-python"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "pyo3",
  "tenuo",

--- a/tenuo-python/Cargo.toml
+++ b/tenuo-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-python"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Capability tokens for AI agents - Python SDK"

--- a/tenuo-python/pyproject.toml
+++ b/tenuo-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tenuo"
-version = "0.1.0b18"
+version = "0.1.0b19"
 description = "Capability tokens for AI agents - Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tenuo-python/tenuo/__init__.py
+++ b/tenuo-python/tenuo/__init__.py
@@ -370,4 +370,4 @@ __all__ = [
     "get_default_nonce_store",
 ]
 
-__version__ = "0.1.0b18"
+__version__ = "0.1.0b19"

--- a/tenuo-python/tenuo/control_plane.py
+++ b/tenuo-python/tenuo/control_plane.py
@@ -5,11 +5,14 @@ PyControlPlaneClient that handles env-var discovery and optional
 process-level singleton for integrations that don't manage lifecycle.
 """
 import json
+import logging
 import os
 import uuid
 import atexit
 import platform
 from typing import Optional, Any
+
+logger = logging.getLogger(__name__)
 
 _global_client: Optional["ControlPlaneClient"] = None
 
@@ -135,7 +138,7 @@ class ControlPlaneClient:
                 mod = __import__(mod_name)
                 meta.setdefault(meta_key, getattr(mod, "__version__", "unknown"))
             except Exception:
-                pass
+                logger.debug("Optional framework %r not installed, skipping metadata", mod_name)
 
         # Delegate everything to Rust core: token parsing, key generation,
         # agent claiming, and heartbeat loop startup.
@@ -252,7 +255,7 @@ def _auto_shutdown():
         try:
             client.shutdown(timeout_secs=2.0)
         except Exception:
-            pass
+            logger.debug("Control plane shutdown failed at exit", exc_info=True)
 
 atexit.register(_auto_shutdown)
 

--- a/tenuo-wasm/Cargo.toml
+++ b/tenuo-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-wasm"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "WASM bindings for Tenuo"


### PR DESCRIPTION
## Summary

- Changelog entries for all production-readiness work since beta.18
- Version bump to 0.1.0-beta.19 across all manifests
- Replace silent `except` passes in `control_plane.py` with `logger.debug`
- Update README Docker versions and LICENSE copyright year

## After merge

Create a GitHub Release tagged `v0.1.0-beta.19` from main to trigger the publish workflow.