### PR TITLE
Fix WASM connect token using wrong field key for registration token

### DIFF
--- a/tenuo-wasm/src/lib.rs
+++ b/tenuo-wasm/src/lib.rs
@@ -1217,7 +1217,7 @@ pub fn sign_receipt(payload_json: JsValue, authorizer_key_hex: &str) -> JsValue 
 
 /// Parse a `TENUO_CONNECT_TOKEN` string into its component fields.
 ///
-/// The token is a base64url-encoded JSON blob: `{ v, e, k, a?, r? }`.
+/// The token is a base64url-encoded JSON blob: `{ v, e, k, a?, t? }`.
 /// This WASM binding keeps the parsing canonical so TypeScript doesn't need
 /// to duplicate the decode logic.
 ///
@@ -1233,8 +1233,8 @@ pub fn parse_connect_token(token: &str) -> JsValue {
         k: String,
         #[serde(default)]
         a: Option<String>,
-        #[serde(default)]
-        r: Option<String>,
+        #[serde(default, alias = "r")]
+        t: Option<String>,
     }
 
     #[derive(Serialize)]
@@ -1283,7 +1283,7 @@ pub fn parse_connect_token(token: &str) -> JsValue {
         endpoint: Some(raw.e),
         api_key: Some(raw.k),
         agent_id: raw.a,
-        registration_token: raw.r,
+        registration_token: raw.t,
         error: None,
     }).unwrap()
 }


### PR DESCRIPTION
## Summary

- **Bug:** `parse_connect_token` in `tenuo-wasm` deserialized the registration token from JSON key `"r"`, while Rust core (`connect_token.rs`) uses `"t"`. Tokens generated by the dashboard or Rust core silently lost their registration token when parsed in the browser/WASM context.
- **Fix:** Changed the field to `t` (matching core) and added `alias = "r"` for backward compatibility with any tokens that may have already been generated with the old key.

Closes #352

## Test plan

- [x] `cargo check` on `tenuo-wasm` passes (no compile errors)
- [x] `cargo test --features server -- connect_token` on `tenuo-core` passes (7 tests)
- [x] Verified Rust core canonical field is `"t"` via `#[serde(rename = "t")]` and all test fixtures