### PR TITLE
Fix CodeQL alerts: path injection in docs preview server

### DIFF
--- a/docs/_preview.py
+++ b/docs/_preview.py
@@ -138,6 +138,12 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         elif rel.endswith(".md"):
             rel = rel[: -len(".md")]
         for fpath in _resolved_paths_under_docs(rel):
+            # Defense-in-depth: re-verify the resolved path is under DOCS_DIR
+            # (_resolved_paths_under_docs already checks, but this makes the
+            # constraint visible to static analysis tools like CodeQL).
+            _docs_real = os.path.realpath(DOCS_DIR) + os.sep
+            if not os.path.realpath(fpath).startswith(_docs_real):
+                continue
             if os.path.isfile(fpath):
                 try:
                     with open(fpath, encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

Addresses all 5 open CodeQL code scanning alerts:

**Fixed (this PR):**
- **Alerts 61, 62** (high — `py/path-injection` in `docs/_preview.py`): Added redundant path-containment check at the file-open site. The `_resolved_paths_under_docs` generator already validates paths stay under `DOCS_DIR`, but CodeQL cannot trace sanitization through Python generators. The inline re-check makes the constraint visible to static analysis.

**Dismissed as false positives (via GitHub API):**
- **Alerts 33, 50** (high — `js/incomplete-sanitization` in `App.tsx`): Code uses `.replaceAll()` which replaces all occurrences. CodeQL's rule targets `.replace(string, string)` which only replaces the first. `.replaceAll` is not vulnerable to incomplete sanitization.
- **Alert 34** (medium — `js/functionality-from-untrusted-source` in `post.html`): The highlight.js `<script>` tag already includes `integrity="sha512-…"` and `crossorigin="anonymous"`. The Google Fonts `@import` cannot have SRI as the API returns dynamic CSS.

## Test plan

- [x] Pre-commit hooks pass
- [x] Verified `_preview.py` still renders docs correctly (path validation is redundant with existing generator check)
- [x] All 3 false positives dismissed with explanations on GitHub