### PR TITLE
feat(a2a): thread approval transport through A2A adapter

### DIFF
--- a/tenuo-python/tenuo/a2a/errors.py
+++ b/tenuo-python/tenuo/a2a/errors.py
@@ -38,6 +38,10 @@ __all__ = [
     # Client errors
     "KeyMismatchError",
     "MissingSigningKeyError",
+    # Approval errors
+    "ApprovalRequiredError",
+    "InsufficientApprovalsError",
+    "InvalidApprovalError",
     # Configuration errors
     "ConstraintBindingError",
     # Registration errors
@@ -84,6 +88,9 @@ class A2AErrorCode:
     UNKNOWN_CONSTRAINT = -32014  # -> 1504 (UnknownConstraintType)
     POP_REQUIRED = -32015  # -> 1600 (PopSignatureInvalid)
     POP_FAILED = -32016  # -> 1600 (PopSignatureInvalid)
+    APPROVAL_REQUIRED = -32019  # -> 1707 (ApprovalRequired)
+    INSUFFICIENT_APPROVALS = -32020  # -> 1702 (InsufficientApprovals)
+    INVALID_APPROVAL = -32021  # -> 1701 (ApprovalInvalid)
     REGISTRATION_DISABLED = -32017  # agent/register called but no handler configured
     REGISTRATION_DENIED = -32018  # handler explicitly denied the warrant request
 
@@ -105,6 +112,9 @@ class A2AErrorCode:
             cls.UNKNOWN_CONSTRAINT: 1504,
             cls.POP_REQUIRED: 1600,
             cls.POP_FAILED: 1600,
+            cls.APPROVAL_REQUIRED: 1707,
+            cls.INSUFFICIENT_APPROVALS: 1702,
+            cls.INVALID_APPROVAL: 1701,
         }
         return mapping.get(jsonrpc_code)
 
@@ -124,6 +134,9 @@ class A2AErrorCode:
             1501: cls.CONSTRAINT_VIOLATION,
             1504: cls.UNKNOWN_CONSTRAINT,
             1600: cls.POP_FAILED,
+            1701: cls.INVALID_APPROVAL,
+            1702: cls.INSUFFICIENT_APPROVALS,
+            1707: cls.APPROVAL_REQUIRED,
             1800: cls.REVOKED,
         }
         return mapping.get(wire_code, cls.INTERNAL_ERROR)
@@ -147,6 +160,9 @@ ERROR_MESSAGES = {
     A2AErrorCode.UNKNOWN_CONSTRAINT: "unknown_constraint",
     A2AErrorCode.POP_REQUIRED: "pop_required",
     A2AErrorCode.POP_FAILED: "pop_failed",
+    A2AErrorCode.APPROVAL_REQUIRED: "approval_required",
+    A2AErrorCode.INSUFFICIENT_APPROVALS: "insufficient_approvals",
+    A2AErrorCode.INVALID_APPROVAL: "invalid_approval",
     A2AErrorCode.REGISTRATION_DISABLED: "registration_disabled",
     A2AErrorCode.REGISTRATION_DENIED: "registration_denied",
 }
@@ -334,6 +350,62 @@ class RevokedError(A2AError):
     """
 
     code = A2AErrorCode.REVOKED
+
+
+# =============================================================================
+# Approval Errors
+# =============================================================================
+
+
+class ApprovalRequiredError(A2AError):
+    """Approval gate fired — human approval is required.
+
+    The ``data`` field carries all the information the caller needs to
+    obtain approvals and retry:
+
+    - ``request_hash``: hex-encoded hash the approval must cover
+    - ``required_approvers``: list of hex-encoded approver public keys
+    - ``min_approvals``: threshold count
+    - ``skill``: the gated skill
+    """
+
+    code = A2AErrorCode.APPROVAL_REQUIRED
+
+    def __init__(
+        self,
+        skill: str,
+        *,
+        request_hash: str = "",
+        required_approvers: Optional[list[str]] = None,
+        min_approvals: int = 1,
+    ) -> None:
+        super().__init__(
+            f"Approval required for skill '{skill}'",
+            {
+                "skill": skill,
+                "request_hash": request_hash,
+                "required_approvers": required_approvers or [],
+                "min_approvals": min_approvals,
+            },
+        )
+
+
+class InsufficientApprovalsError(A2AError):
+    """Some approvals were provided but not enough valid ones."""
+
+    code = A2AErrorCode.INSUFFICIENT_APPROVALS
+
+    def __init__(self, message: str, *, required: int = 0, received: int = 0) -> None:
+        super().__init__(message, {"required": required, "received": received})
+
+
+class InvalidApprovalError(A2AError):
+    """Approval payload is malformed or unverifiable."""
+
+    code = A2AErrorCode.INVALID_APPROVAL
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"Invalid approval: {reason}", {"reason": reason})
 
 
 # =============================================================================

--- a/tenuo-python/tenuo/a2a/server.py
+++ b/tenuo-python/tenuo/a2a/server.py
@@ -62,10 +62,13 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, FrozenSet, List, Optional
 from .errors import (
     A2AError,
     A2AErrorCode,
+    ApprovalRequiredError,
     AudienceMismatchError,
     ChainValidationError,
     ConstraintBindingError,
     ConstraintViolationError,
+    InsufficientApprovalsError,
+    InvalidApprovalError,
     InvalidSignatureError,
     MissingWarrantError,
     PopRequiredError,
@@ -118,6 +121,9 @@ except ImportError:
 
 # Delegation chain header (legacy transport; WarrantStack is preferred).
 WARRANT_CHAIN_HEADER = "X-Tenuo-Warrant-Chain"
+
+# Approvals header — JSON array of base64 CBOR-encoded SignedApprovals.
+APPROVALS_HEADER = "X-Tenuo-Approvals"
 
 logger = logging.getLogger("tenuo.a2a.server")
 
@@ -1013,6 +1019,7 @@ class A2AServer:
         warrant_chain: Optional[str] = None,
         _preloaded_parents: Optional[List[Any]] = None,
         pop_signature: Optional[bytes] = None,
+        approvals: Optional[List[Any]] = None,
     ) -> "Warrant":
         """
         Validate a warrant for a skill invocation.
@@ -1025,6 +1032,7 @@ class A2AServer:
             _preloaded_parents: Already-decoded parent warrants from a WarrantStack
                 (takes precedence over ``warrant_chain`` when provided)
             pop_signature: Optional Proof-of-Possession signature bytes
+            approvals: Optional list of decoded SignedApproval objects for multi-sig
 
         Returns:
             Validated Warrant object
@@ -1148,15 +1156,36 @@ class A2AServer:
                 if _resolved_chain_parents:
                     all_chain = list(_resolved_chain_parents) + [warrant]
                     self._authorizer.check_chain(
-                        all_chain, skill_id, arguments, signature=pop_signature
+                        all_chain, skill_id, arguments,
+                        signature=pop_signature, approvals=approvals,
                     )
                 else:
                     self._authorizer.authorize_one(
-                        warrant, skill_id, arguments, signature=pop_signature
+                        warrant, skill_id, arguments,
+                        signature=pop_signature, approvals=approvals,
                     )
                 logger.debug(f"PoP verified for skill '{skill_id}'")
             except Exception as e:
-                # Map tenuo_core errors to A2A errors
+                from tenuo.exceptions import (
+                    ApprovalGateTriggered as _ApprovalGate,
+                    InsufficientApprovals as _InsufficientApprovals,
+                    InvalidApproval as _InvalidApproval,
+                )
+                if isinstance(e, _ApprovalGate):
+                    raise ApprovalRequiredError(
+                        skill_id,
+                        request_hash=getattr(e, "request_hash", ""),
+                        min_approvals=getattr(e, "min_approvals", 1),
+                    ) from e
+                if isinstance(e, _InsufficientApprovals):
+                    raise InsufficientApprovalsError(
+                        str(e),
+                        required=getattr(e, "required", 0),
+                        received=getattr(e, "received", 0),
+                    ) from e
+                if isinstance(e, _InvalidApproval):
+                    raise InvalidApprovalError(str(e)) from e
+                # Map PoP errors
                 error_msg = str(e)
                 if "Proof-of-Possession" in error_msg or "signature" in error_msg.lower():
                     raise PopVerificationError(error_msg)
@@ -1780,6 +1809,38 @@ class A2AServer:
             raise UnknownConstraintError(constraint_type=constraint_type, param=param)
 
     # -------------------------------------------------------------------------
+    # Approval Decoding
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_approvals(request: "Request", params: Dict[str, Any]) -> Optional[List[Any]]:
+        """Decode signed approvals from header or params.
+
+        Accepts ``X-Tenuo-Approvals`` header or ``x-tenuo-approvals`` param.
+        The value is a JSON array of base64 CBOR-encoded ``SignedApproval``
+        objects — the same wire format used by the FastAPI and Temporal
+        adapters.
+
+        Returns ``None`` when no approvals are present.
+        """
+        import base64 as _b64
+
+        raw = request.headers.get(APPROVALS_HEADER)
+        if not raw:
+            raw = params.get("x-tenuo-approvals")
+        if not raw:
+            return None
+
+        try:
+            from tenuo_core import SignedApproval  # type: ignore[attr-defined]
+
+            raw_list = json.loads(_b64.b64decode(raw))
+            return [SignedApproval.from_bytes(_b64.b64decode(item)) for item in raw_list]
+        except Exception:
+            logger.warning("Failed to decode %s", APPROVALS_HEADER, exc_info=True)
+            return None
+
+    # -------------------------------------------------------------------------
     # Audit Logging
     # -------------------------------------------------------------------------
 
@@ -2159,10 +2220,13 @@ class A2AServer:
             except Exception as e:
                 logger.warning(f"Failed to decode PoP signature: {e}")
 
+        # Decode signed approvals for multi-sig warrants
+        decoded_approvals = self._decode_approvals(request, params)
+
         if self.require_warrant and not warrant_token:
             raise MissingWarrantError("Warrant required")
 
-        # Validate warrant (with optional chain and PoP)
+        # Validate warrant (with optional chain, PoP, and approvals)
         warrant = None
         if warrant_token:
             warrant = await self.validate_warrant(
@@ -2172,6 +2236,7 @@ class A2AServer:
                 warrant_chain=warrant_chain,
                 _preloaded_parents=_preloaded_parents,
                 pop_signature=pop_signature,
+                approvals=decoded_approvals,
             )
 
         # Set current warrant context
@@ -2181,9 +2246,6 @@ class A2AServer:
             # Get skill handler
             skill_def = self._skills.get(skill_id)
             if not skill_def:
-                # Note: This is different from SkillNotGrantedError
-                # - SkillNotFoundError: skill doesn't exist on this server
-                # - SkillNotGrantedError: skill exists but not granted in warrant
                 raise SkillNotFoundError(skill_id, list(self._skills.keys()))
 
             # Execute skill
@@ -2241,6 +2303,9 @@ class A2AServer:
             except Exception as e:
                 logger.warning(f"Failed to decode PoP signature: {e}")
 
+        # Decode signed approvals for multi-sig warrants
+        decoded_approvals = self._decode_approvals(request, params)
+
         # Validate warrant (same as task/send)
         warrant = None
         if self.require_warrant and not warrant_token:
@@ -2254,6 +2319,7 @@ class A2AServer:
                 warrant_chain=warrant_chain,
                 _preloaded_parents=_preloaded_parents,
                 pop_signature=pop_signature,
+                approvals=decoded_approvals,
             )
 
         # Get warrant expiry for mid-stream checks

--- a/tenuo-python/tenuo/fastapi.py
+++ b/tenuo-python/tenuo/fastapi.py
@@ -484,7 +484,7 @@ class TenuoGuard:
                 from tenuo_core import SignedApproval  # type: ignore[attr-defined]
 
                 raw_list = json.loads(base64.b64decode(x_tenuo_approvals))
-                decoded_approvals = [SignedApproval.from_base64(item) for item in raw_list]
+                decoded_approvals = [SignedApproval.from_bytes(base64.b64decode(item)) for item in raw_list]
             except Exception:
                 logger.warning("Failed to decode X-Tenuo-Approvals header", exc_info=True)
 

--- a/tenuo-python/tests/adapters/test_a2a_approvals.py
+++ b/tenuo-python/tests/adapters/test_a2a_approvals.py
@@ -1,0 +1,311 @@
+"""
+Tests for A2A approval transport (issue #353).
+
+Covers:
+- _decode_approvals extracts from header and params
+- validate_warrant threads approvals into authorize_one / check_chain
+- ApprovalRequired error is surfaced as ApprovalRequiredError JSON-RPC
+- InsufficientApprovals error is surfaced as InsufficientApprovalsError
+- End-to-end: gated skill succeeds with valid approvals
+"""
+
+import base64
+import json
+import time as _time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tenuo.a2a import A2AServer
+from tenuo.a2a.errors import (
+    A2AErrorCode,
+    ApprovalRequiredError,
+    InsufficientApprovalsError,
+    InvalidApprovalError,
+)
+from tenuo.a2a.server import APPROVALS_HEADER
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_server(*, trusted_issuers=None, require_pop=True):
+    """Build a minimal A2AServer with mocked core deps."""
+    key = MagicMock()
+    key.to_bytes.return_value = b"\x01" * 32
+    return A2AServer(
+        name="Test",
+        url="https://test.example.com",
+        public_key="01" * 32,
+        trusted_issuers=trusted_issuers or ["aa" * 32],
+        require_pop=require_pop,
+        require_warrant=True,
+        require_audience=False,
+        check_replay=False,
+    )
+
+
+def _make_request(headers=None):
+    """Build a mock Starlette request."""
+    req = MagicMock()
+    req.headers = headers or {}
+    return req
+
+
+# =============================================================================
+# _decode_approvals
+# =============================================================================
+
+
+class TestDecodeApprovals:
+    """Unit tests for A2AServer._decode_approvals."""
+
+    def test_returns_none_when_no_header_or_param(self):
+        req = _make_request()
+        params: dict = {}
+        assert A2AServer._decode_approvals(req, params) is None
+
+    def test_returns_none_when_header_empty(self):
+        req = _make_request({APPROVALS_HEADER: ""})
+        assert A2AServer._decode_approvals(req, {}) is None
+
+    def test_reads_from_header(self):
+        """Approvals in the HTTP header are decoded."""
+        core = pytest.importorskip("tenuo_core")
+
+        approver = core.SigningKey.generate()
+
+        payload = core.ApprovalPayload(
+            request_hash=bytes(32),
+            nonce=bytes(16),
+            external_id="test@test.com",
+            approved_at=1000,
+            expires_at=9999999999,
+        )
+        approval = core.SignedApproval.create(payload, approver)
+        item_b64 = base64.b64encode(approval.to_bytes()).decode()
+
+        # Wire format: base64(json(["<base64(cbor)>", ...]))
+        wire_value = base64.b64encode(json.dumps([item_b64]).encode()).decode()
+
+        req = _make_request({APPROVALS_HEADER: wire_value})
+        result = A2AServer._decode_approvals(req, {})
+        assert result is not None
+        assert len(result) == 1
+
+    def test_reads_from_params_fallback(self):
+        """Approvals in JSON-RPC params are decoded when header is absent."""
+        core = pytest.importorskip("tenuo_core")
+
+        approver = core.SigningKey.generate()
+        payload = core.ApprovalPayload(
+            request_hash=bytes(32),
+            nonce=bytes(16),
+            external_id="test@test.com",
+            approved_at=1000,
+            expires_at=9999999999,
+        )
+        approval = core.SignedApproval.create(payload, approver)
+        item_b64 = base64.b64encode(approval.to_bytes()).decode()
+
+        wire_value = base64.b64encode(json.dumps([item_b64]).encode()).decode()
+
+        req = _make_request()  # no header
+        result = A2AServer._decode_approvals(req, {"x-tenuo-approvals": wire_value})
+        assert result is not None
+        assert len(result) == 1
+
+    def test_returns_none_on_malformed_payload(self):
+        """Malformed approval data returns None (logged, not raised)."""
+        wire_value = base64.b64encode(b"not valid json").decode()
+        req = _make_request({APPROVALS_HEADER: wire_value})
+        assert A2AServer._decode_approvals(req, {}) is None
+
+
+# =============================================================================
+# Error classes
+# =============================================================================
+
+
+class TestApprovalErrors:
+    """Verify the new A2A approval error types."""
+
+    def test_approval_required_error_code(self):
+        err = ApprovalRequiredError("deploy", request_hash="abc", min_approvals=2)
+        assert err.code == A2AErrorCode.APPROVAL_REQUIRED
+        rpc = err.to_jsonrpc_error()
+        assert rpc["data"]["min_approvals"] == 2
+        assert rpc["data"]["request_hash"] == "abc"
+        assert rpc["data"]["tenuo_code"] == 1707
+
+    def test_insufficient_approvals_error_code(self):
+        err = InsufficientApprovalsError("not enough", required=3, received=1)
+        assert err.code == A2AErrorCode.INSUFFICIENT_APPROVALS
+        rpc = err.to_jsonrpc_error()
+        assert rpc["data"]["required"] == 3
+        assert rpc["data"]["received"] == 1
+        assert rpc["data"]["tenuo_code"] == 1702
+
+    def test_invalid_approval_error_code(self):
+        err = InvalidApprovalError("bad format")
+        assert err.code == A2AErrorCode.INVALID_APPROVAL
+        rpc = err.to_jsonrpc_error()
+        assert rpc["data"]["tenuo_code"] == 1701
+
+
+# =============================================================================
+# validate_warrant approval threading (integration with real crypto)
+# =============================================================================
+
+
+class TestValidateWarrantApprovals:
+    """Integration tests: validate_warrant passes approvals to the Authorizer."""
+
+    @pytest.mark.asyncio
+    async def test_approval_required_raised_when_gate_fires_without_approvals(self):
+        """A gated warrant with no approvals raises ApprovalRequiredError."""
+        core = pytest.importorskip("tenuo_core")
+
+        root_key = core.SigningKey.generate()
+        approver = core.SigningKey.generate()
+
+        warrant = core.Warrant.issue(
+            keypair=root_key,
+            holder=root_key.public_key,
+            capabilities={"deploy": {}},
+            ttl_seconds=3600,
+            required_approvers=[approver.public_key],
+            min_approvals=1,
+            approval_gates={"deploy": None},
+        )
+
+        server = A2AServer(
+            name="Test",
+            url="https://test.example.com",
+            public_key=root_key.public_key.to_bytes().hex(),
+            trusted_issuers=[root_key.public_key.to_bytes().hex()],
+            require_pop=True,
+            require_warrant=True,
+            require_audience=False,
+            check_replay=False,
+        )
+
+        now = int(_time.time())
+        pop_sig = warrant.sign(root_key, "deploy", {}, now)
+
+        with pytest.raises(ApprovalRequiredError) as exc_info:
+            await server.validate_warrant(
+                warrant.to_base64(),
+                "deploy",
+                {},
+                pop_signature=pop_sig,
+                approvals=None,
+            )
+        assert "deploy" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_gated_skill_succeeds_with_valid_approval(self):
+        """A gated warrant with a valid approval succeeds."""
+        core = pytest.importorskip("tenuo_core")
+
+        root_key = core.SigningKey.generate()
+        approver = core.SigningKey.generate()
+
+        warrant = core.Warrant.issue(
+            keypair=root_key,
+            holder=root_key.public_key,
+            capabilities={"deploy": {}},
+            ttl_seconds=3600,
+            required_approvers=[approver.public_key],
+            min_approvals=1,
+            approval_gates={"deploy": None},
+        )
+
+        server = A2AServer(
+            name="Test",
+            url="https://test.example.com",
+            public_key=root_key.public_key.to_bytes().hex(),
+            trusted_issuers=[root_key.public_key.to_bytes().hex()],
+            require_pop=True,
+            require_warrant=True,
+            require_audience=False,
+            check_replay=False,
+        )
+
+        now = int(_time.time())
+        pop_sig = warrant.sign(root_key, "deploy", {}, now)
+        request_hash = core.py_compute_request_hash(
+            warrant.id, "deploy", {}, warrant.authorized_holder,
+        )
+        approval_payload = core.ApprovalPayload(
+            request_hash=request_hash,
+            nonce=bytes(range(16)),
+            external_id="admin@test.com",
+            approved_at=now,
+            expires_at=now + 300,
+        )
+        signed_approval = core.SignedApproval.create(approval_payload, approver)
+
+        result = await server.validate_warrant(
+            warrant.to_base64(),
+            "deploy",
+            {},
+            pop_signature=pop_sig,
+            approvals=[signed_approval],
+        )
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_wrong_approver_raises_invalid_approval(self):
+        """An approval from an untrusted approver raises InvalidApprovalError."""
+        core = pytest.importorskip("tenuo_core")
+
+        root_key = core.SigningKey.generate()
+        trusted_approver = core.SigningKey.generate()
+        wrong_approver = core.SigningKey.generate()
+
+        warrant = core.Warrant.issue(
+            keypair=root_key,
+            holder=root_key.public_key,
+            capabilities={"deploy": {}},
+            ttl_seconds=3600,
+            required_approvers=[trusted_approver.public_key],
+            min_approvals=1,
+            approval_gates={"deploy": None},
+        )
+
+        server = A2AServer(
+            name="Test",
+            url="https://test.example.com",
+            public_key=root_key.public_key.to_bytes().hex(),
+            trusted_issuers=[root_key.public_key.to_bytes().hex()],
+            require_pop=True,
+            require_warrant=True,
+            require_audience=False,
+            check_replay=False,
+        )
+
+        now = int(_time.time())
+        pop_sig = warrant.sign(root_key, "deploy", {}, now)
+        request_hash = core.py_compute_request_hash(
+            warrant.id, "deploy", {}, warrant.authorized_holder,
+        )
+        bad_payload = core.ApprovalPayload(
+            request_hash=request_hash,
+            nonce=bytes(range(16)),
+            external_id="wrong@test.com",
+            approved_at=now,
+            expires_at=now + 300,
+        )
+        bad_approval = core.SignedApproval.create(bad_payload, wrong_approver)
+
+        with pytest.raises(InvalidApprovalError):
+            await server.validate_warrant(
+                warrant.to_base64(),
+                "deploy",
+                {},
+                pop_signature=pop_sig,
+                approvals=[bad_approval],
+            )

--- a/tenuo-python/tests/adapters/test_a2a_approvals.py
+++ b/tenuo-python/tests/adapters/test_a2a_approvals.py
@@ -12,7 +12,7 @@ Covers:
 import base64
 import json
 import time as _time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tenuo-python/tests/adapters/test_a2a_error_codes.py
+++ b/tenuo-python/tests/adapters/test_a2a_error_codes.py
@@ -68,7 +68,7 @@ class TestA2AErrorCodeMappings:
 
     def test_unknown_wire_code_returns_internal_error(self):
         """Test that unknown wire codes map to INTERNAL_ERROR."""
-        unknown_codes = [1001, 1201, 1302, 1702, 1900, 2000]
+        unknown_codes = [1001, 1201, 1302, 1900, 2000]
 
         for code in unknown_codes:
             assert A2AErrorCode.from_wire_code(code) == A2AErrorCode.INTERNAL_ERROR


### PR DESCRIPTION
## Summary

- Add signed-approval decoding and forwarding in the A2A JSON-RPC handler so that gated warrants work end-to-end over the A2A protocol
- Add `ApprovalRequiredError` (-32019), `InsufficientApprovalsError` (-32020), `InvalidApprovalError` (-32021) with wire-format mappings (1707/1702/1701)
- Add `_decode_approvals()` helper that reads `X-Tenuo-Approvals` header or `x-tenuo-approvals` JSON-RPC param, threading decoded approvals into `validate_warrant` → `authorize_one` / `check_chain` for both `task/send` and `task/sendSubscribe`
- Fix latent bug in FastAPI adapter: `SignedApproval.from_base64()` doesn't exist, corrected to `from_bytes(b64decode(...))`
- 11 new tests covering decode, error codes, and full crypto integration

## Test plan

- [x] 11 new tests in `test_a2a_approvals.py` (decode, error serialization, crypto integration)
- [x] Full A2A suite: 298 passed, 6 skipped, 0 failed
- [ ] Manual: issue a gated warrant, call a skill via A2A without approvals → verify 403 with actionable data
- [ ] Manual: retry with valid signed approval → verify skill executes