### PR TITLE
Release 0.1.0-beta.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-beta.20] - 2026-04-13
+
 ### Breaking
 
 - **Removed `trusted_approvers` and `approval_threshold` from `TenuoPluginConfig`.**
@@ -14,6 +16,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   approvals are required. Passing these options to `TenuoPluginConfig()` will raise
   `TypeError`. Set `required_approvers` and `approval_threshold` on the warrant at
   mint time instead.
+
+### Security
+
+- **Temporal child workflow header isolation** — child workflows started via `workflow.execute_child_workflow()` no longer inherit parent Tenuo headers. Use `tenuo_execute_child_workflow()` for explicit attenuation. (#349)
+- **Temporal mint activity fail-closed** — `_tenuo_internal_mint_activity` raises `TenuoContextError` if the parent warrant lacks `issue_execution()` instead of silently falling back to `attenuate()`. (#349)
+- **CodeQL path injection fix** — resolved path injection alert in docs preview server. (#361)
+- **Authorizer approval response blind spots** — fixed cases where the authorizer could miss approval verification errors. (#362)
+
+### Added
+
+- **A2A approval transport** — threaded approval transport through the A2A adapter for human-in-the-loop flows. (#363)
+- **`tenuo_continue_as_new()` attenuation guard** — raises `NotImplementedError` if the `tenuo_attenuation` argument is provided (not yet implemented). (#349)
+
+### Fixed
+
+- **WASM connect token field key** — corrected the field key used for registration tokens in WASM builds. (#357)
+- **Connect token URL normalization** — fixed URL normalization and removed phantom Helm ServiceMonitor. (#360)
+- **Stale doc references** — removed `llms.txt`, `INTEGRATION_MAINTENANCE.md`, IETF stub, and fixed dead API references. (#358, #359)
+- **Docs merge artifact** — removed `HEAD` merge artifact from `temporal.md` security heading, corrected `current_warrant()` docs, fixed code fences and missing imports. (#349)
+
+### Changed
+
+- **`@guard` enforcement delegation** — refactored `@guard` to delegate enforcement to `enforce_tool_call`. (#356)
 
 ## [0.1.0-beta.19] - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ This runs the [orchestrator -> worker -> authorizer demo](https://tenuo.ai/demo.
 **Official Images** on [Docker Hub](https://hub.docker.com/u/tenuo):
 
 ```bash
-docker pull tenuo/authorizer:0.1.0-beta.19  # Sidecar for warrant verification
-docker pull tenuo/control:0.1.0-beta.19     # Control plane (demo/reference)
+docker pull tenuo/authorizer:0.1.0-beta.20  # Sidecar for warrant verification
+docker pull tenuo/control:0.1.0-beta.20     # Control plane (demo/reference)
 ```
 
 **Helm Chart**:
@@ -371,7 +371,7 @@ What you get in Rust:
 
 ```toml
 [dependencies]
-tenuo = "0.1.0-beta.19"
+tenuo = "0.1.0-beta.20"
 ```
 
 Use the Rust API when you need a language-native enforcement boundary

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "axum",
  "base64",

--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Agent Capability Flow Control - Rust core library"

--- a/tenuo-python/Cargo.lock
+++ b/tenuo-python/Cargo.lock
@@ -2236,7 +2236,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "axum",
  "base64",
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-python"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "pyo3",
  "tenuo",

--- a/tenuo-python/Cargo.toml
+++ b/tenuo-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-python"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Capability tokens for AI agents - Python SDK"

--- a/tenuo-python/pyproject.toml
+++ b/tenuo-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tenuo"
-version = "0.1.0b19"
+version = "0.1.0b20"
 description = "Capability tokens for AI agents - Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tenuo-python/tenuo/__init__.py
+++ b/tenuo-python/tenuo/__init__.py
@@ -370,4 +370,4 @@ __all__ = [
     "get_default_nonce_store",
 ]
 
-__version__ = "0.1.0b19"
+__version__ = "0.1.0b20"

--- a/tenuo-wasm/Cargo.lock
+++ b/tenuo-wasm/Cargo.lock
@@ -1449,7 +1449,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "base64",
  "cel-interpreter",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-wasm"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "base64",
  "chrono",

--- a/tenuo-wasm/Cargo.toml
+++ b/tenuo-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-wasm"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "WASM bindings for Tenuo"


### PR DESCRIPTION
## Summary

- Version bump to `0.1.0-beta.20` across all manifests (pyproject.toml, Cargo.toml, __init__.py, README, Cargo.lock files)
- Changelog entries for all 13 commits since beta.19

## What's in this release

### Breaking
- Removed `trusted_approvers` / `approval_threshold` from `TenuoPluginConfig` — warrant is sole source of truth (#372)

### Security
- Temporal child workflow header isolation (#349)
- Temporal mint activity fail-closed on missing `issue_execution()` (#349)
- CodeQL path injection fix (#361)
- Authorizer approval response blind spots (#362)

### Added
- A2A approval transport (#363)
- `tenuo_continue_as_new()` attenuation guard (#349)

### Fixed
- WASM connect token field key (#357)
- Connect token URL normalization (#360)
- Stale doc references (#358, #359)
- Docs merge artifact in temporal.md (#349)

### Changed
- `@guard` enforcement delegation to `enforce_tool_call` (#356)

## After merge

Create a GitHub Release tagged `v0.1.0-beta.20` from main to trigger the publish workflow.