### PR TITLE
Clean docs to remove ApprovalPolicy from docs — document real warrant gates API

### DIFF
--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -2,19 +2,17 @@
 
 > **Cryptographically verified human-in-the-loop authorization for AI agent tool calls.**
 
-Warrants define *what* an agent can do. Approval policies define *when* a human must confirm before execution. Every approval is cryptographically signed - there is no unsigned path.
+Warrants define *what* an agent can do — including *which* tool calls require human approval, *who* can approve, and *how many* must agree. Every approval is cryptographically signed; there is no unsigned path.
 
 ---
 
 ## Architecture
 
 ```
-                   Warrant Authorization           Approval Policy
-                   ──────────────────             ────────────────
-Tool Call ──► Rust Core verifies warrant ──► Python checks policy rules
+Tool Call ──► Rust Core verifies warrant ──► Approval gate fires?
               (PoP, expiration, constraints)        |
-                                              no rule matches → proceed
-                                              rule matches → invoke handler
+                                              no gate → proceed
+                                              gate fires → invoke handler
                                                     |
                                               handler(s) sign → collect approvals
                                                     |
@@ -29,11 +27,12 @@ Tool Call ──► Rust Core verifies warrant ──► Python checks policy ru
 
 | Concern | Mechanism | Where |
 |---------|-----------|-------|
-| *What* an agent can do | Warrant (cryptographic) | Rust core |
-| *When* a human must confirm | ApprovalPolicy (runtime) | Python |
+| *What* an agent can do | Warrant capabilities + constraints | Rust core |
+| *When* a human must confirm | Approval gates (in warrant) | Rust core |
+| *Who* can confirm | `required_approvers` (in warrant) | Rust core |
+| *How many* must confirm | `approval_threshold` (in warrant) | Rust core |
 | *Proof* of confirmation | SignedApproval (Ed25519) | Rust core |
-| *Who* can confirm | required_approvers (in warrant) | Rust core |
-| *How many* must confirm | approval_threshold (in warrant) | Rust core |
+| *How* confirmation happens | `approval_handler` callback | Python adapter |
 
 ---
 
@@ -85,12 +84,12 @@ The `ApprovalPayload` contains:
 
 When `enforce_tool_call()` receives `SignedApproval`(s) from a handler, the Rust core verifies each one:
 
-1. **Signature** - Ed25519 signature check
-2. **Hash match** - `payload.request_hash == expected_hash` (prevents reuse across calls)
-3. **Expiry** - `payload.expires_at > now` (with 30-second clock tolerance for distributed systems)
-4. **Key trust** - `signed.approver_key in warrant.required_approvers()` (prevents rogue approvers)
-5. **Deduplication** - one vote per approver key (prevents double-counting)
-6. **Threshold** - valid approval count >= `warrant.approval_threshold()` (m-of-n satisfaction)
+1. **Signature** — Ed25519 signature check
+2. **Hash match** — `payload.request_hash == expected_hash` (prevents reuse across calls)
+3. **Expiry** — `payload.expires_at > now` (with 30-second clock tolerance for distributed systems)
+4. **Key trust** — `signed.approver_key in warrant.required_approvers()` (prevents rogue approvers)
+5. **Deduplication** — one vote per approver key (prevents double-counting)
+6. **Threshold** — valid approval count >= `warrant.approval_threshold()` (m-of-n satisfaction)
 
 For **1-of-1** failures, the Rust core returns the specific rejection reason (e.g., "request hash mismatch", "approval expired"). For **m-of-n** failures, it returns a summary of all rejection reasons (e.g., "required 2, received 1 [rejected: 1 expired, 1 not trusted]").
 
@@ -99,47 +98,63 @@ For **1-of-1** failures, the Rust core returns the specific rejection reason (e.
 ## Quick Start
 
 ```python
-from tenuo import (
-    SigningKey, Warrant, ApprovalPolicy,
-    require_approval, auto_approve, sign_approval, cli_prompt,
-    guard, warrant_scope, key_scope,
-)
+from tenuo import SigningKey, Warrant, sign_approval, cli_prompt
 
 # 1. Keys
+control_key = SigningKey.generate()    # control plane
 agent_key = SigningKey.generate()      # the AI agent
 approver_key = SigningKey.generate()   # the human approver
 
-# 2. Warrant (what the agent can do — including who can approve)
+# 2. Warrant — defines capabilities, approval gates, and who can approve
 warrant = (Warrant.mint_builder()
     .capability("transfer")
     .capability("search")
+    .approval_gates({"transfer": None})  # all transfer calls need approval
     .required_approvers([approver_key.public_key])
     .approval_threshold(1)
     .holder(agent_key.public_key)
     .ttl(3600)
-    .mint(agent_key)
+    .mint(control_key)
 )
 
-# 3. Approval policy (when a human must confirm)
-policy = ApprovalPolicy(
-    require_approval("transfer", when=lambda args: args["amount"] > 10_000),
-)
+# 3. Enforce with an approval handler
+from tenuo import enforce_tool_call, BoundWarrant
 
-# 4. Protect a function with @guard
-@guard(
-    tool="transfer",
-    approval_policy=policy,
+result = enforce_tool_call(
+    tool_name="transfer",
+    tool_args={"amount": 50_000, "to": "alice"},
+    bound_warrant=BoundWarrant(warrant, agent_key),
+    trusted_roots=[control_key.public_key],
     approval_handler=cli_prompt(approver_key=approver_key),
 )
-def transfer(amount: int, to: str):
-    print(f"Transferring {amount} to {to}")
-
-# 5. Call it within a warrant context
-with warrant_scope(warrant), key_scope(agent_key):
-    transfer(amount=50_000, to="alice")
-    # The CLI prompts the human. If they type 'y', a SignedApproval is
-    # created, verified, and the call proceeds. If 'n', ApprovalDenied is raised.
+# The CLI prompts the human. If they type 'y', a SignedApproval is
+# created, verified, and the call proceeds. If 'n', ApprovalDenied is raised.
 ```
+
+---
+
+## Approval Gates
+
+Approval gates are defined in the warrant and evaluated by the Rust core. They determine *which* tool calls require human confirmation:
+
+```python
+warrant = (Warrant.mint_builder()
+    .capability("search")
+    .capability("transfer")
+    .capability("delete_user")
+    .approval_gates({
+        "transfer": None,           # all transfer calls need approval
+        "delete_user": None,        # all delete_user calls need approval
+        # "search" has no gate — proceeds without approval
+    })
+    .required_approvers([approver_key.public_key])
+    .holder(agent_key.public_key)
+    .ttl(3600)
+    .mint(control_key)
+)
+```
+
+When `enforce_tool_call()` or a framework adapter processes a tool call, the Rust core runs `evaluate_approval_gates(warrant, tool_name, tool_args)`. If a gate fires, the enforcement layer invokes the `approval_handler` to collect signatures.
 
 ---
 
@@ -152,20 +167,17 @@ Approvers and threshold are set **in the warrant** — the single source of trut
 warrant = (Warrant.mint_builder()
     .capability("deploy_prod")
     .capability("transfer_funds")
+    .approval_gates({
+        "deploy_prod": None,
+        "transfer_funds": None,
+    })
     .required_approvers([alice.public_key, bob.public_key, carol.public_key])
     .approval_threshold(2)  # any 2-of-3 must approve
     .holder(agent_key.public_key)
     .ttl(3600)
     .mint(control_key)
 )
-
-policy = ApprovalPolicy(
-    require_approval("deploy_prod"),
-    require_approval("transfer_funds", when=lambda a: a["amount"] > 100_000),
-)
 ```
-
-The `approval_threshold` on the warrant (default: 1) specifies the minimum number of valid approvals required. The Rust core verifies each approval independently and checks that the count of valid, unique approvals meets the threshold.
 
 | `approval_threshold` | `required_approvers` | Meaning |
 |----------------------|----------------------|---------|
@@ -186,47 +198,32 @@ Approval TTL (how long a signed approval remains valid) is resolved in priority 
 
 ```
 1. Handler-level ttl_seconds argument         (highest priority)
-2. Policy-level default_ttl                   (org-wide default)
-3. 300 seconds (5 minutes)                    (fallback)
+2. 300 seconds (5 minutes)                    (fallback)
 ```
 
 Examples:
 
 ```python
-# Policy sets a 1-hour default for async workflows
-policy = ApprovalPolicy(
-    require_approval("deploy"),
-    default_ttl=3600,
-)
-
-# Handler overrides with a shorter window
+# Handler with a short window
 handler = cli_prompt(approver_key=ops_key, ttl_seconds=60)
 
-# Or let the policy default flow through
-handler = cli_prompt(approver_key=ops_key)  # uses policy's 3600s
+# Handler with the default 5-minute window
+handler = cli_prompt(approver_key=ops_key)
 ```
 
-For long-running approval flows (e.g., Slack-based, email-based), set `default_ttl` on the policy:
-
-```python
-# Approvers + threshold are in the warrant; the policy only controls TTL
-policy = ApprovalPolicy(
-    require_approval("deploy_prod"),
-    default_ttl=86400,  # 24 hours for async multi-sig collection
-)
-```
+For long-running approval flows (e.g., Slack-based, email-based), pass a longer `ttl_seconds` to `sign_approval()` in your custom handler.
 
 ---
 
 ## Framework Integration
 
-Approval policies plug into all framework `GuardBuilder`s via `.approval_policy()` and `.on_approval()`:
+All framework adapters accept `approval_handler` directly — the callback invoked when an approval gate fires.
 
 ### CrewAI
 
 ```python
 from tenuo.crewai import GuardBuilder
-from tenuo import SigningKey, ApprovalPolicy, require_approval, cli_prompt
+from tenuo import SigningKey, cli_prompt
 
 approver_key = SigningKey.generate()
 
@@ -234,9 +231,6 @@ guard = (GuardBuilder()
     .allow("search", query=Wildcard())
     .allow("transfer_funds", amount=Range(0, 100_000))
     .with_warrant(warrant, agent_key)
-    .approval_policy(ApprovalPolicy(
-        require_approval("transfer_funds", when=lambda a: a["amount"] > 10_000),
-    ))
     .on_approval(cli_prompt(approver_key=approver_key))
     .build())
 
@@ -252,7 +246,6 @@ from tenuo.autogen import GuardBuilder
 guard = (GuardBuilder()
     .allow("transfer_funds")
     .with_warrant(warrant, agent_key)
-    .approval_policy(policy)
     .on_approval(cli_prompt(approver_key=approver_key))
     .build())
 
@@ -267,7 +260,6 @@ from tenuo.openai import GuardBuilder
 client = (GuardBuilder(openai.OpenAI())
     .allow("transfer_funds")
     .with_warrant(warrant, agent_key)
-    .approval_policy(policy)
     .on_approval(cli_prompt(approver_key=approver_key))
     .build())
 ```
@@ -279,7 +271,6 @@ from tenuo.google_adk import GuardBuilder
 
 guard = (GuardBuilder()
     .with_warrant(warrant, agent_key)
-    .approval_policy(policy)
     .on_approval(cli_prompt(approver_key=approver_key))
     .build())
 
@@ -291,13 +282,10 @@ agent = Agent(
 
 ### LangGraph
 
-Both `TenuoMiddleware` (recommended) and `TenuoToolNode` accept approval parameters directly:
-
 ```python
 from tenuo.langgraph import TenuoMiddleware
 
 middleware = TenuoMiddleware(
-    approval_policy=policy,
     approval_handler=cli_prompt(approver_key=approver_key),
 )
 
@@ -310,68 +298,28 @@ agent = create_agent(
 
 ### LangChain
 
-Pass approval parameters through `guard()`:
-
 ```python
 from tenuo.langchain import guard
 
 tools = guard(
     [search, transfer_funds],
     bound_warrant,
-    approval_policy=policy,
     approval_handler=cli_prompt(approver_key=approver_key),
 )
 ```
 
----
-
-## Approval Rules
-
-Rules define which tool calls require approval:
+### Temporal
 
 ```python
-from tenuo import require_approval
+from tenuo.temporal import TenuoPluginConfig, TenuoPlugin
 
-# Always requires approval
-require_approval("delete_user")
-
-# Conditional - only when amount > 10K
-require_approval("transfer", when=lambda args: args["amount"] > 10_000)
-
-# With description (shown to the approver)
-require_approval("send_email",
-    when=lambda args: not args["to"].endswith("@company.com"),
-    description="External emails require approval")
-```
-
-If the `when` predicate raises an exception, the rule **triggers** (fail-closed).
-
----
-
-## Approval Policy
-
-The policy collects rules and configures TTL. Trusted approvers and threshold are
-always embedded in the warrant — the single source of truth:
-
-```python
-from tenuo import ApprovalPolicy
-
-policy = ApprovalPolicy(
-    require_approval("transfer", when=lambda a: a["amount"] > 10_000),
-    require_approval("delete_user"),
-    require_approval("send_email"),
-    default_ttl=3600,  # optional: 1-hour approval window
+config = TenuoPluginConfig(
+    key_resolver=resolver,
+    trusted_roots=[control_key.public_key],
+    approval_handler=cli_prompt(approver_key=approver_key),
 )
+plugin = TenuoPlugin(config)
 ```
-
-| Parameter | Default | Effect |
-|-----------|---------|--------|
-| `*rules` | (required) | One or more `ApprovalRule` instances |
-| `default_ttl` | `None` | Default TTL in seconds for signed approvals. `None` means handlers use their own default (typically 300s) |
-
-> **Note:** `required_approvers` and `approval_threshold` are set on the
-> warrant at mint time, not on the policy. This ensures the cryptographic
-> authority chain cannot be bypassed by runtime configuration.
 
 ---
 
@@ -379,10 +327,9 @@ policy = ApprovalPolicy(
 
 | Handler | Signs? | Use Case |
 |---------|--------|----------|
-| `cli_prompt(approver_key=key)` | Yes | Local development - prompts in terminal |
-| `auto_approve(approver_key=key)` | Yes | Testing - signs everything automatically |
+| `cli_prompt(approver_key=key)` | Yes | Local development — prompts in terminal |
+| `auto_approve(approver_key=key)` | Yes | Testing — signs everything automatically |
 | `auto_deny(reason=...)` | No (raises) | Dry-run / audit mode |
-| `tenuo.approval.webhook(url=...)` | Placeholder | Tenuo Cloud integration (not yet in public API) |
 
 All signing handlers require the approver's `SigningKey`. This is the key that produces the `SignedApproval`. It should be held by the human (or approval service), not the agent.
 
@@ -460,17 +407,17 @@ from tenuo.approval import (
 
 | Exception | When | Contains |
 |-----------|------|----------|
-| `ApprovalRequired` | Rule triggered but no handler configured | `request` |
+| `ApprovalRequired` | Gate triggered but no handler configured | `request` |
 | `ApprovalDenied` | Handler explicitly denied | `request`, `reason` |
 | `ApprovalTimeout` | Handler timed out (subclass of `ApprovalDenied`) | `request`, `timeout_seconds` |
 | `ApprovalVerificationError` | Crypto verification failed | `request`, `reason` |
 
 `ApprovalVerificationError` reasons include:
-- `"invalid signature: ..."` - Ed25519 signature check failed
-- `"request hash mismatch (approval was signed for a different request)"` - replay attempt
-- `"approval expired (beyond clock tolerance)"` - `expires_at` in the past (with 30s tolerance)
-- `"approver not in trusted set"` - untrusted key
-- `"duplicate approval from same approver"` - same key signed twice
+- `"invalid signature: ..."` — Ed25519 signature check failed
+- `"request hash mismatch (approval was signed for a different request)"` — replay attempt
+- `"approval expired (beyond clock tolerance)"` — `expires_at` in the past (with 30s tolerance)
+- `"approver not in trusted set"` — untrusted key
+- `"duplicate approval from same approver"` — same key signed twice
 
 For m-of-n failures, `InsufficientApprovals` is raised with a diagnostic summary:
 ```
@@ -514,6 +461,6 @@ Warrants are the security boundary. Approvals are defense in depth. Even if the 
 
 ## See Also
 
-- [Enforcement Architecture](enforcement.md) - Where approvals fit in the enforcement pipeline
-- [AI Agents Security](ai-agents.md) - The 4-layer defense strategy
-- [Concepts](concepts.md) - Warrants, PoP, attenuation
+- [Enforcement Architecture](enforcement.md) — Where approvals fit in the enforcement pipeline
+- [AI Agents Security](ai-agents.md) — The 4-layer defense strategy
+- [Concepts](concepts.md) — Warrants, PoP, attenuation

--- a/docs/langgraph.md
+++ b/docs/langgraph.md
@@ -707,25 +707,23 @@ graph.invoke({"warrant": str(warrant), "messages": [...]})
 
 ## Human Approval
 
-Add human-in-the-loop approval for sensitive tool calls. Both `TenuoMiddleware` and `TenuoToolNode` accept `approval_policy` and `approval_handler` parameters. See [Human Approvals](approvals.md) for the full guide.
+Add human-in-the-loop approval for sensitive tool calls. Approval gates are defined in the warrant, and `approval_handler` is passed to the adapter. See [Human Approvals](approvals.md) for the full guide.
 
 ```python
-from tenuo.approval import ApprovalPolicy, require_approval, cli_prompt
+from tenuo import cli_prompt
 
-policy = ApprovalPolicy(
-    require_approval("delete_database"),
-)
+# Approval gates are in the warrant:
+#   .approval_gates({"delete_database": None})
+#   .required_approvers([approver_key.public_key])
 
 # TenuoToolNode pattern (recommended)
 tool_node = TenuoToolNode(
     tools,
-    approval_policy=policy,
     approval_handler=cli_prompt(approver_key=approver_key),
 )
 
 # Or TenuoMiddleware pattern (experimental)
 middleware = TenuoMiddleware(
-    approval_policy=policy,
     approval_handler=cli_prompt(approver_key=approver_key),
 )
 ```
@@ -735,7 +733,7 @@ middleware = TenuoMiddleware(
 ## See Also
 
 - [LangChain Integration](./langchain)  -- Tool protection for LangChain
-- [Human Approvals](./approvals)  -- Approval policy guide
+- [Human Approvals](./approvals)  -- Approval gates and handlers guide
 - [FastAPI Integration](./fastapi)  -- Zero-boilerplate API protection
 - [Security](./security)  -- Threat model, best practices
 - [API Reference](./api-reference)  -- Full Python API documentation

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -22,7 +22,7 @@ The integration runs entirely in your workers (Rust `tenuo_core` in-process). Va
 - **Signal & update guards**: Restrict which signals and updates a workflow accepts
 - **Nexus header propagation**: Warrant context flows through Nexus operations
 - **PoP replay protection**: Default in-process dedup plus PoP time-window verification (clock skew); optional **`PopDedupStore`** for fleet-wide dedup ([Security considerations](#security-considerations))
-- **Continue-as-new support**: Warrant headers survive workflow continuation
+- **Continue-as-new support**: Warrant headers survive workflow continuation (attenuation during continue-as-new is not yet supported)
 - **Fail-closed**: Missing or invalid warrants block execution by default
 - **Secure key management**: Private keys NEVER transmitted in headers - resolved from Vault/KMS/Secret Manager
 - **Enterprise key resolvers**: `VaultKeyResolver`, `AWSSecretsManagerKeyResolver`, `GCPSecretManagerKeyResolver`, `CompositeKeyResolver`
@@ -107,6 +107,7 @@ worker = Worker(client, task_queue="q", workflows=[...], activities=[...],
 ```
 
 Manual setup is used in `demo.py`, `delegation.py`, `multi_warrant.py`, and all PoC examples. `ensure_tenuo_workflow_runner` from `tenuo.temporal_plugin` provides the sandbox runner without the full plugin.
+
 ---
 
 ## Runnable examples
@@ -340,7 +341,7 @@ sequenceDiagram
     T->>WW: workflow task
     WW->>KR: resolve(key_id)
     KR-->>WW: signing_key  ← never transmitted
-    Note over WW: PoP = sign(warrant, tool, args, workflow.now())
+    Note over WW: PoP = sign(warrant_id, tool, sorted_args, window_ts)
     WW->>AW: activity headers (warrant + PoP)
     Note over AW: verify warrant chain → trusted_roots
     Note over AW: verify PoP signature + constraints
@@ -641,10 +642,6 @@ config = TenuoPluginConfig(
 
 > **Warning:** `dry_run=True` disables enforcement for authorization denials. Use only in non-production environments.
 
-
----
-
-
 ---
 
 ## Activity registry (`activity_fns`) and PoP argument names
@@ -897,7 +894,7 @@ config = TenuoPluginConfig(
 )
 ```
 
-When `retry_pop_max_windows` is not set and a retry arrives, the interceptor logs a `DEBUG` advisory:
+The default `retry_pop_max_windows` is `5` (same as the standard PoP window). When a retry arrives, the interceptor logs a `DEBUG` advisory:
 ```
 Activity '...' is a retry (attempt=2). If this fails with PopVerificationError,
 set TenuoPluginConfig.retry_pop_max_windows to accommodate Temporal's retry time offset.
@@ -1061,7 +1058,7 @@ class CustomerSupportWorkflow(AuthorizedWorkflow):
     async def run(self, customer_id: str) -> str:
         # Inspect the active warrant at workflow start
         warrant = current_warrant()    # Raises TenuoContextError if no warrant
-        key_id = current_key_id()      # Returns the key_id string, or "" if not set
+        key_id = current_key_id()      # Raises TenuoContextError if no key ID
 
         workflow.logger.info(f"Agent tools: {warrant.tools}")
         workflow.logger.info(f"Signing key: {key_id}")
@@ -1072,7 +1069,7 @@ class CustomerSupportWorkflow(AuthorizedWorkflow):
         return await self._handle_standard(customer_id)
 ```
 
-`current_warrant()` raises `TenuoContextError` when called outside a Tenuo-authorized workflow (or when no warrant header is present). `current_key_id()` returns `""` in the same case. Both are read-only — they do not modify authorization state.
+`current_warrant()` and `current_key_id()` both raise `TenuoContextError` when called outside a Tenuo-authorized workflow (or when no warrant header is present). Both are read-only — they do not modify authorization state.
 
 ### tool_mappings - Config-Driven Activity Name Mapping
 
@@ -1106,7 +1103,7 @@ class MyWorkflow(AuthorizedWorkflow):
     async def run(self, path: str) -> str:
         # Issue a 60-second, read-only grant for exactly one tool,
         # narrower than the workflow's own warrant.
-        file_warrant = workflow_grant(
+        file_warrant = await workflow_grant(
             "read_file",
             constraints={"path": path},  # Must be keys the parent already has
             ttl_seconds=60,
@@ -1206,7 +1203,7 @@ See **[Security considerations](#security-considerations)** for the full threat 
 
 ## Exceptions
 
-All exceptions include `error_code` for wire format compatibility:
+The main authorization exceptions include `error_code` for wire format compatibility:
 
 ```python
 from tenuo.temporal import (
@@ -1256,7 +1253,7 @@ For the full module-level troubleshooting entries, see the `tenuo.temporal` modu
 | `WarrantExpired` | Warrant TTL elapsed before or during workflow execution | Mint a new warrant with a longer `ttl()`, or refresh the warrant at workflow start |
 | Activity denied despite a warrant that looks correct | PoP argument keys or tool name mismatch between signer and verifier | Check worker logs for the outbound interceptor warning about positional vs. named keys; also verify `tool_mappings` if activity type differs from warrant tool name |
 | Child workflow runs with no authorization | Started with `workflow.execute_child_workflow()` | Use `tenuo_execute_child_workflow()` so warrant headers propagate ([Child Workflow Delegation](#child-workflow-delegation)) |
-| `TenuoArgNormalizationError: Activity argument 'x' has type 'set' which cannot be normalized` | Activity argument is a type Tenuo cannot normalize for PoP signing (`set`, `datetime`, `Enum`, custom class, etc.) | Convert to a `@dataclass` or `dict`, or lift the field to a top-level primitive argument. See [Structured state in activity arguments](#structured-state-in-activity-arguments). |
+| `TenuoArgNormalizationError: Activity argument 'x' has type 'set' which cannot be normalized` | Activity argument is a type Tenuo cannot normalize for PoP signing (`set`, `datetime`, `Enum`, custom class, etc.) | Convert to a `@dataclass` or `dict`, or lift the field to a top-level primitive argument. |
 | `TenuoPreValidationError: unknown field not allowed (zero-trust mode): a, b, c` | Warrant capability declares fewer fields than the activity accepts | Declare all activity arguments in the warrant capability (use `Wildcard()` for fields that don't need structural constraints). The error lists ALL unknown/missing fields at once. |
 
 ---


### PR DESCRIPTION
## Summary

- **Rewrote `docs/approvals.md`** to remove all references to the non-existent `ApprovalPolicy` class (deprecated and removed in beta.18). Now documents the real API: warrant `.approval_gates()`, `.required_approvers()`, `.approval_threshold()`, and adapter `approval_handler` callbacks.
- **Fixed `docs/langgraph.md`** approval section to use `approval_handler` instead of `approval_policy`.

## What changed

| Before (fictional) | After (real API) |
|---|---|
| `ApprovalPolicy(require_approval("tool"))` | `warrant.approval_gates({"tool": None})` |
| `approval_policy=policy` on adapters | `approval_handler=cli_prompt(...)` on adapters |
| `trusted_approvers=[...]` on policy | `.required_approvers([...])` on warrant builder |
| `threshold=2` on policy | `.approval_threshold(2)` on warrant builder |

## Test plan

- [x] 2662 tests pass, no regressions (docs-only change)
- [x] No `ApprovalPolicy` references remain outside CHANGELOG history