### PR TITLE
fix: address user friction log blockers and docs gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,17 @@ warrant = await client.request_warrant(signing_key=worker_key, capabilities={"se
 result = await client.send_task(skill="search", warrant=warrant, signing_key=worker_key)
 ```
 
-**Temporal** -- Durable workflows with warrant-based activity authorization
+**Temporal** — Durable workflows with warrant-based activity authorization
 ```python
 from tenuo.temporal import (
-    AuthorizedWorkflow,
-    TenuoClientInterceptor,
-    execute_workflow_authorized,
+    TenuoTemporalPlugin, TenuoPluginConfig, EnvKeyResolver,
+    AuthorizedWorkflow, execute_workflow_authorized,
 )
+
+plugin = TenuoTemporalPlugin(
+    TenuoPluginConfig(key_resolver=EnvKeyResolver(), trusted_roots=[issuer_public_key])
+)
+client = await Client.connect("localhost:7233", plugins=[plugin])
 
 @workflow.defn
 class MyWorkflow(AuthorizedWorkflow):
@@ -236,10 +240,9 @@ class MyWorkflow(AuthorizedWorkflow):
             read_file, args=[path], start_to_close_timeout=timedelta(seconds=30),
         )
 
-client_interceptor = TenuoClientInterceptor()
 result = await execute_workflow_authorized(
     client=client,
-    client_interceptor=client_interceptor,
+    client_interceptor=plugin.client_interceptor,
     workflow_run_fn=MyWorkflow.run,
     workflow_id="wf-123",
     warrant=warrant,
@@ -341,18 +344,20 @@ See [Helm chart README](./charts/tenuo-authorizer) and [Kubernetes guide](https:
 
 ---
 
-## Roadmap
+## Deploying to Production
 
-| Feature | Status |
-|---------|--------|
-| A2A integration | Implemented (`tenuo[a2a]`) |
-| AutoGen integration | Implemented (`tenuo[autogen]`) |
-| Google ADK integration | Implemented (`tenuo[google_adk]`) |
-| MCP integration | Implemented (`tenuo[mcp]` SDK; `tenuo[fastmcp]` for FastMCP) |
-| Warrant guards (human approval) | Implemented (experimental) |
-| Revocation (SRL) | Ongoing development |
-| TypeScript/Node SDK | Planned for v0.2 |
-| Context-aware constraints | Spec under development |
+Self-hosted Tenuo is free forever. The core library and sidecar run entirely in your infrastructure — no external calls at verification time.
+
+**Self-hosted checklist:**
+
+- Store signing keys in a secrets manager (Vault, AWS Secrets Manager, GCP Secret Manager) — not environment variables
+- Configure `trusted_roots` with your control plane's public keys
+- Ensure `dry_run` is disabled and warrants are required in all enforcement points
+- Enable audit callbacks and metrics for observability
+
+See [Security Model](https://tenuo.ai/security) for the full threat model and production hardening guidance.
+
+**[Tenuo Cloud](https://tenuo.ai/early-access.html)** adds managed warrant issuance, key rotation, revocation (SRL), observability dashboards, and multi-tenant isolation for teams that prefer a hosted control plane.
 
 ---
 
@@ -387,7 +392,7 @@ without Python runtime dependencies.
 
 Tenuo builds on capability token ideas described in [CaMeL](https://arxiv.org/abs/2503.18813) (Debenedetti et al., 2025). Inspired by [Macaroons](https://research.google/pubs/pub41892/), [Biscuit](https://www.biscuitsec.org/), and [UCAN](https://ucan.xyz/).
 
-The token format and delegation protocol are being standardized as [draft-niyikiza-oauth-attenuating-agent-tokens](https://datatracker.ietf.org/doc/draft-niyikiza-oauth-attenuating-agent-tokens/) in the IETF OAuth Working Group.
+The token format and delegation protocol are being standardized as [draft-niyikiza-oauth-attenuating-agent-tokens](https://datatracker.ietf.org/doc/draft-niyikiza-oauth-attenuating-agent-tokens/) in the IETF OAuth Working Group. The core attenuation rules are formally verified with [Alloy](docs/formal_verification/aat_constraints.als) (capability and argument-key monotonicity) and [Z3](docs/formal_verification/z3_bounds.py) (constraint-type subsumption bounds).
 
 See [Related Work](https://tenuo.ai/related-work) for detailed comparison.
 
@@ -422,12 +427,6 @@ Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 We're planning a TypeScript/Node SDK for v0.2. If you're interested in leading or contributing to this effort, open an issue or email us at [dev@tenuo.ai](mailto:dev@tenuo.ai).
 
 **Security issues**: Email security@tenuo.ai with PGP ([key](./SECURITY_PUBKEY.asc), not public issues).
-
----
-
-## Deploying to Production
-
-Self-hosted is free forever. For a managed control plane with observability and revocation workflows, [request early access](https://tenuo.ai/early-access.html) to Tenuo Cloud.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,8 +5,6 @@ description: Get started with Tenuo in 5 minutes
 
 # Quick Start
 
-Get Tenuo running in 5 minutes. For a visual walkthrough, see the [Demo](./demo.html).
-
 ## What is Tenuo?
 
 Tenuo is a warrant-based authorization library for AI agent workflows. A **warrant** is a signed token specifying which tools an agent can call, under what constraints, and for how long.
@@ -41,15 +39,21 @@ uv pip install tenuo
 
 **With framework support:**
 ```bash
-uv pip install "tenuo[autogen]"     # AutoGen (AgentChat) integration (Python >= 3.10)
-uv pip install "tenuo[langchain]"   # LangChain integration
-uv pip install "tenuo[langgraph]"   # LangGraph integration (includes LangChain)
-uv pip install "tenuo[fastapi]"     # FastAPI integration
+uv pip install "tenuo[openai]"      # OpenAI Agents SDK
+uv pip install "tenuo[google_adk]"  # Google ADK
+uv pip install "tenuo[langchain]"   # LangChain (langchain-core ≥0.2)
+uv pip install "tenuo[langgraph]"   # LangGraph (includes LangChain)
+uv pip install "tenuo[crewai]"      # CrewAI
+uv pip install "tenuo[temporal]"    # Temporal workflows
+uv pip install "tenuo[autogen]"     # AutoGen AgentChat (Python ≥3.10)
+uv pip install "tenuo[a2a]"         # A2A inter-agent delegation
+uv pip install "tenuo[mcp]"         # MCP client & server verification (Python ≥3.10)
+uv pip install "tenuo[fastapi]"     # FastAPI
 ```
 
 > **Note:** Quotes are required in zsh (default macOS shell) since `[]` are glob characters.
 
-> **Rust SDK**: If you're using Rust directly, add `tenuo = "0.1.0-beta.15"` to your `Cargo.toml`. See the [crates.io documentation](https://crates.io/crates/tenuo) for Rust-specific examples. This guide focuses on Python.
+> **Rust SDK**: If you're using Rust directly, add `tenuo = "0.1.0-beta.21"` to your `Cargo.toml`. See the [crates.io documentation](https://crates.io/crates/tenuo) for Rust-specific examples. This guide focuses on Python.
 
 ---
 
@@ -270,6 +274,8 @@ Now violations are blocked. Roll out to a subset of traffic first if needed.
 - **OpenAI SDK** (`openai.OpenAI`, `openai.AsyncOpenAI`) --> Use [`tenuo.openai`](./openai)
 - **CrewAI** (`crewai.Crew`, `crewai.Agent`) --> Use [`tenuo.crewai`](./crewai)
 - **Google ADK** (`google.adk.agents.Agent`) --> Use [`tenuo.google_adk`](./google-adk)
+- **Temporal** (durable workflows) --> Use [`tenuo.temporal`](./temporal)
+- **MCP** (Model Context Protocol) --> Use [`tenuo.mcp`](./mcp)
 - **LangChain / LangGraph / AutoGen** --> See [Framework Integrations](#framework-integrations) below
 - **Custom/other** --> Use [API Reference](./api-reference) directly
 
@@ -287,15 +293,15 @@ Now violations are blocked. Roll out to a subset of traffic first if needed.
 
 ### Comparison
 
-| Feature | OpenAI | CrewAI | ADK | A2A |
-|---------|--------|--------|-----|-----|
-| **Runtime** | OpenAI SDK | CrewAI | Google ADK | Any (HTTP) |
-| **Deployment** | Single/multi process | Single/multi process | Single/multi process | Distributed |
-| **Tier 1 (Guardrails)** | Yes | Yes | Yes | N/A (Tier 2 required) |
-| **Tier 2 (Warrant + PoP)** | Yes | Yes | Yes | Yes |
-| **Delegation** | No | Yes `WarrantDelegator` | No | Yes (discovery) |
-| **Streaming** | Yes | No | Yes | No |
-| **Learning Curve** | Easy | Easy | Medium | Steep |
+| Feature | OpenAI | CrewAI | ADK | Temporal | MCP | A2A |
+|---------|--------|--------|-----|---------|-----|-----|
+| **Runtime** | OpenAI SDK | CrewAI | Google ADK | Temporal SDK | MCP protocol | Any (HTTP) |
+| **Deployment** | Single/multi process | Single/multi process | Single/multi process | Distributed workers | Client/server | Distributed |
+| **Tier 1 (Guardrails)** | Yes | Yes | Yes | N/A | N/A | N/A |
+| **Tier 2 (Warrant + PoP)** | Yes | Yes | Yes | Yes | Yes | Yes |
+| **Delegation** | No | Yes `WarrantDelegator` | No | Yes (child workflows) | No | Yes (discovery) |
+| **Streaming** | Yes | No | Yes | N/A | No | No |
+| **Learning Curve** | Easy | Easy | Medium | Medium | Easy | Steep |
 
 ### Migration Paths
 
@@ -326,6 +332,7 @@ result = await client.send_task("search_papers", {...}, warrant=task_warrant)
 |-------------|----------|
 | **OpenAI + A2A** | Workers are separate OpenAI services |
 | **ADK + A2A** | ADK orchestrator --> various worker services |
+| **Temporal + MCP** | Durable workflows calling MCP tool servers |
 | **OpenAI + ADK + A2A** | Mixed runtimes in distributed system |
 
 **Rule of thumb**: Same language + same process --> runtime integration only. Cross-service --> add A2A.
@@ -606,11 +613,7 @@ pop_sig = worker_warrant.sign(
 )
 
 # Verify authorization
-authorized = worker_warrant.authorize(
-    tool="manage_infrastructure",
-    args=args,
-    signature=bytes(pop_sig)
-)
+authorized = worker_warrant.allows("manage_infrastructure", args)
 print(f"Authorized: {authorized}")  # True
 ```
 
@@ -641,10 +644,16 @@ diagnose(warrant)  # Prints warrant details, TTL, constraints, etc.
 
 ## Next Steps
 
-- **[AI Agent Patterns](./ai-agents)** - P-LLM/Q-LLM, prompt injection defense
-- **[Concepts](./concepts)** - Why Tenuo? Threat model, core invariants
-- **[AutoGen](./autogen)** - Protect AutoGen AgentChat tools
-- **[LangChain](./langchain)** - Protect LangChain tools
-- **[LangGraph](./langgraph)** - Scope LangGraph nodes
-- **[FastAPI](./fastapi)** - Zero-boilerplate API protection
-- **[Security](./security)** - Threat model, best practices
+- **[AI Agent Patterns](./ai-agents)** — P-LLM/Q-LLM, prompt injection defense
+- **[Concepts](./concepts)** — Why Tenuo? Threat model, core invariants
+- **[OpenAI](./openai)** — Direct API protection with streaming
+- **[Google ADK](./google-adk)** — ADK agent tool protection
+- **[CrewAI](./crewai)** — Multi-agent crew protection
+- **[LangChain](./langchain)** — Protect LangChain tools
+- **[LangGraph](./langgraph)** — Scope LangGraph nodes
+- **[AutoGen](./autogen)** — Protect AutoGen AgentChat tools
+- **[Temporal](./temporal)** — Durable workflow authorization
+- **[MCP](./mcp)** — Model Context Protocol client & server verification
+- **[A2A](./a2a)** — Inter-agent delegation
+- **[FastAPI](./fastapi)** — Zero-boilerplate API protection
+- **[Security](./security)** — Threat model, best practices

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -49,7 +49,12 @@ worker = Worker(
 )
 ```
 
-Set `TENUO_KEY_<key_id>` environment variables with your base64-encoded holder signing keys. For production, use `VaultKeyResolver` or `AWSSecretsManagerKeyResolver` instead. **[Tenuo Cloud](https://cloud.tenuo.ai)** handles key issuance, warrant minting, rotation, and audit for teams that prefer a managed control plane. See the [reference](./temporal-reference.md#key-management-required) for key management details.
+`TenuoPluginConfig` requires two things:
+
+- **`trusted_roots`** — public keys of warrant issuers (for verification on the activity worker)
+- **`key_resolver`** — how the workflow worker fetches holder signing keys for PoP (e.g. `EnvKeyResolver`, `VaultKeyResolver`, `AWSSecretsManagerKeyResolver`)
+
+Set `TENUO_KEY_<key_id>` environment variables with your base64-encoded holder signing keys. `TenuoTemporalPlugin` automatically preloads all matching keys into an in-memory cache so that `resolve_sync()` never touches `os.environ` inside the workflow sandbox. For production, use `VaultKeyResolver` or `AWSSecretsManagerKeyResolver` instead. **[Tenuo Cloud](https://cloud.tenuo.ai)** handles key issuance, warrant minting, rotation, and audit for teams that prefer a managed control plane. See the [reference](./temporal-reference.md#key-management-required) for key management details.
 
 > **Important:** Pass the plugin on `Client.connect(plugins=[plugin])` only. Workers created from that client automatically merge client plugins — do not duplicate.
 
@@ -107,6 +112,36 @@ class MyWorkflow(AuthorizedWorkflow):
         )
         return data.upper()
 ```
+
+## Capability constraints
+
+Warrants use a **closed-world (zero-trust) model**: every argument the activity receives must be declared in the capability, even if unconstrained. Use `Wildcard()` for arguments that can take any value:
+
+```python
+from tenuo import Warrant, SigningKey
+from tenuo_core import Subpath, Wildcard
+
+warrant = (
+    Warrant.mint_builder()
+    .holder(agent_key.public_key)
+    .capability("read_file", path=Subpath("/data"))       # path must be under /data
+    .capability("search", query=Wildcard())               # query can be anything
+    .capability("fetch_url",
+        url=UrlSafe(allow_schemes=["https"],
+                    allow_domains=["api.example.com"],
+                    block_private=True),
+        timeout=Wildcard(),                               # unconstrained but declared
+    )
+    .ttl(3600)
+    .mint(control_key)
+)
+```
+
+If an activity argument is not listed in the capability, the interceptor rejects the call with `TemporalConstraintViolation` — even if the value would otherwise be valid. This prevents accidental exposure of undeclared parameters.
+
+> **Common mistake:** listing only the constrained fields. If your activity has parameters `path` and `encoding`, the capability needs both — e.g. `.capability("read_file", path=Subpath("/data"), encoding=Wildcard())`.
+
+See [Temporal Integration Reference — Constraint types](./temporal-reference.md#constraint-types) for the full list of constraint types (`Subpath`, `UrlSafe`, `Exact`, `Pattern`, `Range`, `AnyOf`, etc.).
 
 ## How it works
 

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -119,7 +119,7 @@ Warrants use a **closed-world (zero-trust) model**: every argument the activity 
 
 ```python
 from tenuo import Warrant, SigningKey
-from tenuo_core import Subpath, Wildcard
+from tenuo_core import Subpath, UrlSafe, Wildcard
 
 warrant = (
     Warrant.mint_builder()

--- a/tenuo-python/examples/temporal/README.md
+++ b/tenuo-python/examples/temporal/README.md
@@ -160,7 +160,34 @@ The child receives only the attenuated warrant, not the parent's full scope.
 
 ## Worker setup (required)
 
-Tenuo's core is a PyO3 Rust extension. Unlike pure-Python integrations (e.g. OpenTelemetry's `TracingInterceptor`), Tenuo signs the Proof-of-Possession challenge *inside the workflow sandbox* at `execute_activity()` dispatch time, committing the exact tool and arguments the workflow is authorising. Because PyO3 extensions cannot be re-imported per sandbox task, both `tenuo` and `tenuo_core` must be declared as passthrough modules:
+### Recommended: `TenuoTemporalPlugin` (one-line setup)
+
+`TenuoTemporalPlugin` registers client interceptors, worker interceptors, sandbox passthrough, and key preloading in one step:
+
+```python
+from tenuo.temporal import TenuoTemporalPlugin, TenuoPluginConfig, EnvKeyResolver
+
+plugin = TenuoTemporalPlugin(
+    TenuoPluginConfig(
+        key_resolver=EnvKeyResolver(),
+        trusted_roots=[control_key.public_key],
+    )
+)
+
+client = await Client.connect("localhost:7233", plugins=[plugin])
+worker = Worker(
+    client,
+    task_queue="my-queue",
+    workflows=[MyWorkflow],
+    activities=[read_file],
+)
+```
+
+> **Important:** Pass the plugin on `Client.connect(plugins=[plugin])` only. Workers created from that client inherit it automatically — do not pass it again on `Worker(plugins=[...])`.
+
+### Advanced: manual `TenuoPlugin` + sandbox runner
+
+Use this when you need full control over the sandbox runner or interceptor composition (e.g. combining with other interceptors):
 
 ```python
 from temporalio.worker.workflow_sandbox import (
@@ -170,14 +197,13 @@ from temporalio.worker.workflow_sandbox import (
 from tenuo.temporal import EnvKeyResolver, TenuoPlugin, TenuoPluginConfig
 
 resolver = EnvKeyResolver()
-resolver.preload_keys(["agent1"])  # cache before Worker(...); sandbox PoP cannot read os.environ
+resolver.preload_all()  # cache all TENUO_KEY_* env vars before Worker starts
 
 interceptor = TenuoPlugin(
     TenuoPluginConfig(
         key_resolver=resolver,
         on_denial="raise",
-        trusted_roots=[control_key.public_key],  # required (or tenuo.configure(trusted_roots=[...]) before building config)
-        strict_mode=True,  # optional: fail-fast on ambiguous PoP with named constraints
+        trusted_roots=[control_key.public_key],
     )
 )
 
@@ -189,13 +215,15 @@ worker = Worker(
     interceptors=[interceptor],
     workflow_runner=SandboxedWorkflowRunner(
         restrictions=SandboxRestrictions.default.with_passthrough_modules(
-            "tenuo", "tenuo_core",  # Required: PyO3 extension cannot be re-imported per sandbox task
+            "tenuo", "tenuo_core",
         )
     ),
 )
 ```
 
-Omitting this causes `ImportError: PyO3 modules may only be initialized once per interpreter process`. The worker may still look healthy while every workflow task fails. See [Sandbox passthrough explained](../../../docs/temporal-reference.md#sandbox-passthrough-explained) in `docs/temporal-reference.md`.
+The manual pattern requires you to handle sandbox passthrough and key preloading yourself. `TenuoTemporalPlugin` does both automatically.
+
+> **Why passthrough?** Tenuo's core is a PyO3 Rust extension. PyO3 modules cannot be re-imported per sandbox task, so `tenuo` and `tenuo_core` must be declared as passthrough modules. Omitting this causes `ImportError: PyO3 modules may only be initialized once per interpreter process`.
 
 ## Architecture
 

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -448,6 +448,14 @@ class TenuoPlugin(_TemporalWorkerInterceptor):
                 "See the module docstring for a full Worker setup example."
             ) from _e
 
+        if config.pop_dedup_store is None:
+            logger.warning(
+                "TenuoPluginConfig: using in-memory PopDedupStore (single-process only). "
+                "In multi-worker deployments, PoP replays from other workers will not be "
+                "detected. Set pop_dedup_store= to a shared backend (Redis, Memcached, "
+                "etc.) for fleet-wide replay prevention."
+            )
+
         logger.info(
             "Loaded %s (warrant authorization middleware for Temporal Python SDK)",
             TENUO_TEMPORAL_PLUGIN_ID,
@@ -507,13 +515,6 @@ class TenuoActivityInboundInterceptor:
         self._pop_dedup_store: PopDedupStore = (
             config.pop_dedup_store or _default_pop_dedup_store
         )
-        if config.pop_dedup_store is None:
-            logger.warning(
-                "TenuoPluginConfig: using in-memory PopDedupStore (single-process only). "
-                "In multi-worker deployments, PoP replays from other workers will not be "
-                "detected. Set pop_dedup_store= to a shared backend (Redis, Memcached, "
-                "etc.) for fleet-wide replay prevention."
-            )
         self._trusted_roots_provider = config.trusted_roots_provider
         self._trusted_roots_refresh_interval = config.trusted_roots_refresh_interval_secs
         import time as _time

--- a/tenuo-python/tenuo/temporal/_resolvers.py
+++ b/tenuo-python/tenuo/temporal/_resolvers.py
@@ -169,10 +169,10 @@ class EnvKeyResolver(KeyResolver):
         return self._load_key_from_env(key_id)
 
     def preload_keys(self, key_ids: list[str]) -> None:
-        """Pre-load keys from environment to cache for Temporal workflows.
+        """Pre-load specific keys from environment into the cache.
 
-        Call this before creating the Temporal worker to avoid os.environ access
-        inside the workflow sandbox, which is blocked as non-deterministic.
+        Call this before creating the Temporal worker to avoid ``os.environ``
+        access inside the workflow sandbox.
 
         Args:
             key_ids: List of key IDs to pre-load (e.g., ["agent1", "agent2"])
@@ -183,8 +183,42 @@ class EnvKeyResolver(KeyResolver):
         for key_id in key_ids:
             self._key_cache[key_id] = self._load_key_from_env(key_id)
 
+    def preload_all(self) -> int:
+        """Scan ``os.environ`` for all ``{prefix}*`` keys and cache them.
+
+        Called automatically by :class:`~tenuo.temporal_plugin.TenuoTemporalPlugin`
+        at worker init so that ``resolve_sync()`` never touches ``os.environ``
+        inside the Temporal workflow sandbox.
+
+        Returns:
+            Number of keys loaded.
+        """
+        import os
+
+        loaded = 0
+        for name, _value in os.environ.items():
+            if name.startswith(self._prefix):
+                key_id = name[len(self._prefix):]
+                if key_id and key_id not in self._key_cache:
+                    try:
+                        self._key_cache[key_id] = self._load_key_from_env(key_id)
+                        loaded += 1
+                    except KeyResolutionError:
+                        logger.warning("EnvKeyResolver: skipping malformed key %s", name)
+        if loaded:
+            logger.info("EnvKeyResolver: preloaded %d key(s) from environment", loaded)
+        return loaded
+
     def resolve_sync(self, key_id: str) -> Any:
-        """Resolve key from cache or environment variable synchronously."""
+        """Resolve key from cache or environment variable synchronously.
+
+        .. warning::
+            Falls back to ``os.environ`` if the key isn't cached.  Inside the
+            Temporal workflow sandbox this will raise.  Use :meth:`preload_all`
+            or :meth:`preload_keys` before worker startup, or use
+            :class:`~tenuo.temporal_plugin.TenuoTemporalPlugin` which calls
+            ``preload_all()`` automatically.
+        """
         if key_id in self._key_cache:
             return self._key_cache[key_id]
         self._maybe_warn()

--- a/tenuo-python/tenuo/temporal_plugin.py
+++ b/tenuo-python/tenuo/temporal_plugin.py
@@ -218,26 +218,14 @@ class TenuoTemporalPlugin(SimplePlugin):
                     len(config.activity_fns),
                 )
 
-            # Item 1.6: auto-call preload_keys() if the resolver supports it
-            # Only auto-call if preload_keys() can be invoked with no arguments
-            # (EnvKeyResolver.preload_keys requires key_ids; resolvers designed for
-            # auto-preload declare preload_keys() with no required positional args).
-            _preload = getattr(config.key_resolver, "preload_keys", None)
-            if _preload is not None:
+            # Auto-preload signing keys so resolve_sync() never touches
+            # os.environ (or external storage) inside the workflow sandbox.
+            _preload_all = getattr(config.key_resolver, "preload_all", None)
+            if _preload_all is not None:
                 try:
-                    _sig = inspect.signature(_preload)
-                    _required = [
-                        p for p in _sig.parameters.values()
-                        if p.default is inspect.Parameter.empty
-                        and p.kind not in (
-                            inspect.Parameter.VAR_POSITIONAL,
-                            inspect.Parameter.VAR_KEYWORD,
-                        )
-                    ]
-                    if not _required:
-                        _preload()
-                except (ValueError, TypeError):
-                    pass
+                    _preload_all()
+                except Exception as _exc:
+                    _logger.warning("key preload failed: %s", _exc)
 
             if _tenuo_internal_mint_activity is not None:
                 existing.append(_tenuo_internal_mint_activity)

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -188,19 +188,20 @@ def test_duplicate_plugin_registration_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Item 1.6 — preload_keys() auto-called
+# Item 1.6 — preload_all() auto-called
 # ---------------------------------------------------------------------------
 
-def test_preload_keys_auto_called() -> None:
-    """TenuoTemporalPlugin.configure_worker auto-calls preload_keys() if available."""
+def test_preload_all_auto_called() -> None:
+    """TenuoTemporalPlugin.configure_worker auto-calls preload_all() if available."""
     preload_called: list[bool] = []
 
     class MockResolver:
         def resolve_sync(self, key_id: str) -> None:
             return None
 
-        def preload_keys(self) -> None:
+        def preload_all(self) -> int:
             preload_called.append(True)
+            return 0
 
     config = _minimal_config()
     config.key_resolver = MockResolver()  # type: ignore[assignment]
@@ -208,11 +209,11 @@ def test_preload_keys_auto_called() -> None:
     plugin = TenuoTemporalPlugin(config)
     plugin.activities([])  # type: ignore[operator]
 
-    assert preload_called, "preload_keys() should have been called automatically"
+    assert preload_called, "preload_all() should have been called automatically"
 
 
-def test_preload_keys_not_called_if_unsupported() -> None:
-    """If key_resolver has no preload_keys(), configure_worker does not error."""
+def test_preload_all_not_called_if_unsupported() -> None:
+    """If key_resolver has no preload_all(), configure_worker does not error."""
     class NoPreloadResolver:
         def resolve_sync(self, key_id: str) -> None:
             return None


### PR DESCRIPTION
## Summary

Addresses findings from a developer friction log testing the Temporal integration end-to-end.

- **P0: `EnvKeyResolver` crashes in sandbox** — Added `EnvKeyResolver.preload_all()` that scans `os.environ` for all `TENUO_KEY_*` keys and caches them. `TenuoTemporalPlugin` calls it automatically at worker init, so `resolve_sync()` never hits `os.environ` inside the workflow sandbox.
- **P0: Zero-trust / `Wildcard()` undocumented** — Added "Capability constraints" section to `docs/temporal.md` explaining the closed-world model and `Wildcard()` for unconstrained arguments.
- **P1: `TenuoPlugin` vs `TenuoTemporalPlugin` confusion** — Rewrote `examples/temporal/README.md` worker setup to lead with `TenuoTemporalPlugin` (recommended) and show manual `TenuoPlugin` as an "Advanced" alternative.
- **P1: Config requirements undocumented** — Added explicit note that `TenuoPluginConfig` needs both `trusted_roots` and `key_resolver`, and documented the auto-preload behavior.
- **P2: PopDedupStore warning noise** — Moved warning from `TenuoActivityInboundInterceptor.__init__` (per `intercept_activity` call) to `TenuoPlugin.__init__` (once per worker).

## Test plan

- [x] 275 temporal-related tests pass
- [x] Ruff clean
- [x] Manual verification of `preload_all()` with real keys
- [ ] CI passes