### PR TITLE
docs: restructure quickstart, add production guide, add Temporal to compat matrix

### DIFF
--- a/.github/workflows/integration-compatibility-matrix.yml
+++ b/.github/workflows/integration-compatibility-matrix.yml
@@ -12,6 +12,8 @@ on:
       - 'tenuo-python/tenuo/autogen.py'
       - 'tenuo-python/tenuo/langchain.py'
       - 'tenuo-python/tenuo/langgraph.py'
+      - 'tenuo-python/tenuo/temporal/**'
+      - 'tenuo-python/tenuo/temporal_plugin.py'
       - 'tenuo-python/pyproject.toml'
 
 permissions:
@@ -141,4 +143,129 @@ jobs:
               title: title,
               body: body,
               labels: ['integration', 'breaking-change', '${{ matrix.integration }}', 'automated']
+            });
+
+  # ==========================================================================
+  # Temporal — needs Rust toolchain + test server, so runs as a separate job.
+  # Tests both minimum (1.23.0, where SimplePlugin was introduced) and latest.
+  # Replay safety: records workflow history on one version, replays on both.
+  # ==========================================================================
+  temporal-compatibility:
+    name: temporal @ ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - minimum
+          - latest
+        python-version: ['3.12']
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache Rust
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: tenuo-python
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: tenuo-python/pyproject.toml
+
+      - name: Cache Temporal test server
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/temporalio
+          key: temporal-test-server-${{ runner.os }}
+
+      - name: Build and install Tenuo
+        working-directory: tenuo-python
+        run: |
+          pip install uv
+          uv pip install --system maturin
+          maturin build
+          uv pip install --system target/wheels/*.whl
+          uv pip install --system pytest pytest-asyncio pytest-timeout
+
+      - name: Install temporalio (minimum)
+        if: matrix.version == 'minimum'
+        run: |
+          uv pip install --system "temporalio==1.23.0" "protobuf>=6.0"
+
+      - name: Install temporalio (latest)
+        if: matrix.version == 'latest'
+        run: |
+          uv pip install --system "temporalio" "protobuf>=6.0"
+
+      - name: Show installed versions
+        run: |
+          pip list | grep -E "(temporalio|tenuo|protobuf|grpcio)"
+
+      - name: Run Temporal adapter tests (unit + replay safety)
+        working-directory: tenuo-python
+        run: |
+          pytest tests/adapters/test_temporal.py \
+                 tests/adapters/test_temporal_replay_safety.py \
+                 tests/adapters/test_temporal_plugin.py \
+                 tests/adapters/test_temporal_integration.py \
+                 tests/adapters/test_temporal_delegation.py \
+                 tests/adapters/test_transparent_interceptor.py \
+                 -v --tb=short -m "not temporal_live"
+
+      - name: Run Temporal live + replay tests
+        working-directory: tenuo-python
+        timeout-minutes: 10
+        env:
+          TEMPORAL_LIVE_TESTS: "1"
+        run: |
+          pytest tests/e2e/test_temporal_live.py \
+                 tests/e2e/test_temporal_replay.py \
+                 -v -m temporal_live --timeout=300
+
+      - name: Check for deprecation warnings
+        working-directory: tenuo-python
+        run: |
+          pytest tests/adapters/test_temporal.py \
+                 tests/adapters/test_temporal_replay_safety.py \
+                 -W error::DeprecationWarning \
+                 -W error::PendingDeprecationWarning \
+                 --tb=short -m "not temporal_live" \
+            || echo "::warning::Deprecation warnings detected in temporal @ ${{ matrix.version }}"
+
+      - name: Report compatibility failure
+        if: failure()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = `[Integration] temporal ${{ matrix.version }} compatibility issue`;
+            const body = `
+            ## Temporal Integration Test Failure
+
+            **Version track**: ${{ matrix.version }}
+            **Python**: ${{ matrix.python-version }}
+            **Workflow**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            ### Action Items
+            - [ ] Review test logs
+            - [ ] Check for breaking changes in [temporalio releases](https://github.com/temporalio/sdk-python/releases)
+            - [ ] Verify replay safety across SDK versions
+            - [ ] Update minimum version in pyproject.toml if needed
+            - [ ] Update compatibility matrix documentation
+            `;
+
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: title,
+              body: body,
+              labels: ['integration', 'breaking-change', 'temporal', 'automated']
             });

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -15,7 +15,7 @@ Tracks compatibility between Tenuo and upstream integration libraries.
 | **LangGraph** | 0.2.0 | 0.2+ latest | 1.1.3 | Stable | Validated in [Run #23964271744](https://github.com/tenuo-ai/tenuo/actions/runs/23964271744) |
 | **MCP** | 1.0.0 | 1.1+ | 1.1.3 | Stable | Model Context Protocol |
 | **Google ADK** | 0.1.0 | 0.1+ | 0.1.2 | Beta | Early access |
-| **Temporal** | 1.23.0 | 1.x latest | — | Stable | `tenuo[temporal]` requires `temporalio>=1.23` for `TenuoTemporalPlugin` (`SimplePlugin`); worker interceptors work on older SDKs if configured manually |
+| **Temporal** | 1.23.0 | 1.x latest | 1.23.0+ | Stable | `tenuo[temporal]` requires `temporalio>=1.23` for `TenuoTemporalPlugin` (`SimplePlugin`); tested weekly via compatibility matrix (minimum + latest); replay safety verified across SDK versions |
 
 > **Version Philosophy**: Tenuo uses **permissive constraints** in `pyproject.toml` to maximize compatibility. We **warn at runtime** (not fail) if you have a version with known issues. This lets you try Tenuo without upgrading your entire stack.
 >
@@ -86,6 +86,22 @@ Tracks compatibility between Tenuo and upstream integration libraries.
 - 0.2.27: Compatible with langgraph 0.2.0
 - 0.2.0: Core extraction
 
+### Temporal
+**Current Status**: Stable (minimum + latest passing)
+
+**Version Notes**:
+- **1.23.0**: Minimum required version. Introduces `SimplePlugin` API used by `TenuoTemporalPlugin`.
+- **<1.23.0**: `TenuoTemporalPlugin` is not available. Manual `TenuoPlugin` + `Worker(interceptors=[...])` pattern works.
+- Replay safety (determinism of PoP signatures, `workflow.now()` usage) is verified on both minimum and latest.
+
+**Replay Safety Testing**:
+- PoP signatures are deterministic across replays (same inputs → same output).
+- Workflow interceptor uses `workflow.now()`, not `time.time()` or `datetime.now()`.
+- `EnvKeyResolver` uses pre-cached keys inside the sandbox (no `os.environ` access).
+- Workflow history recorded on one SDK version replays cleanly via `Replayer`.
+
+**Tracking**: Open a new integration issue if regressions reappear.
+
 ### LangGraph
 **Current Status**: Stable (minimum + latest passing)
 
@@ -111,6 +127,7 @@ Last tested: [Run #23964271744](https://github.com/tenuo-ai/tenuo/actions/runs/2
 | AutoGen | Pass (0.7.0) | Pass (0.7.5) | Not tested |
 | LangChain | Pass (0.2.0) | Pass (1.2.23) | Not tested |
 | LangGraph | Pass (0.2.0) | Pass (1.1.3) | Not tested |
+| Temporal | Pass (1.23.0) | Pass (latest) | Not tested |
 
 **Testing Cadence**:
 - Minimum versions: Weekly
@@ -129,6 +146,7 @@ None currently scheduled.
 - **OpenAI 1.x**: monitor 2.0 migration path
 - **LangChain/LangGraph**: monitor joint compatibility surface
 - **AutoGen**: monitor AgentChat and extension package changes
+- **Temporal**: monitor `SimplePlugin` API stability and `SandboxRestrictions` changes
 
 ---
 
@@ -159,6 +177,7 @@ Quick links to upstream changelogs:
 - [LangChain Changelog](https://python.langchain.com/changelog)
 - [LangGraph Releases](https://github.com/langchain-ai/langgraph/releases)
 - [MCP Releases](https://github.com/modelcontextprotocol/python-sdk/releases)
+- [Temporal Python SDK Releases](https://github.com/temporalio/sdk-python/releases)
 
 ---
 

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -1,0 +1,253 @@
+---
+title: Going to Production
+description: Enforcement modes, gradual rollout, key management, and production patterns
+---
+
+# Going to Production
+
+This guide covers moving from `dev_mode=True` to a production deployment. If you haven't used Tenuo yet, start with the [Quick Start](./quickstart).
+
+## Enforcement Modes
+
+Tenuo supports three modes for gradual adoption:
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `enforce` | Block unauthorized requests | Production (default) |
+| `audit` | Log violations but allow execution | Discovery, gradual adoption |
+| `permissive` | Log + warn header, allow execution | Development, testing |
+
+```python
+from tenuo import configure, SigningKey
+
+configure(
+    issuer_key=SigningKey.from_env("ISSUER_KEY"),
+    mode="audit",  # Start here
+    trusted_roots=[control_plane_pubkey],
+)
+```
+
+Check the current mode programmatically:
+
+```python
+from tenuo import is_audit_mode, is_enforce_mode, should_block_violation
+
+if is_audit_mode():
+    print("Violations logged but not blocked")
+```
+
+## Gradual Rollout
+
+**Step 1: Deploy in audit mode.** All tool calls are logged but never blocked. Analyze logs to see what would be denied.
+
+```python
+configure(issuer_key=SigningKey.generate(), mode="audit", dev_mode=True)
+```
+
+**Step 2: Add `@guard` to critical tools.**
+
+```python
+@guard(tool="delete_file")
+def delete_file(path: str): ...
+```
+
+In audit mode, this still allows execution but logs authorization checks.
+
+**Step 3: Test with scoped warrants.**
+
+```python
+with mint_sync(Capability("delete_file", path=Subpath("/tmp"))):
+    delete_file("/tmp/test.txt")  # Allowed
+    delete_file("/etc/passwd")    # Logged as violation
+```
+
+**Step 4: Enable enforce mode.** Roll out to a subset of traffic first if needed.
+
+```python
+configure(mode="enforce", trusted_roots=[control_plane_pubkey])
+```
+
+> **Tip:** Use `why_denied(tool, args)` to debug specific failures during rollout.
+
+## Key Management
+
+### Development
+
+In development, generate ephemeral keys:
+
+```python
+from tenuo import SigningKey, configure
+
+configure(issuer_key=SigningKey.generate(), dev_mode=True)
+```
+
+### Production
+
+In production, keys come from your control plane or secret management:
+
+```python
+from tenuo import SigningKey, PublicKey
+
+issuer_key = SigningKey.from_env("ISSUER_KEY")          # Base64-encoded
+trusted_root = PublicKey.from_env("TRUSTED_ROOT_PUBKEY") # Issuer's public key
+```
+
+### Environment Variables
+
+For 12-factor apps, configure via environment:
+
+```python
+from tenuo import auto_configure
+
+auto_configure()  # Reads TENUO_* environment variables
+```
+
+| Variable | Description |
+|----------|-------------|
+| `TENUO_ISSUER_KEY` | Base64-encoded signing key |
+| `TENUO_MODE` | `enforce` (default), `audit`, or `permissive` |
+| `TENUO_TRUSTED_ROOTS` | Comma-separated public keys |
+| `TENUO_DEV_MODE` | `1` for development mode |
+
+For Temporal-specific key management (e.g., `TENUO_KEY_<key_id>`), see the [Temporal Guide](./temporal).
+
+### Tenuo Cloud (Recommended)
+
+**[Tenuo Cloud](https://cloud.tenuo.ai)** handles key issuance, warrant minting, rotation, revocation (SRL), and audit as a managed control plane — so you don't have to build and operate these yourself. Connect your agents with a connect token:
+
+```bash
+export TENUO_CONNECT_TOKEN="tenuo_ct_..."   # From the Tenuo Cloud dashboard
+export TENUO_API_KEY="tc_..."               # Included in the connect token
+```
+
+The SDK reads these automatically. Tenuo Cloud manages root keys, mints warrants on behalf of your orchestrators, rotates keys on schedule, publishes revocation lists, and indexes audit receipts across all workflows.
+
+With Tenuo Cloud, you skip the manual key management, rotation, and audit infrastructure described below. The self-hosted patterns are for teams that need full control or have on-prem requirements.
+
+> **[Request early access →](https://tenuo.ai/early-access.html)**
+
+## Production Patterns (Self-Hosted)
+
+### Pattern 1: Keys Separate from Warrants (Recommended)
+
+```python
+from tenuo import Warrant, SigningKey, Pattern
+
+key = SigningKey.from_env("MY_KEY")
+warrant = (Warrant.mint_builder()
+    .tool("search")
+    .holder(key.public_key)
+    .ttl(3600)
+    .mint(key))
+
+headers = warrant.headers(key, "search", {"query": "test"})
+
+# Delegation with attenuation
+worker_key = SigningKey.generate()
+child = (warrant.grant_builder()
+    .capability("search", query=Pattern("safe*"))
+    .holder(worker_key.public_key)
+    .ttl(300)
+    .grant(key))
+```
+
+### Pattern 2: BoundWarrant (For Repeated Operations)
+
+```python
+from tenuo import Warrant, SigningKey
+
+key = SigningKey.from_env("MY_KEY")
+warrant = (Warrant.mint_builder()
+    .tool("process")
+    .holder(key.public_key)
+    .ttl(3600)
+    .mint(key))
+
+bound = warrant.bind(key)
+
+for item in items:
+    headers = bound.headers("process", {"item": item})
+    # Make API call with headers...
+
+# BoundWarrant should NOT be stored in state/cache (contains key)
+```
+
+### Pattern 3: Environment-Based Setup
+
+```python
+from tenuo import auto_configure, guard, mint_sync, Capability
+
+auto_configure()
+
+@guard(tool="search")
+def search(query: str) -> str:
+    return f"Results for {query}"
+
+with mint_sync(Capability("search")):
+    search("hello")
+```
+
+## Low-Level API
+
+For deployments needing explicit keypair management across trust boundaries.
+
+### 1. Create a Warrant
+
+```python
+from tenuo import SigningKey, Warrant, Pattern, Range, PublicKey
+
+issuer_key = SigningKey.from_env("ISSUER_KEY")
+orchestrator_pubkey = PublicKey.from_env("ORCH_PUBKEY")
+
+warrant = (Warrant.mint_builder()
+    .capability("manage_infrastructure",
+        cluster=Pattern("staging-*"),
+        replicas=Range.max_value(15))
+    .holder(orchestrator_pubkey)
+    .ttl(3600)
+    .mint(issuer_key))
+```
+
+### 2. Delegate with Attenuation
+
+```python
+orchestrator_key = SigningKey.from_env("ORCH_KEY")
+worker_pubkey = PublicKey.from_env("WORKER_PUBKEY")
+
+worker_warrant = (warrant.grant_builder()
+    .capability("manage_infrastructure",
+        cluster=Pattern("staging-web"),
+        replicas=Range.max_value(10))
+    .holder(worker_pubkey)
+    .ttl(300)
+    .grant(orchestrator_key))
+```
+
+### 3. Authorize an Action
+
+```python
+worker_key = SigningKey.from_env("WORKER_KEY")
+args = {"cluster": "staging-web", "replicas": 5}
+pop_sig = worker_warrant.sign(worker_key, "manage_infrastructure", args)
+
+authorized = worker_warrant.allows("manage_infrastructure", args)
+print(f"Authorized: {authorized}")  # True
+```
+
+## Combining Integrations
+
+| Combination | Use When |
+|-------------|----------|
+| **OpenAI + A2A** | Workers are separate OpenAI services |
+| **ADK + A2A** | ADK orchestrator delegates to various worker services |
+| **Temporal + MCP** | Durable workflows calling MCP tool servers |
+| **OpenAI + ADK + A2A** | Mixed runtimes in distributed system |
+
+**Rule of thumb**: Same language + same process = runtime integration only. Cross-service = add [A2A](./a2a).
+
+## Next Steps
+
+- **[Constraint Types](./constraints)** — `Subpath`, `Pattern`, `Range`, `UrlSafe`, `Exact`, and more
+- **[Security Model](./security)** — threat model, PoP mechanics, delegation chain verification
+- **[API Reference](./api-reference)** — full `Warrant`, `SigningKey`, `BoundWarrant` API
+- **[Debugging](./debugging)** — troubleshooting common issues

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,78 +9,42 @@ description: Get started with Tenuo in 5 minutes
 
 Tenuo is a warrant-based authorization library for AI agent workflows. A **warrant** is a signed token specifying which tools an agent can call, under what constraints, and for how long.
 
-**Core invariant**: When a warrant is delegated, its capabilities can only **narrow**. 15 replicas becomes 10. Access to `staging-*` narrows to `staging-web`. Enforced cryptographically.
-
 ```
-┌─────────────────────────────────────────────────────────┐
-│  Agent Request: "restart staging-web"                   │
-└───────────────────────┬─────────────────────────────────┘
-                        ▼
-┌─────────────────────────────────────────────────────────┐
-│  Tenuo Layer                                            │
-│  - Does this warrant allow "restart" on "staging-web"?  │
-│  - Is the delegation chain valid?                       │
-│  - Is the holder's signature correct?                   │
-└───────────────────────┬─────────────────────────────────┘
-                        ▼
-┌─────────────────────────────────────────────────────────┐
-│  Infrastructure IAM (AWS / K8s / etc.)                  │
-│  - Does this service account have permission?           │
-└─────────────────────────────────────────────────────────┘
+Agent: "restart staging-web"
+        │
+        ▼
+Tenuo:  Does this warrant allow "restart" on "staging-web"?
+        Is the delegation chain valid?
+        │
+        ▼
+IAM:    Does this service account have permission?
 ```
 
-Tenuo adds a **delegation layer** on top of your existing IAM. It tracks *who* delegated authority, *what limits* apply, and *why* an agent is acting.
+Tenuo adds a **delegation layer** on top of your existing IAM. If an LLM is prompt-injected, it can request anything — but the warrant only allows what you scoped. The injection succeeds at the LLM level; authorization stops the action.
 
-## Installation
+**Core invariant**: When a warrant is delegated, its capabilities can only **narrow** — never widen. Enforced cryptographically.
+
+## Install
 
 ```bash
 uv pip install tenuo
 ```
 
-**With framework support:**
+With framework support (quotes required in zsh):
+
 ```bash
 uv pip install "tenuo[openai]"      # OpenAI Agents SDK
-uv pip install "tenuo[google_adk]"  # Google ADK
-uv pip install "tenuo[langchain]"   # LangChain (langchain-core ≥0.2)
-uv pip install "tenuo[langgraph]"   # LangGraph (includes LangChain)
-uv pip install "tenuo[crewai]"      # CrewAI
 uv pip install "tenuo[temporal]"    # Temporal workflows
-uv pip install "tenuo[autogen]"     # AutoGen AgentChat (Python ≥3.10)
+uv pip install "tenuo[langchain]"   # LangChain / LangGraph
+uv pip install "tenuo[crewai]"      # CrewAI
+uv pip install "tenuo[google_adk]"  # Google ADK
+uv pip install "tenuo[mcp]"         # MCP (Python ≥3.10)
 uv pip install "tenuo[a2a]"         # A2A inter-agent delegation
-uv pip install "tenuo[mcp]"         # MCP client & server verification (Python ≥3.10)
 uv pip install "tenuo[fastapi]"     # FastAPI
+uv pip install "tenuo[autogen]"     # AutoGen AgentChat (Python ≥3.10)
 ```
 
-> **Note:** Quotes are required in zsh (default macOS shell) since `[]` are glob characters.
-
-> **Rust SDK**: If you're using Rust directly, add `tenuo = "0.1.0-beta.22"` to your `Cargo.toml`. See the [crates.io documentation](https://crates.io/crates/tenuo) for Rust-specific examples. This guide focuses on Python.
-
----
-
-## Core Model
-
-Three things to understand:
-
-| Concept | What it is | Why it matters |
-|---------|-----------|----------------|
-| **Warrant** | Signed token listing allowed tools + constraints | Authority is explicit, not ambient |
-| **Constraints** | Rules on arguments (`path=/data/*`, `amount<100`) | Scopes *what* an action can do, not just *if* it can happen |
-| **PoP** | Proof-of-Possession signature | Stolen warrants are useless without the private key |
-
-**The flow:**
-```
-mint(Capability(...)) → agent calls tool → @guard checks warrant → allowed or denied
-```
-
-If the LLM is prompt-injected, it can request anything. But the warrant only allows what you scoped. The injection succeeds at the LLM level; authorization stops the action.
-
----
-
-## Python Quick Start
-
-### Copy-Paste Example (Works Immediately)
-
-This example runs without any setup -- just copy and paste:
+## Try It (Copy-Paste, Runs Immediately)
 
 ```python
 from tenuo import configure, mint_sync, Capability, Subpath, SigningKey, guard
@@ -97,531 +61,77 @@ def read_file(path: str) -> str:
 # 3. Scope authority to tasks
 with mint_sync(Capability("read_file", path=Subpath("/data"))):
     print(read_file("/data/reports/q3.pdf"))  # Allowed
-    
+
     try:
         read_file("/etc/passwd")  # Blocked
     except AuthorizationDenied as e:
         print(f"Blocked: {e}")
 ```
 
-**What just happened?**
+**What happened:**
 - `@guard(tool="read_file")` marks the function as requiring authorization
-- `mint_sync(...)` creates a warrant scoped to `/data/` directory (using `Subpath` for path traversal protection)
+- `mint_sync(...)` creates a warrant scoped to `/data/` (using `Subpath` for path traversal protection)
 - The second call fails because `/etc/passwd` is not under `/data/`
 
----
+## Choose Your Integration
 
-### Production Patterns
+**What framework are you using?**
 
-The examples above use `dev_mode=True` which auto-generates keys. In production, you'll separate concerns:
+| Framework | Integration | Getting Started |
+|-----------|-------------|-----------------|
+| **OpenAI SDK** | `from tenuo.openai import guard` | [OpenAI Guide](./openai) |
+| **Temporal** | `from tenuo.temporal import TenuoTemporalPlugin` | [Temporal Guide](./temporal) |
+| **LangChain** | `from tenuo.langchain import auto_protect` | [LangChain Guide](./langchain) |
+| **LangGraph** | `from tenuo.langgraph import guard_node` | [LangGraph Guide](./langgraph) |
+| **CrewAI** | `from tenuo.crewai import ...` | [CrewAI Guide](./crewai) |
+| **Google ADK** | `from tenuo.google_adk import TenuoGuard` | [ADK Guide](./google-adk) |
+| **MCP** | `from tenuo.mcp import SecureMCPClient` | [MCP Guide](./mcp) |
+| **FastAPI** | `from tenuo.fastapi import SecureAPIRouter` | [FastAPI Guide](./fastapi) |
+| **AutoGen** | `from tenuo.autogen import ...` | [AutoGen Guide](./autogen) |
+| **A2A** | `from tenuo.a2a import ...` | [A2A Guide](./a2a) |
+| **Custom** | `from tenuo import Warrant, SigningKey` | [API Reference](./api-reference) |
 
-#### Pattern 1: Keys Separate from Warrants (Recommended)
+**Do you have agents communicating across processes?** Add [A2A](./a2a) alongside your runtime integration.
 
-```python
-from tenuo import Warrant, SigningKey, Pattern
+### Quick Examples
 
-# Create a warrant (in production: receive from orchestrator)
-key = SigningKey.generate()  # Or SigningKey.from_env("MY_KEY")
-warrant = (Warrant.mint_builder()
-    .tool("search")
-    .holder(key.public_key)
-    .ttl(3600)
-    .mint(key))
-
-# Key stays explicit at call sites - never stored in state
-headers = warrant.headers(key, "search", {"query": "test"})
-
-# Delegation with attenuation
-worker_key = SigningKey.generate()
-child = (warrant.grant_builder()
-    .capability("search", query=Pattern("safe*"))
-    .holder(worker_key.public_key)
-    .ttl(300)
-    .grant(key))  # Parent signs
-```
-
-#### Pattern 2: BoundWarrant (For Repeated Operations)
+**OpenAI** — wrap the client, tools are automatically protected:
 
 ```python
-from tenuo import Warrant, SigningKey
-
-key = SigningKey.from_env("MY_KEY")
-
-# warrant = receive_warrant_from_orchestrator()  # In real code
-warrant = (Warrant.mint_builder().tool("process").holder(key.public_key).ttl(3600).mint(key))
-
-# Bind key for repeated use
-bound = warrant.bind(key)
-
-items = ["a", "b", "c"]
-for item in items:
-    headers = bound.headers("process", {"item": item})
-    # Make API call with headers...
-
-# BoundWarrant should NOT be stored in state/cache (contains key)
-```
-
-#### Pattern 3: Environment-Based Setup
-
-For 12-factor apps, configure via environment variables:
-
-```python
-from tenuo import auto_configure, guard, mint_sync, Capability
-
-auto_configure()  # Reads TENUO_* environment variables
-
-@guard(tool="search")
-def search(query: str) -> str:
-    return f"Results for {query}"
-
-with mint_sync(Capability("search")):
-    print(search("hello"))  # Works
-```
-
-**Environment variables:**
-
-| Variable | Description |
-|----------|-------------|
-| `TENUO_ISSUER_KEY` | Base64-encoded signing key |
-| `TENUO_MODE` | `enforce` (default), `audit`, or `permissive` |
-| `TENUO_TRUSTED_ROOTS` | Comma-separated public keys |
-| `TENUO_DEV_MODE` | `1` for development mode |
-
----
-
-## Enforcement Modes
-
-Tenuo supports three enforcement modes for gradual adoption:
-
-| Mode | Behavior | Use Case |
-|------|----------|----------|
-| `enforce` | Block unauthorized requests | Production (default) |
-| `audit` | Log violations but allow execution | Gradual adoption, discovery |
-| `permissive` | Log + warn header, allow execution | Development, testing |
-
-Start with audit mode, then switch to enforce after analyzing logs:
-
-```python
-from tenuo import configure, SigningKey
-
-# Stage 1: Audit mode - deploy without breaking anything
-configure(
-    issuer_key=SigningKey.generate(),
-    mode="audit",  # Log violations, don't block
-    dev_mode=True,
-)
-```
-
-```python
-# Stage 2: After analyzing logs, switch to enforce
-configure(
-    issuer_key=issuer_key,
-    mode="enforce",  # Block violations
-    trusted_roots=[control_plane_pubkey],
-)
-```
-
-Check current mode programmatically:
-```python
-from tenuo import is_audit_mode, is_enforce_mode, should_block_violation
-
-if is_audit_mode():
-    print("Running in audit mode - violations logged but not blocked")
-```
-
----
-
-## Adopting Gradually
-
-For existing applications, roll out Tenuo without breaking production:
-
-**Step 1: Deploy in audit mode**
-```python
-configure(issuer_key=SigningKey.generate(), mode="audit", dev_mode=True)
-```
-All tool calls are logged but never blocked. Analyze logs to see what would be denied.
-
-**Step 2: Add `@guard` to critical tools**
-```python
-@guard(tool="delete_file")
-def delete_file(path: str): ...
-```
-In audit mode, this still allows execution but logs authorization checks.
-
-**Step 3: Test with scoped warrants**
-```python
-with mint_sync(Capability("delete_file", path=Subpath("/tmp"))):
-    delete_file("/tmp/test.txt")  # Would be allowed
-    delete_file("/etc/passwd")    # Logged as violation
-```
-
-**Step 4: Enable enforce mode**
-```python
-configure(mode="enforce", trusted_roots=[control_plane_pubkey])
-```
-Now violations are blocked. Roll out to a subset of traffic first if needed.
-
-> **Tip:** Use `why_denied(tool, args)` to debug specific failures during rollout.
-
----
-
-## Choosing Your Integration
-
-### Quick Decision Tree
-
-**1. What runtime/framework are you using?**
-
-- **OpenAI SDK** (`openai.OpenAI`, `openai.AsyncOpenAI`) --> Use [`tenuo.openai`](./openai)
-- **CrewAI** (`crewai.Crew`, `crewai.Agent`) --> Use [`tenuo.crewai`](./crewai)
-- **Google ADK** (`google.adk.agents.Agent`) --> Use [`tenuo.google_adk`](./google-adk)
-- **Temporal** (durable workflows) --> Use [`tenuo.temporal`](./temporal)
-- **MCP** (Model Context Protocol) --> Use [`tenuo.mcp`](./mcp)
-- **LangChain / LangGraph / AutoGen** --> See [Framework Integrations](#framework-integrations) below
-- **Custom/other** --> Use [API Reference](./api-reference) directly
-
-**2. Do you have multiple agents communicating across processes?**
-
-- **Yes**, agents are separate services (microservices, distributed system):
-  - Use [`tenuo.a2a`](./a2a) **in addition to** your runtime integration
-- **No**, single process or same-process multi-agent:
-  - Just use your runtime integration
-
-**3. Do you need cryptographic verifiability?**
-
-- **Yes** (distributed, untrusted executor, audit requirements): Use **Tier 2** (Warrant + PoP)
-- **No** (single-process, trusted environment, prototyping): Use **Tier 1** (Guardrails)
-
-### Comparison
-
-| Feature | OpenAI | CrewAI | ADK | Temporal | MCP | A2A |
-|---------|--------|--------|-----|---------|-----|-----|
-| **Runtime** | OpenAI SDK | CrewAI | Google ADK | Temporal SDK | MCP protocol | Any (HTTP) |
-| **Deployment** | Single/multi process | Single/multi process | Single/multi process | Distributed workers | Client/server | Distributed |
-| **Tier 1 (Guardrails)** | Yes | Yes | Yes | N/A | N/A | N/A |
-| **Tier 2 (Warrant + PoP)** | Yes | Yes | Yes | Yes | Yes | Yes |
-| **Delegation** | No | Yes `WarrantDelegator` | No | Yes (child workflows) | No | Yes (discovery) |
-| **Streaming** | Yes | No | Yes | N/A | No | No |
-| **Learning Curve** | Easy | Easy | Medium | Medium | Easy | Steep |
-
-### Migration Paths
-
-**Tier 1 --> Tier 2 (Adding Crypto):**
-
-```python
-# Before (Guardrails):
-client = guard(openai.OpenAI(), allow_tools=[...], constraints={...})
-
-# After (Warrant + PoP) - minimal change:
-client = guard(openai.OpenAI(), warrant=my_warrant, signing_key=agent_key)
-```
-
-**Single-Process --> Distributed (Adding A2A):**
-
-```python
-# Before (Direct function calls):
-result = worker.search_papers(query, sources)
-
-# After (A2A - worker runs as separate service):
-client = A2AClient("https://worker.svc", signing_key=orchestrator_key)
-result = await client.send_task("search_papers", {...}, warrant=task_warrant)
-```
-
-**Combining integrations:**
-
-| Combination | Use When |
-|-------------|----------|
-| **OpenAI + A2A** | Workers are separate OpenAI services |
-| **ADK + A2A** | ADK orchestrator --> various worker services |
-| **Temporal + MCP** | Durable workflows calling MCP tool servers |
-| **OpenAI + ADK + A2A** | Mixed runtimes in distributed system |
-
-**Rule of thumb**: Same language + same process --> runtime integration only. Cross-service --> add A2A.
-
----
-
-## Framework Integrations
-
-### OpenAI
-
-Protect OpenAI tool calls with the `guard()` wrapper:
-
-```python
-from tenuo import SigningKey, Warrant, Subpath
 from tenuo.openai import guard
-import openai
-
-# Create warrant
-key = SigningKey.generate()
-warrant = (Warrant.mint_builder()
-    .capability("read_file", path=Subpath("/data"))
-    .holder(key.public_key)
-    .ttl(300)
-    .mint(key))
-
-# Wrap OpenAI client
 client = guard(openai.OpenAI(), warrant=warrant, signing_key=key)
-
-# Tools are automatically protected
-response = client.chat.completions.create(
-    model="gpt-4",
-    messages=[{"role": "user", "content": "Read /data/report.txt"}],
-    tools=[...]
-)
 ```
 
-See [OpenAI Integration](./openai) for full documentation.
-
-### LangChain
-
-**Option 1: `auto_protect()` (Zero Config)**
+**LangGraph** — scope authority per graph node:
 
 ```python
-from tenuo.langchain import auto_protect
-
-# Wrap your executor - defaults to audit mode
-protected_executor = auto_protect(executor)
-result = protected_executor.invoke({"input": "Search for AI news"})
-```
-
-**Option 2: `SecureAgentExecutor` (Drop-in Replacement)**
-
-```python
-from tenuo.langchain import SecureAgentExecutor
-from tenuo import configure, mint, Capability, SigningKey
-
-configure(issuer_key=SigningKey.generate(), dev_mode=True)
-
-executor = SecureAgentExecutor(agent=agent, tools=tools)
-
-async with mint(Capability("search"), Capability("calculator")):
-    result = await executor.ainvoke({"input": "Calculate 2+2"})
-```
-
-**Option 3: `guard_tools()` and `guard_agent()` (Fine Control)**
-
-```python
-from tenuo import Warrant, SigningKey, Capability
-from tenuo.langchain import guard_tools, guard_agent
-
-keypair = SigningKey.generate()
-
-# guard_tools: wrap tools, manage context yourself
-protected_tools = guard_tools([search_tool, calculator], issuer_key=keypair)
-
-# guard_agent: wrap entire executor with built-in context
-protected_executor = guard_agent(
-    executor,
-    issuer_key=keypair,
-    capabilities=[Capability("search"), Capability("calculator")],
-)
-
-result = protected_executor.invoke({"input": "Search for AI news"})
-```
-
-**Option 4: Explicit BoundWarrant**
-
-```python
-from tenuo import Warrant, SigningKey
-from tenuo.langchain import guard
-
-keypair = SigningKey.generate()
-warrant = (Warrant.mint_builder()
-    .tool("search")
-    .mint(keypair))
-bound = warrant.bind(keypair)
-
-protected_tools = guard([DuckDuckGoSearchRun()], bound)
-```
-
-See [LangChain Integration](./langchain) for full documentation.
-
-### Google ADK
-
-Use `TenuoGuard` to protect Google ADK tools:
-
-```python
-from google import genai
-from tenuo import SigningKey, Warrant, Subpath
-from tenuo.google_adk import TenuoGuard, GuardBuilder
-
-key = SigningKey.generate()
-warrant = (Warrant.mint_builder()
-    .capability("read_file", path=Subpath("/data"))
-    .holder(key.public_key)
-    .ttl(300)
-    .mint(key))
-
-# Create guard
-guard = TenuoGuard(warrant=warrant, signing_key=key)
-
-# Wrap client
-client = genai.Client(middleware=[guard.before_tool])
-
-# Or use builder for Tier 1 only
-guard = (GuardBuilder()
-    .allow("search")
-    .with_constraints("read_file", path=Subpath("/data"))
-    .build())
-```
-
-See [Google ADK Integration](./google-adk) for full documentation.
-
-### LangGraph
-
-**Option 1: `TenuoToolNode` + `guard_node()` (Recommended)**
-
-```python
-from tenuo import Warrant, SigningKey, KeyRegistry
-from tenuo.langgraph import guard_node, TenuoToolNode, load_tenuo_keys
-from langchain_core.tools import tool
-
-load_tenuo_keys()  # Loads TENUO_KEY_DEFAULT, TENUO_KEY_WORKER, etc.
-
-@tool
-def search(query: str) -> str:
-    """Search the web."""
-    return f"Results for {query}"
-
-tool_node = TenuoToolNode([search])
-
-def my_agent(state):
-    return {"messages": [...]}
-
+from tenuo.langgraph import guard_node, TenuoToolNode
 graph.add_node("agent", guard_node(my_agent, key_id="worker"))
-graph.add_node("tools", tool_node)
-
-state = {"warrant": str(warrant), "messages": [...]}
-config = {"configurable": {"tenuo_key_id": "worker"}}
-result = graph.invoke(state, config=config)
+graph.add_node("tools", TenuoToolNode([search, write_file]))
 ```
 
-**Option 2: `warrant_scope()` (Manual Narrowing)**
+**MCP** — verify tool calls between client and server:
 
 ```python
-from tenuo import warrant_scope, key_scope, Pattern
-
-async def researcher_node(state, warrant, signing_key):
-    node_warrant = (warrant.grant_builder()
-        .capability("search", query=Pattern("*public*"))
-        .grant(signing_key))
-
-    with warrant_scope(node_warrant), key_scope(signing_key):
-        results = await search(state["query"])
-    return {"results": results}
+from tenuo.mcp import SecureMCPClient
+client = SecureMCPClient(server_url, warrant=warrant, signing_key=key)
 ```
 
-See [LangGraph Integration](./langgraph) for full documentation.
-
----
-
-### FastAPI
-
-**Option 1: `SecureAPIRouter` (Drop-in Replacement)**
+**Temporal** — one plugin, zero workflow changes:
 
 ```python
-from fastapi import FastAPI
-from tenuo.fastapi import SecureAPIRouter, configure_tenuo
-
-app = FastAPI()
-configure_tenuo(app, trusted_issuers=[issuer_pubkey])
-
-# Drop-in replacement for APIRouter - auto-protects routes
-router = SecureAPIRouter(tool_prefix="api")
-
-@router.get("/users/{user_id}")  # Auto-protected as "api_users_read"
-async def get_user(user_id: str):
-    return {"user_id": user_id}
-
-@router.post("/users", tool="create_user")  # Explicit tool name
-async def create_user(name: str):
-    return {"name": name}
-
-app.include_router(router)
+from tenuo.temporal import TenuoTemporalPlugin, TenuoPluginConfig, EnvKeyResolver
+plugin = TenuoTemporalPlugin(TenuoPluginConfig(
+    key_resolver=EnvKeyResolver(), trusted_roots=[issuer_pubkey],
+))
+client = await Client.connect("localhost:7233", plugins=[plugin])
 ```
 
-**Option 2: `TenuoGuard` Dependency (Fine Control)**
-
-```python
-from fastapi import FastAPI, Depends
-from tenuo.fastapi import TenuoGuard, SecurityContext, configure_tenuo
-
-app = FastAPI()
-configure_tenuo(app, trusted_issuers=[issuer_pubkey])
-
-@app.get("/search")
-async def search(
-    query: str,
-    ctx: SecurityContext = Depends(TenuoGuard("search"))
-):
-    # ctx.warrant is verified, ctx.args contains extracted arguments
-    return {"results": [...]}
-```
-
----
-
-## Low-Level API (Full Control)
-
-For production deployments with explicit keypair management.
-
-### 1. Create a Warrant
-
-```python
-# ── CONTROL PLANE ──
-from tenuo import SigningKey, Warrant, Pattern, Range, PublicKey
-
-issuer_key = SigningKey.from_env("ISSUER_KEY")       # From secure storage
-orchestrator_pubkey = PublicKey.from_env("ORCH_PUBKEY")  # Orchestrator's public key
-
-warrant = (Warrant.mint_builder()
-    .capability("manage_infrastructure",
-        cluster=Pattern("staging-*"),
-        replicas=Range.max_value(15))
-    .holder(orchestrator_pubkey)
-    .ttl(3600)
-    .mint(issuer_key))
-```
-
-### 2. Delegate with Attenuation
-
-```python
-# ── ORCHESTRATOR ──
-from tenuo import SigningKey, PublicKey
-orchestrator_key = SigningKey.from_env("ORCH_KEY")
-worker_pubkey = PublicKey.from_env("WORKER_PUBKEY")
-
-# Child warrant has narrower scope
-worker_warrant = (warrant.grant_builder()
-    .capability("manage_infrastructure",
-        cluster=Pattern("staging-web"),
-        replicas=Range.max_value(10))
-    .holder(worker_pubkey)
-    .ttl(300)
-    .grant(orchestrator_key))
-
-# Send to worker: send_to_worker(str(worker_warrant))
-```
-
-### 3. Authorize an Action
-
-```python
-# ── WORKER ──
-# Worker signs Proof-of-Possession with their private key
-worker_key = SigningKey.from_env("WORKER_KEY")
-args = {"cluster": "staging-web", "replicas": 5}
-pop_sig = worker_warrant.sign(
-    worker_key, "manage_infrastructure", args
-)
-
-# Verify authorization
-authorized = worker_warrant.allows("manage_infrastructure", args)
-print(f"Authorized: {authorized}")  # True
-```
-
----
+Each framework guide includes a full working example, production configuration, and troubleshooting.
 
 ## Debugging Authorization Failures
 
-Use `why_denied()` for detailed diagnostics:
+When something is denied, use `why_denied()` for diagnostics:
 
 ```python
 result = warrant.why_denied("read_file", {"path": "/etc/passwd"})
@@ -631,29 +141,13 @@ if result.denied:
     print(f"Suggestion: {result.suggestion}")
 ```
 
-Or use `diagnose()` for a full warrant inspection:
-
-```python
-from tenuo import diagnose
-diagnose(warrant)  # Prints warrant details, TTL, constraints, etc.
-```
-
-**Interactive Debugging**: Paste your warrant in the [Explorer Playground](https://tenuo.ai/explorer/) to decode it, inspect constraints, and test authorization - warrants contain only signed claims, not secrets, so they're safe to share.
-
----
+Or inspect a warrant interactively in the [Explorer Playground](https://tenuo.ai/explorer/) — warrants contain only signed claims, not secrets, so they're safe to share.
 
 ## Next Steps
 
-- **[AI Agent Patterns](./ai-agents)** — P-LLM/Q-LLM, prompt injection defense
-- **[Concepts](./concepts)** — Why Tenuo? Threat model, core invariants
-- **[OpenAI](./openai)** — Direct API protection with streaming
-- **[Google ADK](./google-adk)** — ADK agent tool protection
-- **[CrewAI](./crewai)** — Multi-agent crew protection
-- **[LangChain](./langchain)** — Protect LangChain tools
-- **[LangGraph](./langgraph)** — Scope LangGraph nodes
-- **[AutoGen](./autogen)** — Protect AutoGen AgentChat tools
-- **[Temporal](./temporal)** — Durable workflow authorization
-- **[MCP](./mcp)** — Model Context Protocol client & server verification
-- **[A2A](./a2a)** — Inter-agent delegation
-- **[FastAPI](./fastapi)** — Zero-boilerplate API protection
-- **[Security](./security)** — Threat model, best practices
+- **[Going to Production](./production-guide)** — enforcement modes, gradual rollout, key management ([Tenuo Cloud](https://cloud.tenuo.ai) or self-hosted)
+- **[AI Agent Patterns](./ai-agents)** — P-LLM/Q-LLM architecture, prompt injection defense
+- **[Concepts](./concepts)** — threat model, core invariants, why warrant-based auth
+- **[Constraint Types](./constraints)** — `Subpath`, `Pattern`, `Range`, `UrlSafe`, `Exact`, and more
+- **[Security Model](./security)** — full threat model, PoP mechanics, delegation chain verification
+- **[API Reference](./api-reference)** — low-level `Warrant`, `SigningKey`, `BoundWarrant` API


### PR DESCRIPTION
## Summary

- **Quickstart restructured** (660 → 154 lines): stripped to intro, install, copy-paste demo, framework routing table with teasers (OpenAI, LangGraph, MCP, Temporal), debugging tips, and next-steps links. No more embedded 200+ line framework code blocks or premature production patterns.
- **Production guide** (`docs/production-guide.md`, new): captures enforcement modes, gradual rollout, key management with Tenuo Cloud recommendation, self-hosted patterns, low-level API, and combining integrations.
- **Temporal added to compatibility matrix CI**: dedicated job testing `temporalio==1.23.0` (minimum) and latest, with Rust toolchain, test-server cache, adapter unit tests, live + replay-safety tests, and deprecation-warning checks. Auto-opens GitHub issue on failure.
- **Compatibility matrix docs updated**: Temporal row filled in with test coverage details, Known Issues section, Watching list, and changelog link.

## Test plan

- [ ] Verify quickstart copy-paste example still works
- [ ] Verify production-guide links resolve correctly
- [ ] Trigger compatibility matrix workflow manually to validate Temporal job runs on both minimum and latest
- [ ] Confirm existing matrix jobs (openai, crewai, autogen, langchain, langgraph) are unaffected