### PR TITLE
fix: close security gaps in adapter integrations and add shotgun tests

### DIFF
--- a/tenuo-python/tenuo/_enforcement.py
+++ b/tenuo-python/tenuo/_enforcement.py
@@ -804,6 +804,20 @@ def enforce_tool_call(
                 # Build the full chain: [root, ..., parents, leaf]
                 # warrant_chain contains parent warrants in root-first order.
                 full_chain = list(warrant_chain or []) + [bound_warrant.warrant]
+
+                # Pre-check expiry so we don't conflate trust failures with
+                # expired warrants inside the except handler.
+                if bound_warrant.warrant.is_expired():
+                    return EnforcementResult(
+                        allowed=False,
+                        tool=tool_name,
+                        arguments=tool_args,
+                        denial_reason="Warrant has expired",
+                        constraint_violated=None,
+                        error_type="expired",
+                        warrant_id=warrant_id,
+                    )
+
                 _chain_result = authorizer.check_chain(
                     full_chain,
                     tool_name,
@@ -814,9 +828,6 @@ def enforce_tool_call(
             except Exception as chain_err:
                 denial_reason = str(chain_err)
                 error_type = "authorization_failed"
-                if bound_warrant.warrant.is_expired():
-                    denial_reason = "Warrant has expired"
-                    error_type = "expired"
                 return EnforcementResult(
                     allowed=False,
                     tool=tool_name,
@@ -1078,6 +1089,14 @@ async def enforce_tool_call_async(
                 raise ConfigurationError("authorizer required for verify_mode='verify'")
             try:
                 full_chain = list(warrant_chain or []) + [bound_warrant.warrant]
+
+                if bound_warrant.warrant.is_expired():
+                    return EnforcementResult(
+                        allowed=False, tool=tool_name, arguments=tool_args,
+                        denial_reason="Warrant has expired", constraint_violated=None,
+                        error_type="expired", warrant_id=warrant_id,
+                    )
+
                 _chain_result = authorizer.check_chain(
                     full_chain, tool_name, tool_args,
                     signature=precomputed_signature, approvals=_gate_approvals or [],
@@ -1085,9 +1104,6 @@ async def enforce_tool_call_async(
             except Exception as chain_err:
                 denial_reason = str(chain_err)
                 error_type = "authorization_failed"
-                if bound_warrant.warrant.is_expired():
-                    denial_reason = "Warrant has expired"
-                    error_type = "expired"
                 return EnforcementResult(
                     allowed=False, tool=tool_name, arguments=tool_args,
                     denial_reason=denial_reason, constraint_violated=None,

--- a/tenuo-python/tenuo/autogen.py
+++ b/tenuo-python/tenuo/autogen.py
@@ -30,7 +30,7 @@ from typing import (
 )
 
 from ._builder import BaseGuardBuilder
-from ._enforcement import EnforcementResult, enforce_tool_call, handle_denial
+from ._enforcement import EnforcementResult, enforce_tool_call, enforce_tool_call_async, handle_denial
 from .config import resolve_trusted_roots
 from .exceptions import (
     AuthorizationDenied,
@@ -461,6 +461,59 @@ class _Guard:
         constraints = self._constraints.get(tool_name)
         _check_constraints(tool_name, constraints, auth_args)
 
+    async def _authorize_async(self, tool_name: str, auth_args: Dict[str, Any]) -> None:
+        """Async variant of _authorize — uses enforce_tool_call_async for Tier 2."""
+        if self._bound is not None:
+            result = await enforce_tool_call_async(
+                tool_name, auth_args, self._bound,
+                trusted_roots=resolve_trusted_roots(self._trusted_roots),
+                approval_handler=self._approval_handler,
+                approvals=self._approvals,
+            )
+
+            if self._control_plane is not None:
+                try:
+                    self._control_plane.emit_for_enforcement(result, chain_result=result.chain_result)
+                except Exception:
+                    logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
+
+            if not result.allowed:
+                from .exceptions import ConstraintResult, ExpiredError
+
+                if result.error_type == "expired":
+                    raise ExpiredError(result.denial_reason or "Warrant has expired")
+                elif result.error_type == "tool_not_allowed":
+                    raise ToolNotAuthorized(tool=tool_name)
+                elif result.error_type == "clearance_insufficient":
+                    raise AuthorizationDenied(
+                        tool=tool_name,
+                        constraint_results=[],
+                        reason=result.denial_reason or "Insufficient clearance",
+                    )
+                elif _is_tool_not_authorized(result.denial_reason or ""):
+                    raise ToolNotAuthorized(tool=tool_name)
+
+                constraint_results = []
+                if result.constraint_violated:
+                    constraint_results.append(
+                        ConstraintResult(
+                            name=result.constraint_violated,
+                            passed=False,
+                            constraint_repr="<see warrant>",
+                            value=auth_args.get(result.constraint_violated, "<unknown>"),
+                            explanation=result.denial_reason or "Constraint not satisfied",
+                        )
+                    )
+                raise AuthorizationDenied(
+                    tool=tool_name,
+                    constraint_results=constraint_results,
+                    reason=result.denial_reason or "Authorization denied",
+                )
+            return
+
+        constraints = self._constraints.get(tool_name)
+        _check_constraints(tool_name, constraints, auth_args)
+
     def _handle_denial(
         self,
         exc: Exception,
@@ -514,7 +567,7 @@ class _Guard:
         kwargs: Dict[str, Any],
     ) -> Any:
         try:
-            self._authorize(tool_name, auth_args)
+            await self._authorize_async(tool_name, auth_args)
         except (
             AuthorizationDenied,
             ConstraintViolation,

--- a/tenuo-python/tenuo/crewai.py
+++ b/tenuo-python/tenuo/crewai.py
@@ -501,12 +501,11 @@ class GuardBuilder(BaseGuardBuilder["GuardBuilder"]):
             .on_denial("raise")
             .build())
 
-        protected_tool = guard.protect(my_tool)
+        # Use as a CrewAI hook
+        hook = guard.as_hook()
 
-    Security Note:
-        By default, protect() returns a NEW tool, and the original is unchanged.
-        If you want to ensure the original cannot be used (preventing bypass),
-        use .seal(True) to destructively seal the original tool.
+        # Or authorize directly
+        result = guard.authorize(tool_name, args)
     """
 
     def __init__(self):
@@ -743,12 +742,10 @@ class CrewAIGuard:
                 result = guard._authorize(tool_name, args, agent_role=effective_role)
             except TenuoCrewAIError as e:
                 logger.info(f"[TENUO] BLOCKED {tool_name}: {e}")
-                report_unguarded_call(tool_name)
                 return False
 
             if result is not None:
                 logger.info(f"[TENUO] BLOCKED {tool_name}: {result.reason}")
-                report_unguarded_call(tool_name)
                 return False
 
             return None
@@ -807,12 +804,10 @@ class CrewAIGuard:
                 result = await guard._authorize_async(tool_name, args, agent_role=effective_role)
             except TenuoCrewAIError as e:
                 logger.info(f"[TENUO] BLOCKED {tool_name}: {e}")
-                report_unguarded_call(tool_name)
                 return False
 
             if result is not None:
                 logger.info(f"[TENUO] BLOCKED {tool_name}: {result.reason}")
-                report_unguarded_call(tool_name)
                 return False
 
             return None
@@ -1006,6 +1001,14 @@ class CrewAIGuard:
                 error = self._map_enforcement_error(enforcement, tool_name, args, reason)  # type: ignore[assignment]
                 return self._handle_denial(error, tool_name, args, agent_role)
 
+        elif self._warrant and not self._signing_key:
+            raise CrewAIConfigurationError(
+                f"Warrant is configured but signing_key is missing — Tier 2 PoP "
+                f"authorization cannot proceed for tool '{tool_name}'. "
+                f"Either provide a signing_key via .with_warrant(warrant, key) "
+                f"or remove the warrant to use Tier 1 only."
+            )
+
         # Authorization granted
         self._emit_audit(tool_name, args, "ALLOW", "Authorized", agent_role=agent_role)
         logger.debug(f"Authorized {tool_name}")
@@ -1088,6 +1091,14 @@ class CrewAIGuard:
                 reason = enforcement.denial_reason or "Authorization denied"
                 error = self._map_enforcement_error(enforcement, tool_name, args, reason)  # type: ignore[assignment]
                 return self._handle_denial(error, tool_name, args, agent_role)
+
+        elif self._warrant and not self._signing_key:
+            raise CrewAIConfigurationError(
+                f"Warrant is configured but signing_key is missing — Tier 2 PoP "
+                f"authorization cannot proceed for tool '{tool_name}'. "
+                f"Either provide a signing_key via .with_warrant(warrant, key) "
+                f"or remove the warrant to use Tier 1 only."
+            )
 
         # Authorization granted
         self._emit_audit(tool_name, args, "ALLOW", "Authorized", agent_role=agent_role)
@@ -1692,7 +1703,7 @@ class UnguardedToolError(TenuoCrewAIError):
         super().__init__(
             f"Strict mode violation in step '{step_name}': "
             f"{len(tools)} unguarded tool call(s) detected: {', '.join(tools)}. "
-            "Ensure all tools called within a guarded step are protected."
+            "Ensure all tools called within a guarded step are covered by the guard."
         )
 
 
@@ -1724,7 +1735,11 @@ def is_strict_mode() -> bool:
 
 
 def report_unguarded_call(tool_name: str) -> None:
-    """Report an unguarded tool call in strict mode."""
+    """Report a tool call that bypassed Tenuo enforcement entirely.
+
+    This should only be called for calls that the guard never evaluated —
+    NOT for calls that were evaluated and denied (those are guarded).
+    """
     if is_strict_mode():
         calls = _unguarded_calls.get()
         calls.append(tool_name)

--- a/tenuo-python/tenuo/google_adk/guard.py
+++ b/tenuo-python/tenuo/google_adk/guard.py
@@ -66,7 +66,7 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
-from tenuo._enforcement import EnforcementResult, enforce_tool_call
+from tenuo._enforcement import EnforcementResult, enforce_tool_call, enforce_tool_call_async
 from tenuo.config import resolve_trusted_roots
 
 if TYPE_CHECKING:
@@ -553,14 +553,97 @@ class TenuoGuard:
         """
         Async ADK before_tool_callback.
 
-        Delegates to the synchronous :meth:`before_tool` — warrant verification
-        is pure CPU/memory work that does not require async execution.
+        Uses ``enforce_tool_call_async`` for Tier 2 warrant authorization,
+        allowing async approval handlers to be awaited natively.
         Register this as ``before_tool_callback`` on async ADK agents.
 
         Returns:
             None: Allow tool execution
             Dict: Skip tool, use this as result (denial message)
         """
+        import time
+        start_ns = time.perf_counter_ns()
+
+        skill_name = self._skill_map.get(tool.name, tool.name)
+        validation_args = self._remap_args(skill_name, args)
+
+        warrant = self._get_warrant(tool_context)
+        use_direct_constraints = warrant is None and (self._constraints or self._allow_tools)
+
+        if warrant is None and not use_direct_constraints:
+            return self._deny("No warrant or constraints available", tool.name, args,
+                              start_ns=start_ns)
+
+        if warrant is not None and self._require_pop:
+            if self._signing_key is None:
+                raise MissingSigningKeyError()
+
+            try:
+                bound_warrant = warrant.bind(self._signing_key)
+
+                result = await enforce_tool_call_async(
+                    tool_name=skill_name,
+                    tool_args=validation_args,
+                    bound_warrant=bound_warrant,
+                    trusted_roots=resolve_trusted_roots(self._trusted_roots),
+                    approval_handler=self._approval_handler,
+                    approvals=self._approvals,
+                )
+
+                if self._control_plane is not None:
+                    latency_us = (time.perf_counter_ns() - start_ns) // 1000
+                    _warrant_stack = None
+                    try:
+                        from tenuo_core import encode_warrant_stack
+                        _warrant_stack = encode_warrant_stack([bound_warrant.warrant])
+                    except Exception:
+                        logger.warning(
+                            "encode_warrant_stack failed; warrant stack will be missing "
+                            "from control plane event for '%s'",
+                            skill_name,
+                            exc_info=True,
+                        )
+                    try:
+                        self._control_plane.emit_for_enforcement(
+                            result, chain_result=result.chain_result,
+                            latency_us=latency_us,
+                            warrant_stack_override=_warrant_stack,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Control plane emission failed for '%s'; audit event lost",
+                            skill_name,
+                            exc_info=True,
+                        )
+
+                if not result.allowed:
+                    if result.error_type == "expired":
+                        return self._deny("Warrant expired", tool.name, args,
+                                          start_ns=start_ns, _cp_already_emitted=True)
+                    else:
+                        reason, constraint_param, constraint = self._get_denial_info(warrant, skill_name, validation_args)
+                        return self._deny(
+                            f"Authorization failed: {reason}",
+                            tool.name,
+                            args,
+                            constraint_param=constraint_param,
+                            constraint=constraint,
+                            start_ns=start_ns,
+                            _cp_already_emitted=True,
+                        )
+
+                self._audit("tool_allowed", tool.name, args, warrant)
+                return None
+
+            except AttributeError as e:
+                logger.warning(f"Warrant missing required methods: {e}")
+                return self._deny(
+                    f"Warrant type doesn't support PoP: {type(warrant).__name__}",
+                    tool.name,
+                    args,
+                )
+
+        # Tier 1 path is CPU-only, safe to delegate to sync
         return self.before_tool(tool, args, tool_context)
 
     def after_tool(

--- a/tenuo-python/tenuo/langchain.py
+++ b/tenuo-python/tenuo/langchain.py
@@ -284,7 +284,10 @@ class TenuoTool(BaseTool):  # type: ignore[misc]
         elif hasattr(self.wrapped, "_arun"):
             return await self.wrapped._arun(*args, **kwargs)
         elif hasattr(self.wrapped, "_run"):
-            return self.wrapped._run(*args, **kwargs)
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                None, lambda: self.wrapped._run(*args, **kwargs)
+            )
         else:
             result = self.wrapped(*args, **kwargs)
             if asyncio.iscoroutine(result):

--- a/tenuo-python/tenuo/langgraph.py
+++ b/tenuo-python/tenuo/langgraph.py
@@ -851,7 +851,8 @@ def require_warrant(
     Example:
         def my_node(state, config=None):
             bw = require_warrant(state, config)
-            if bw.authorize("search", {"query": "test"}):
+            result = bw.validate("search", {"query": "test"})
+            if result.success:
                 ...
     """
     return _get_bound_warrant(state, config)

--- a/tenuo-python/tenuo/mcp/client.py
+++ b/tenuo-python/tenuo/mcp/client.py
@@ -13,7 +13,7 @@ import time
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any, Callable, Dict, List, Literal, Optional
 
-from .._enforcement import EnforcementResult, enforce_tool_call
+from .._enforcement import EnforcementResult, enforce_tool_call_async
 from ..config import is_configured
 from ..decorators import key_scope, warrant_scope
 from ..exceptions import (
@@ -495,8 +495,8 @@ class SecureMCPClient:
                     exc_info=True,
                 )
 
-        # Use unified enforcement logic
-        enforcement: EnforcementResult = enforce_tool_call(
+        # Use unified enforcement logic (async for approval handler support)
+        enforcement: EnforcementResult = await enforce_tool_call_async(
             tool_name=tool_name,
             tool_args=extraction_args,
             bound_warrant=bound_warrant,
@@ -521,7 +521,6 @@ class SecureMCPClient:
             )
             return ValidationResult.fail(
                 reason=enforcement.denial_reason or "Authorization denied",
-                # TODO: enforcement module could provide suggestions in the future
                 suggestions=[],
             )
 
@@ -704,7 +703,7 @@ class SecureMCPClient:
                     "Use `with warrant_scope(w), key_scope(k):` or set warrant_context=False."
                 )
             bw = BoundWarrant(w, k)
-            result = enforce_tool_call(
+            result = await enforce_tool_call_async(
                 tool_name=tool_name,
                 tool_args=arguments,
                 bound_warrant=bw,
@@ -780,7 +779,7 @@ class SecureMCPClient:
             k = key_scope()
             if w is not None and k is not None:
                 bw = BoundWarrant(w, k)
-                result = enforce_tool_call(
+                result = await enforce_tool_call_async(
                     tool_name=tool_name,
                     tool_args=auth_args,
                     bound_warrant=bw,
@@ -799,6 +798,18 @@ class SecureMCPClient:
                     "MCP tool authorised: %s (warrant=%s)",
                     tool_name,
                     getattr(w, "id", None),
+                )
+            elif w is not None or k is not None:
+                raise ConfigurationError(
+                    f"Incomplete authorization context for MCP tool '{tool_name}': "
+                    f"warrant={'set' if w else 'missing'}, "
+                    f"signing_key={'set' if k else 'missing'}. "
+                    f"Both must be provided via warrant_scope/key_scope."
+                )
+            else:
+                logger.warning(
+                    "MCP tool '%s' executed without authorization context "
+                    "(no warrant/key in scope)", tool_name,
                 )
 
             if allowed_keys is not None:

--- a/tenuo-python/tenuo/openai.py
+++ b/tenuo-python/tenuo/openai.py
@@ -133,7 +133,7 @@ from tenuo.constraints import Subpath, UrlSafe
 check_openai_compat()
 
 # Import shared enforcement logic (after version check)
-from tenuo._enforcement import DenialPolicy, EnforcementResult, enforce_tool_call, handle_denial  # noqa: E402
+from tenuo._enforcement import DenialPolicy, EnforcementResult, enforce_tool_call, enforce_tool_call_async, handle_denial  # noqa: E402
 from tenuo.config import resolve_trusted_roots  # noqa: E402
 
 logger = logging.getLogger("tenuo.openai")
@@ -604,6 +604,81 @@ def verify_tool_call(
                 )
 
 
+async def verify_tool_call_async(
+    tool_name: str,
+    arguments: Dict[str, Any],
+    allow_tools: Optional[List[str]],
+    deny_tools: Optional[List[str]],
+    constraints: Optional[Dict[str, Dict[str, Constraint]]],
+    warrant: Optional[Warrant] = None,
+    signing_key: Optional[SigningKey] = None,
+    trusted_roots: Optional[list] = None,
+    approval_handler: Optional[Any] = None,
+    approvals: Optional[list] = None,
+) -> None:
+    """Async variant of verify_tool_call — uses enforce_tool_call_async for Tier 2.
+
+    Required for async streaming paths so approval handlers can be awaited.
+    See verify_tool_call for full documentation.
+    """
+    if warrant is not None:
+        if signing_key is None:
+            raise MissingSigningKey()
+
+        bound_warrant = warrant.bind(signing_key)
+
+        result = await enforce_tool_call_async(
+            tool_name=tool_name,
+            tool_args=arguments,
+            bound_warrant=bound_warrant,
+            trusted_roots=resolve_trusted_roots(trusted_roots),
+            approval_handler=approval_handler,
+            approvals=approvals,
+        )
+
+        if not result.allowed:
+            if result.error_type == "expired":
+                raise WarrantDenied(tool_name, "warrant expired")
+            else:
+                raise WarrantDenied(tool_name, result.denial_reason or "not authorized by warrant")
+
+    if deny_tools and tool_name in deny_tools:
+        raise ToolDenied(tool_name, "Tool is in denylist")
+
+    if allow_tools is not None and tool_name not in allow_tools:
+        raise ToolDenied(tool_name, "Tool not in allowlist")
+
+    if warrant is None and constraints and tool_name in constraints:
+        tool_constraints = constraints[tool_name]
+        allow_unknown = tool_constraints.get("_allow_unknown", False)
+
+        for arg_name, value in arguments.items():
+            try:
+                if arg_name in tool_constraints:
+                    constraint = tool_constraints[arg_name]
+                    if arg_name.startswith("_"):
+                        continue
+                    type_mismatch, reason = _check_type_compatibility(constraint, value)
+                    if type_mismatch:
+                        raise OpenAIConstraintViolation(
+                            tool_name, arg_name, value, constraint, type_mismatch=True, reason=reason
+                        )
+                    if not check_constraint(constraint, value):
+                        raise OpenAIConstraintViolation(tool_name, arg_name, value, constraint)
+                elif not allow_unknown:
+                    raise OpenAIConstraintViolation(
+                        tool_name, arg_name, value,
+                        constraint=Wildcard(),
+                        reason=f"Unknown argument '{arg_name}' - not in constraints",
+                    )
+            except OpenAIConstraintViolation:
+                raise
+            except Exception as e:
+                raise OpenAIConstraintViolation(
+                    tool_name, arg_name, value, constraint=Wildcard(), reason=f"internal validation error: {e}"
+                )
+
+
 def _check_type_compatibility(constraint: Constraint, value: Any) -> tuple:
     """Check if value type is compatible with constraint.
 
@@ -1035,6 +1110,7 @@ class GuardedCompletions:
         """Async buffer-verify-emit pattern for streaming responses.
 
         SECURITY: Same TOCTOU protection as sync version.
+        Uses verify_tool_call_async for async approval handler support.
         """
         buffers: Dict[int, ToolCallBuffer] = {}
         pending_chunks: List[Any] = []
@@ -1062,7 +1138,7 @@ class GuardedCompletions:
         for index, buffer in buffers.items():
             try:
                 arguments = buffer.get_arguments()
-                verify_tool_call(
+                await verify_tool_call_async(
                     buffer.name,
                     arguments,
                     self._allow_tools,
@@ -2162,7 +2238,7 @@ class TenuoToolGuardrail:
         violations = []
         for tool_name, arguments in tool_calls:
             try:
-                verify_tool_call(
+                await verify_tool_call_async(
                     tool_name,
                     arguments,
                     self.allow_tools,

--- a/tenuo-python/tests/property/test_adapter_invariants.py
+++ b/tenuo-python/tests/property/test_adapter_invariants.py
@@ -1,0 +1,548 @@
+"""Property tests for adapter behavioral invariants.
+
+These tests verify security-critical properties across ALL framework adapters.
+They catch the class of bugs that existing structural tests missed:
+
+1. Strict mode semantics: denied calls must NOT be reported as unguarded
+2. Async enforcement parity: every adapter async path must use
+   enforce_tool_call_async — using the sync variant in async code can block
+   the event loop and break async approval handlers
+3. Tier 2 routing: every adapter with warrant support must actually call
+   enforce_tool_call (sync) or enforce_tool_call_async (async)
+4. Sync-fallback in async paths must not block the event loop
+5. Docstring accuracy: no references to nonexistent API methods
+
+Security rationale: if an adapter's async path silently falls back to sync
+enforcement, async approval handlers will never fire — meaning approval gates
+can be bypassed by using the async client.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+from hypothesis import given, settings
+
+from tenuo._enforcement import EnforcementResult
+
+from .strategies import st_warrant_bundle
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_method_source(module_path: str, method_name: str) -> str | None:
+    """Extract the source of a specific method from a module via AST."""
+    try:
+        mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+    except ImportError:
+        return None
+
+    source = inspect.getsource(mod)
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == method_name:
+                return ast.get_source_segment(source, node)
+    return None
+
+
+def _has_bare_sync_enforce(method_source: str) -> bool:
+    """Check if source calls enforce_tool_call (sync) outside a comment."""
+    for line in method_source.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if "enforce_tool_call(" in stripped and "enforce_tool_call_async" not in stripped:
+            return True
+    return False
+
+
+# ==========================================================================
+# 1. CrewAI strict mode: denied != unguarded
+# ==========================================================================
+
+
+class TestStrictModeSemantic:
+    """Denied tool calls are guarded (the guard evaluated them).
+
+    The ``report_unguarded_call`` function should ONLY be called for calls
+    that bypass the guard entirely, never for calls that the guard
+    evaluated and denied.
+    """
+
+    @given(data=st_warrant_bundle())
+    @settings(max_examples=15, deadline=None)
+    def test_denied_call_not_reported_as_unguarded(self, data):
+        """Sync hook: denied tool must NOT appear in unguarded list."""
+        _, key, tool, _ = data
+        try:
+            from tenuo.crewai import (
+                GuardBuilder,
+                _guarded_zone,
+                get_unguarded_calls,
+            )
+        except ImportError:
+            pytest.skip("crewai not installed")
+
+        guard = GuardBuilder().allow("only_this_tool").build()
+
+        if tool == "only_this_tool":
+            return
+
+        with _guarded_zone(guard, strict=True):
+            hook = guard._create_hook()
+            ctx = MagicMock()
+            ctx.tool_name = tool
+            ctx.tool_input = {}
+            ctx.agent = None
+
+            result = hook(ctx)
+            assert result is False, "Unlisted tool should be denied"
+
+            unguarded = get_unguarded_calls()
+            assert tool not in unguarded, (
+                f"Denied tool '{tool}' was incorrectly reported as unguarded. "
+                "Denied means the guard evaluated it — it IS guarded."
+            )
+
+    @given(data=st_warrant_bundle())
+    @settings(max_examples=15)
+    def test_denied_async_hook_not_reported_as_unguarded(self, data):
+        """Async hook: denied tool must NOT appear in unguarded list."""
+        _, key, tool, _ = data
+        try:
+            from tenuo.crewai import (
+                GuardBuilder,
+                _guarded_zone,
+                get_unguarded_calls,
+            )
+        except ImportError:
+            pytest.skip("crewai not installed")
+
+        guard = GuardBuilder().allow("only_this_tool").build()
+
+        if tool == "only_this_tool":
+            return
+
+        with _guarded_zone(guard, strict=True):
+            async_hook = guard._create_async_hook()
+            ctx = MagicMock()
+            ctx.tool_name = tool
+            ctx.tool_input = {}
+            ctx.agent = None
+
+            result = asyncio.run(async_hook(ctx))
+            assert result is False
+
+            unguarded = get_unguarded_calls()
+            assert tool not in unguarded, (
+                f"Denied tool '{tool}' was incorrectly reported as unguarded in async hook"
+            )
+
+
+# ==========================================================================
+# 2. Async enforcement parity — ALL adapters
+# ==========================================================================
+
+
+_ASYNC_ENFORCEMENT_CASES = [
+    # (module_path, async_method_name, must_contain)
+    # -- LangChain --
+    ("tenuo.langchain", "_acheck_authorization", "enforce_tool_call_async"),
+    ("tenuo.langchain", "_run_enforcement_async", "enforce_tool_call_async"),
+    # -- CrewAI --
+    ("tenuo.crewai", "_authorize_async", "enforce_tool_call_async"),
+    # -- LangGraph --
+    ("tenuo.langgraph", "_authorize_tool_request_async", "enforce_tool_call_async"),
+    # -- AutoGen --
+    ("tenuo.autogen", "_authorize_async", "enforce_tool_call_async"),
+    # -- Google ADK --
+    ("tenuo.google_adk.guard", "async_before_tool", "enforce_tool_call_async"),
+    # -- MCP Client --
+    ("tenuo.mcp.client", "validate_tool", "enforce_tool_call_async"),
+]
+
+_NO_SYNC_ENFORCE_CASES = [
+    # These async methods must NOT call the sync enforce_tool_call directly.
+    ("tenuo.langchain", "_run_enforcement_async"),
+    ("tenuo.crewai", "_authorize_async"),
+    ("tenuo.langgraph", "_authorize_tool_request_async"),
+    ("tenuo.autogen", "_authorize_async"),
+    ("tenuo.google_adk.guard", "async_before_tool"),
+    ("tenuo.mcp.client", "validate_tool"),
+]
+
+
+class TestAsyncEnforcementParity:
+    """Adapters with async code paths must use enforce_tool_call_async.
+
+    Using the sync variant in an async context:
+    - Blocks the event loop
+    - Breaks async approval handlers (approval gates silently skipped)
+    - Makes concurrent warrant enforcement sequential
+    """
+
+    @pytest.mark.parametrize(
+        "module_path,async_method,expected_call",
+        _ASYNC_ENFORCEMENT_CASES,
+        ids=[f"{m.split('.')[-1]}.{f}" for m, f, _ in _ASYNC_ENFORCEMENT_CASES],
+    )
+    def test_async_method_uses_async_enforcement(
+        self, module_path, async_method, expected_call
+    ):
+        """Async methods must call the async enforcement function."""
+        method_source = _get_method_source(module_path, async_method)
+        if method_source is None:
+            pytest.skip(f"{module_path}.{async_method} not found")
+
+        assert expected_call in method_source, (
+            f"{module_path}.{async_method} must call {expected_call}, "
+            f"not the sync variant. Sync enforcement in async code blocks "
+            f"the event loop and breaks async approval handlers."
+        )
+
+    @pytest.mark.parametrize(
+        "module_path,async_method",
+        _NO_SYNC_ENFORCE_CASES,
+        ids=[f"{m.split('.')[-1]}.{f}" for m, f in _NO_SYNC_ENFORCE_CASES],
+    )
+    def test_async_method_does_not_call_sync_enforce(
+        self, module_path, async_method
+    ):
+        """Async methods must NOT call the sync enforce_tool_call directly."""
+        method_source = _get_method_source(module_path, async_method)
+        if method_source is None:
+            pytest.skip(f"{module_path}.{async_method} not found")
+
+        assert not _has_bare_sync_enforce(method_source), (
+            f"{module_path}.{async_method} calls sync enforce_tool_call — "
+            f"must use enforce_tool_call_async. Sync enforcement in async "
+            f"context blocks the event loop and bypasses async approval gates."
+        )
+
+
+# ==========================================================================
+# 3. Tier 2 routing — all adapters call enforce_tool_call
+# ==========================================================================
+
+
+class TestLangChainTier2:
+    """LangChain TenuoTool must route through enforce_tool_call for Tier 2."""
+
+    @given(data=st_warrant_bundle())
+    @settings(max_examples=15)
+    def test_bound_warrant_calls_enforce(self, data):
+        warrant, key, tool, _ = data
+        try:
+            from tenuo.langchain import TenuoTool
+        except ImportError:
+            pytest.skip("langchain not installed")
+
+        bound = warrant.bind(key)
+
+        with patch("tenuo.langchain.enforce_tool_call") as spy:
+            spy.return_value = EnforcementResult(
+                allowed=True, tool=tool, arguments={},
+            )
+            try:
+                wrapped_tool = MagicMock()
+                wrapped_tool.name = tool
+                wrapped_tool.description = "test"
+                wrapped_tool.func = lambda **kw: "ok"
+                wrapped_tool.args_schema = None
+
+                tt = TenuoTool(
+                    wrapped_tool,
+                    bound_warrant=bound,
+                    trusted_roots=[key.public_key],
+                )
+                tt._run()
+            except Exception:
+                pass
+            spy.assert_called()
+
+    @given(data=st_warrant_bundle())
+    @settings(max_examples=15)
+    def test_bound_warrant_async_calls_enforce_async(self, data):
+        warrant, key, tool, _ = data
+        try:
+            from tenuo.langchain import TenuoTool
+        except ImportError:
+            pytest.skip("langchain not installed")
+
+        bound = warrant.bind(key)
+
+        with patch("tenuo.langchain.enforce_tool_call_async") as spy:
+            spy.return_value = EnforcementResult(
+                allowed=True, tool=tool, arguments={},
+            )
+
+            async def run():
+                wrapped_tool = MagicMock()
+                wrapped_tool.name = tool
+                wrapped_tool.description = "test"
+                wrapped_tool.coroutine = None
+                wrapped_tool.func = lambda **kw: "ok"
+                wrapped_tool.args_schema = None
+
+                tt = TenuoTool(
+                    wrapped_tool,
+                    bound_warrant=bound,
+                    trusted_roots=[key.public_key],
+                )
+                try:
+                    await tt._arun()
+                except Exception:
+                    pass
+
+            asyncio.run(run())
+            spy.assert_called()
+
+
+class TestOpenAITier2Async:
+    """OpenAI adapter async paths (acreate, _guard_stream_async) must use
+    enforce_tool_call_async inside verify_tool_call, not sync enforcement."""
+
+    def test_acreate_path_eventually_calls_async_enforce(self):
+        """The async create path must not call sync enforce_tool_call."""
+        try:
+            mod = __import__("tenuo.openai", fromlist=["openai"])
+        except ImportError:
+            pytest.skip("openai not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "_guard_stream_async":
+                method_source = ast.get_source_segment(source, node) or ""
+                if "verify_tool_call" in method_source:
+                    # Acceptable if it calls verify_tool_call_async
+                    if "verify_tool_call_async" not in method_source:
+                        # Check if verify_tool_call itself is async-safe
+                        vtc_source = _get_method_source("tenuo.openai", "verify_tool_call_async")
+                        if vtc_source is None:
+                            pytest.fail(
+                                "OpenAI._guard_stream_async calls sync verify_tool_call. "
+                                "Need verify_tool_call_async for async paths."
+                            )
+
+
+class TestAutoGenTier2Async:
+    """AutoGen _execute_call_async must use async enforcement."""
+
+    def test_execute_call_async_uses_async_authorize(self):
+        """_execute_call_async must call _authorize_async, not _authorize."""
+        method_source = _get_method_source("tenuo.autogen", "_execute_call_async")
+        if method_source is None:
+            pytest.skip("tenuo.autogen._execute_call_async not found")
+
+        assert "_authorize_async" in method_source, (
+            "AutoGen._execute_call_async calls sync _authorize — must use "
+            "_authorize_async for async enforcement and approval handlers"
+        )
+
+
+class TestGoogleADKTier2Async:
+    """Google ADK async_before_tool must not simply delegate to sync before_tool."""
+
+    def test_async_before_tool_has_own_enforcement(self):
+        """async_before_tool must do its own async enforcement, not just
+        delegate to the sync before_tool."""
+        method_source = _get_method_source("tenuo.google_adk.guard", "async_before_tool")
+        if method_source is None:
+            pytest.skip("tenuo.google_adk.guard.async_before_tool not found")
+
+        delegates_to_sync = "self.before_tool(" in method_source and "enforce_tool_call_async" not in method_source
+        if delegates_to_sync:
+            pytest.fail(
+                "Google ADK async_before_tool delegates to sync before_tool "
+                "without async enforcement. Async approval handlers will never fire."
+            )
+
+
+class TestMCPClientTier2Async:
+    """MCP SecureMCPClient async methods must use enforce_tool_call_async."""
+
+    @pytest.mark.parametrize("method", ["validate_tool", "call_tool"])
+    def test_async_method_uses_async_enforce(self, method):
+        method_source = _get_method_source("tenuo.mcp.client", method)
+        if method_source is None:
+            pytest.skip(f"tenuo.mcp.client.{method} not found")
+
+        if "enforce_tool_call" in method_source:
+            assert "enforce_tool_call_async" in method_source, (
+                f"MCP client.{method} (async def) calls sync enforce_tool_call — "
+                f"must use enforce_tool_call_async"
+            )
+
+
+# ==========================================================================
+# 4. Sync fallback in async paths
+# ==========================================================================
+
+
+class TestAsyncSyncFallback:
+    """When async methods fall back to calling sync code, they must offload
+    via run_in_executor to avoid blocking the event loop."""
+
+    def test_langchain_arun_sync_fallback_uses_executor(self):
+        """LangChain _arun calling wrapped._run should go through run_in_executor."""
+        try:
+            mod = __import__("tenuo.langchain", fromlist=["langchain"])
+        except ImportError:
+            pytest.skip("langchain not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "_arun":
+                method_source = ast.get_source_segment(source, node) or ""
+                if "self.wrapped._run" in method_source:
+                    assert "run_in_executor" in method_source, (
+                        "_arun calls self.wrapped._run without run_in_executor — "
+                        "this blocks the event loop when the wrapped tool is sync-only"
+                    )
+                break
+
+
+# ==========================================================================
+# 5. Docstring accuracy — all builders/entry points
+# ==========================================================================
+
+
+class TestDocstringAccuracy:
+    """Adapter docstrings must not reference methods that don't exist.
+
+    Phantom method references in docstrings mislead users into calling
+    APIs that raise AttributeError. This is especially dangerous for
+    security-critical code where a user might skip authorization
+    because the documented method doesn't exist.
+    """
+
+    @pytest.mark.parametrize("module_path,class_name,forbidden_methods", [
+        ("tenuo.crewai", "GuardBuilder", [".protect(", ".seal("]),
+    ])
+    def test_no_phantom_methods_in_docstring(
+        self, module_path, class_name, forbidden_methods
+    ):
+        """Class docstrings must not reference methods that don't exist."""
+        try:
+            mod = __import__(module_path, fromlist=[class_name])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        cls = getattr(mod, class_name)
+        docstring = cls.__doc__ or ""
+
+        existing_methods = {
+            name for name in dir(cls)
+            if callable(getattr(cls, name, None)) and not name.startswith("__")
+        }
+
+        for forbidden in forbidden_methods:
+            method_name = forbidden.strip(".").strip("(")
+            if forbidden in docstring:
+                assert method_name in existing_methods, (
+                    f"{class_name} docstring references {forbidden} "
+                    f"but no '{method_name}' method exists on the class"
+                )
+
+    def test_langgraph_require_warrant_no_phantom_authorize(self):
+        """LangGraph require_warrant docstring must not reference BoundWarrant.authorize()."""
+        try:
+            from tenuo.langgraph import require_warrant
+        except ImportError:
+            pytest.skip("langgraph not installed")
+
+        docstring = require_warrant.__doc__ or ""
+
+        if "bw.authorize(" in docstring or "bound.authorize(" in docstring:
+            from tenuo.bound_warrant import BoundWarrant
+            assert hasattr(BoundWarrant, "authorize"), (
+                "require_warrant docstring references bw.authorize() but "
+                "BoundWarrant has no authorize() method — users will get "
+                "AttributeError following the example"
+            )
+
+    def test_all_builders_reference_existing_methods(self):
+        """Scan all GuardBuilder subclasses for phantom method references in docstrings."""
+        phantom_refs = {
+            ".protect(": "protect",
+            ".seal(": "seal",
+        }
+        builder_locations = [
+            ("tenuo.crewai", "GuardBuilder"),
+            ("tenuo.autogen", "GuardBuilder"),
+            ("tenuo.openai", "GuardBuilder"),
+        ]
+        for module_path, class_name in builder_locations:
+            try:
+                mod = __import__(module_path, fromlist=[class_name])
+            except ImportError:
+                continue
+
+            cls = getattr(mod, class_name, None)
+            if cls is None:
+                continue
+
+            docstring = cls.__doc__ or ""
+            existing = {
+                name for name in dir(cls)
+                if callable(getattr(cls, name, None)) and not name.startswith("__")
+            }
+
+            for ref, method_name in phantom_refs.items():
+                if ref in docstring and method_name not in existing:
+                    pytest.fail(
+                        f"{module_path}.{class_name} docstring references "
+                        f"'{ref}' but no '{method_name}' method exists"
+                    )
+
+
+# ==========================================================================
+# 6. Import parity — all adapters that import enforce_tool_call must also
+#    import enforce_tool_call_async if they have async methods
+# ==========================================================================
+
+
+class TestImportParity:
+    """If a module imports enforce_tool_call and has async def methods, it
+    must also import enforce_tool_call_async."""
+
+    @pytest.mark.parametrize("module_path", [
+        "tenuo.langchain",
+        "tenuo.langgraph",
+        "tenuo.crewai",
+        "tenuo.autogen",
+        "tenuo.google_adk.guard",
+        "tenuo.mcp.client",
+    ])
+    def test_async_module_imports_async_enforce(self, module_path):
+        """Modules with async methods and sync enforce must also import async enforce."""
+        try:
+            mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        source = inspect.getsource(mod)
+
+        has_async_def = "async def " in source
+        has_sync_enforce = "enforce_tool_call" in source
+
+        if has_async_def and has_sync_enforce:
+            assert "enforce_tool_call_async" in source, (
+                f"{module_path} has async methods and imports enforce_tool_call "
+                f"but does NOT import enforce_tool_call_async. Async code paths "
+                f"will silently use sync enforcement, blocking the event loop "
+                f"and bypassing async approval handlers."
+            )

--- a/tenuo-python/tests/property/test_integration_shotguns.py
+++ b/tenuo-python/tests/property/test_integration_shotguns.py
@@ -1,0 +1,700 @@
+"""Property tests for deep integration security invariants.
+
+These tests catch security-critical patterns that go beyond structural checks:
+
+1. Partial config passthrough: warrant without signing_key (or vice versa)
+   must NOT silently skip Tier 2 and allow via Tier 1 only
+2. trusted_roots=[] vs None: empty list must not silently weaken trust
+3. Control plane emission: every enforce_tool_call site must emit CP events
+4. Error type conflation: expired warrants must not mask real trust failures
+5. CP exception swallowing: audit emission failures must be detectable
+6. ContextVar TOCTOU: warrant/key context must not leak across async tasks
+
+Security rationale: these are "integration shotguns" — patterns where partial
+misconfiguration or subtle semantic differences cause silent security weakening.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+
+import pytest
+from hypothesis import given, settings
+
+from tenuo import SigningKey, Warrant
+from tenuo._enforcement import enforce_tool_call
+from tenuo.config import resolve_trusted_roots
+
+from .strategies import st_warrant_bundle
+
+
+# ==========================================================================
+# 1. Partial config passthrough — warrant without key silently weakens
+# ==========================================================================
+
+
+class TestPartialConfigPassthrough:
+    """When warrant is set but signing_key is missing (or vice versa),
+    Tier 2 must not be silently skipped. Either fail-closed or warn loudly."""
+
+    def test_crewai_warrant_without_key_raises(self):
+        """CrewAI: warrant set + signing_key=None must raise ConfigurationError.
+
+        Previously this silently skipped Tier 2 and allowed via Tier 1 only.
+        Now it fails closed.
+        """
+        try:
+            from tenuo.crewai import CrewAIConfigurationError, GuardBuilder
+        except ImportError:
+            pytest.skip("crewai not installed")
+
+        key = SigningKey.generate()
+        warrant = Warrant.issue(
+            keypair=key,
+            capabilities={"read_file": {}},
+            ttl_seconds=3600,
+            holder=key.public_key,
+        )
+
+        guard = (
+            GuardBuilder()
+            .allow("read_file")
+            .with_warrant(warrant, key)
+            .build()
+        )
+        guard._signing_key = None
+
+        with pytest.raises(CrewAIConfigurationError, match="signing_key is missing"):
+            guard._authorize("read_file", {})
+
+    def test_crewai_async_same_partial_config_issue(self):
+        """Async _authorize_async has the same Tier 2 skip pattern."""
+        try:
+            from tenuo.crewai import CrewAIGuard
+        except ImportError:
+            pytest.skip("crewai not installed")
+
+        source = inspect.getsource(CrewAIGuard._authorize_async)
+        assert "if self._warrant and self._signing_key:" in source, (
+            "_authorize_async must have the same Tier 2 gating pattern"
+        )
+
+    def test_mcp_protected_tool_fails_on_partial_context(self):
+        """MCP protected_tool raises ConfigurationError when only one of
+        warrant/key is present in context (partial config)."""
+        try:
+            mod = __import__("tenuo.mcp.client", fromlist=["client"])
+        except ImportError:
+            pytest.skip("mcp not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "protected_tool":
+                fn_source = ast.get_source_segment(source, node) or ""
+                assert "ConfigurationError" in fn_source, (
+                    "MCP protected_tool must raise ConfigurationError when "
+                    "warrant or key is partially configured"
+                )
+                break
+
+    @pytest.mark.parametrize("module_path,method_name,pattern", [
+        ("tenuo.crewai", "_authorize", "if self._warrant and self._signing_key:"),
+        ("tenuo.crewai", "_authorize_async", "if self._warrant and self._signing_key:"),
+    ])
+    def test_tier2_gating_is_conjunctive(self, module_path, method_name, pattern):
+        """Tier 2 gating uses AND — both must be set. Document this risk."""
+        try:
+            mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == method_name:
+                    fn_source = ast.get_source_segment(source, node) or ""
+                    assert pattern in fn_source, (
+                        f"Expected conjunctive Tier 2 gate in {method_name}"
+                    )
+                    break
+
+    def test_openai_fails_closed_on_missing_signing_key(self):
+        """OpenAI raises MissingSigningKey when warrant set without key — correct."""
+        try:
+            mod = __import__("tenuo.openai", fromlist=["openai"])
+        except ImportError:
+            pytest.skip("openai not installed")
+
+        source = inspect.getsource(mod.verify_tool_call)
+        assert "MissingSigningKey" in source, (
+            "OpenAI verify_tool_call must raise MissingSigningKey when "
+            "warrant is provided without signing_key"
+        )
+
+    def test_adk_fails_closed_on_missing_signing_key(self):
+        """ADK raises MissingSigningKeyError when signing_key is None — correct."""
+        try:
+            mod = __import__("tenuo.google_adk.guard", fromlist=["guard"])
+        except ImportError:
+            pytest.skip("google_adk not installed")
+
+        source = inspect.getsource(mod.TenuoGuard.before_tool)
+        assert "MissingSigningKeyError" in source, (
+            "ADK before_tool must raise MissingSigningKeyError when "
+            "warrant+require_pop is set without signing_key"
+        )
+
+
+# ==========================================================================
+# 2. trusted_roots=[] vs None confusion
+# ==========================================================================
+
+
+class TestTrustedRootsSemantics:
+    """Empty trusted_roots=[] must not silently weaken trust validation."""
+
+    def test_resolve_trusted_roots_empty_list_does_not_fallback(self):
+        """resolve_trusted_roots([]) returns [] — does NOT fall back to global."""
+        result = resolve_trusted_roots([])
+        assert result == [], (
+            "resolve_trusted_roots([]) should return [] (not fall back to "
+            "global config). If this changes, adapters passing explicit "
+            "empty lists will silently accept self-signed warrants."
+        )
+
+    def test_resolve_trusted_roots_none_falls_back(self):
+        """resolve_trusted_roots(None) falls back to global config."""
+        # None should trigger fallback behavior
+        result = resolve_trusted_roots(None)
+        # Result is None (no global config) or a list (global config set)
+        assert result is None or isinstance(result, list)
+
+    @given(data=st_warrant_bundle())
+    @settings(max_examples=10, deadline=None)
+    def test_enforce_with_empty_roots_denies(self, data):
+        """enforce_tool_call with trusted_roots=[] should deny (no trusted issuers)."""
+        bound, _key, tool, args = (
+            data[0].bind(data[1]), data[1], data[2], data[3]
+        )
+        # Empty roots = trust nobody
+        result = enforce_tool_call(
+            tool, args, bound,
+            trusted_roots=[],
+        )
+        # The Rust Authorizer with empty roots should reject
+        # (no issuer can match an empty trust set)
+        assert result.allowed is False, (
+            "enforce_tool_call with trusted_roots=[] must deny — no issuer "
+            "can be trusted. If this passes, the Authorizer accepts warrants "
+            "without any trust anchor."
+        )
+
+    @pytest.mark.parametrize("module_path,method_or_fn", [
+        ("tenuo.crewai", "_authorize"),
+        ("tenuo.langchain", "_run_enforcement"),
+        ("tenuo.langgraph", "_authorize_tool_request"),
+        ("tenuo.google_adk.guard", "before_tool"),
+    ])
+    def test_adapters_pass_trusted_roots_to_enforcement(
+        self, module_path, method_or_fn
+    ):
+        """Every adapter must pass trusted_roots to enforce_tool_call."""
+        try:
+            mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == method_or_fn:
+                    fn_source = ast.get_source_segment(source, node) or ""
+                    if "enforce_tool_call" in fn_source:
+                        assert "trusted_roots" in fn_source, (
+                            f"{module_path}.{method_or_fn} calls enforce_tool_call "
+                            f"without passing trusted_roots"
+                        )
+                    break
+
+
+# ==========================================================================
+# 3. Control plane emission gaps
+# ==========================================================================
+
+
+class TestControlPlaneEmission:
+    """Every enforce_tool_call site must have a corresponding CP emission."""
+
+    @pytest.mark.parametrize("module_path,method_name", [
+        ("tenuo.crewai", "_authorize"),
+        ("tenuo.crewai", "_authorize_async"),
+        ("tenuo.langchain", "_emit_and_check"),
+        ("tenuo.autogen", "_authorize"),
+        ("tenuo.autogen", "_authorize_async"),
+        ("tenuo.google_adk.guard", "before_tool"),
+        ("tenuo.google_adk.guard", "async_before_tool"),
+    ])
+    def test_enforce_call_has_cp_emission(self, module_path, method_name):
+        """Methods calling enforce_tool_call must also emit to control plane.
+
+        Some adapters (LangChain) delegate CP emission to a helper method
+        called from the enforcement method — check the helper too.
+        """
+        try:
+            mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == method_name:
+                    fn_source = ast.get_source_segment(source, node) or ""
+                    if "enforce_tool_call" in fn_source:
+                        assert "emit_for_enforcement" in fn_source, (
+                            f"{module_path}.{method_name} calls enforce_tool_call "
+                            f"but has no emit_for_enforcement — audit events lost"
+                        )
+                    break
+
+    def test_openai_verify_tool_call_no_cp_emission(self):
+        """OpenAI verify_tool_call has no built-in CP emission — document this."""
+        try:
+            mod = __import__("tenuo.openai", fromlist=["openai"])
+        except ImportError:
+            pytest.skip("openai not installed")
+
+        source = inspect.getsource(mod.verify_tool_call)
+        if "emit_for_enforcement" not in source:
+            # This is expected — verify_tool_call is a low-level function,
+            # callers are responsible for CP emission
+            pass
+
+    @pytest.mark.parametrize("module_path,method_name", [
+        ("tenuo.mcp.client", "validate_tool"),
+        ("tenuo.mcp.client", "call_tool"),
+    ])
+    def test_mcp_async_methods_have_cp_emission(self, module_path, method_name):
+        """MCP async methods with enforcement must emit CP events."""
+        try:
+            mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == method_name:
+                    fn_source = ast.get_source_segment(source, node) or ""
+                    if "enforce_tool_call" in fn_source:
+                        assert "emit_for_enforcement" in fn_source or "_control_plane" in fn_source, (
+                            f"MCP {method_name} calls enforcement without CP emission"
+                        )
+                    break
+
+
+# ==========================================================================
+# 4. Error type conflation — expired masking trust failures
+# ==========================================================================
+
+
+class TestErrorTypeConflation:
+    """Enforcement must not conflate different failure types."""
+
+    def test_verify_path_checks_expiry_before_chain(self):
+        """In verify mode, expiry is checked BEFORE check_chain, so
+        an expired warrant gets error_type='expired' cleanly without
+        masking a trust failure inside the except handler."""
+        try:
+            mod = __import__("tenuo._enforcement", fromlist=["_enforcement"])
+        except ImportError:
+            pytest.skip("_enforcement not available")
+
+        source = inspect.getsource(mod.enforce_tool_call)
+        tree = ast.parse(source)
+
+        # Verify the pattern: is_expired() check appears OUTSIDE (before)
+        # the except handler in the verify path
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler):
+                handler_source = ast.get_source_segment(source, node)
+                if handler_source and "is_expired()" in handler_source:
+                    pytest.fail(
+                        "enforce_tool_call verify path still has is_expired() "
+                        "inside an except handler — error types will be conflated"
+                    )
+
+    def test_sign_path_does_not_conflate(self):
+        """Sign path should check expiry and trust separately."""
+        try:
+            mod = __import__("tenuo._enforcement", fromlist=["_enforcement"])
+        except ImportError:
+            pytest.skip("_enforcement not available")
+
+        source = inspect.getsource(mod.enforce_tool_call)
+        # Sign path checks expiry explicitly before Authorizer call
+        assert "is_expired()" in source, (
+            "enforce_tool_call should check warrant expiry"
+        )
+
+    @given(data=st_warrant_bundle())
+    @settings(max_examples=5, deadline=None)
+    def test_untrusted_issuer_not_labeled_expired(self, data):
+        """An untrusted issuer on a non-expired warrant must not get error_type='expired'."""
+        warrant, key, tool, args = data
+        bound = warrant.bind(key)
+        untrusted = SigningKey.generate()
+
+        result = enforce_tool_call(
+            tool, args, bound,
+            trusted_roots=[untrusted.public_key],
+        )
+        assert result.allowed is False
+        if result.error_type == "expired":
+            pytest.fail(
+                "Untrusted issuer was labeled as 'expired' — error type conflation. "
+                f"Warrant is NOT expired but error_type='{result.error_type}'"
+            )
+
+
+# ==========================================================================
+# 5. CP exception swallowing — audit emission failures are silent
+# ==========================================================================
+
+
+class TestCPExceptionSwallowing:
+    """Control plane emission failures must not silently lose audit events.
+
+    All adapters wrap emit_for_enforcement in try/except Exception.
+    This means a broken control plane = invisible security events.
+    """
+
+    @pytest.mark.parametrize("module_path,method_name", [
+        ("tenuo.crewai", "_authorize"),
+        ("tenuo.crewai", "_authorize_async"),
+        ("tenuo.langchain", "_emit_and_check"),
+        ("tenuo.autogen", "_authorize"),
+        ("tenuo.autogen", "_authorize_async"),
+        ("tenuo.google_adk.guard", "before_tool"),
+        ("tenuo.google_adk.guard", "async_before_tool"),
+    ])
+    def test_cp_emission_wrapped_in_try_except(self, module_path, method_name):
+        """CP emission is wrapped in try/except — document the audit loss risk."""
+        try:
+            mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == method_name:
+                    fn_source = ast.get_source_segment(source, node) or ""
+                    if "emit_for_enforcement" in fn_source:
+                        assert "except Exception" in fn_source or "except:" in fn_source, (
+                            f"{module_path}.{method_name} emit_for_enforcement "
+                            f"is NOT wrapped in try/except — good for crashing "
+                            f"but bad for availability"
+                        )
+                        assert "logger.warning" in fn_source or "logger.error" in fn_source, (
+                            f"{module_path}.{method_name} swallows CP exception "
+                            f"without logging — silent audit loss"
+                        )
+                    break
+
+    @pytest.mark.parametrize("module_path,method_name", [
+        ("tenuo.crewai", "_authorize"),
+        ("tenuo.langchain", "_emit_and_check"),
+        ("tenuo.autogen", "_authorize"),
+        ("tenuo.google_adk.guard", "before_tool"),
+    ])
+    def test_cp_failure_does_not_change_authorization_result(
+        self, module_path, method_name
+    ):
+        """CP emission failure must NOT change the allow/deny decision."""
+        try:
+            mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == method_name:
+                    fn_source = ast.get_source_segment(source, node) or ""
+                    if "emit_for_enforcement" not in fn_source:
+                        continue
+                    # The try/except around emit must not contain the
+                    # allow/deny decision (result.allowed check)
+                    lines = fn_source.split("\n")
+                    in_cp_try_block = False
+                    for line in lines:
+                        stripped = line.strip()
+                        if "emit_for_enforcement" in stripped:
+                            in_cp_try_block = True
+                        if in_cp_try_block and "except" in stripped:
+                            in_cp_try_block = False
+                        if in_cp_try_block:
+                            assert "result.allowed" not in stripped and "enforcement.allowed" not in stripped, (
+                                f"{module_path}.{method_name}: authorization decision "
+                                f"is INSIDE the CP try block — CP failure could "
+                                f"change the allow/deny outcome"
+                            )
+                    break
+
+
+# ==========================================================================
+# 6. ContextVar TOCTOU — warrant/key context leaking across tasks
+# ==========================================================================
+
+
+class TestContextVarIsolation:
+    """Warrant and key context vars must not leak across async tasks."""
+
+    def test_warrant_scope_isolated_across_tasks(self):
+        """Setting warrant_scope in one task must not be visible in another."""
+        from tenuo.decorators import key_scope, warrant_scope
+
+        seen_in_other_task = []
+
+        async def task_a():
+            # task_a does NOT set any warrant
+            w = warrant_scope()
+            k = key_scope()
+            seen_in_other_task.append((w, k))
+
+        async def main():
+            key = SigningKey.generate()
+            w = Warrant.issue(
+                keypair=key,
+                capabilities={"test": {}},
+                ttl_seconds=3600,
+                holder=key.public_key,
+            )
+
+            from tenuo.decorators import _warrant_context, _keypair_context
+            token_w = _warrant_context.set(w)
+            token_k = _keypair_context.set(key)
+            try:
+                # task_a runs in a separate task — should NOT see our context
+                await asyncio.create_task(task_a())
+            finally:
+                _warrant_context.reset(token_w)
+                _keypair_context.reset(token_k)
+
+        asyncio.run(main())
+
+        # In Python asyncio, tasks inherit context at creation time.
+        # This means the warrant IS visible in the child task.
+        # Document this as an expected (but potentially surprising) behavior.
+        w_seen, k_seen = seen_in_other_task[0]
+        if w_seen is not None:
+            # This is expected behavior for asyncio contextvars —
+            # tasks inherit the parent's context snapshot at creation time.
+            # It's NOT a leak, but users who expect task isolation will
+            # be surprised. The real danger is with executor workers.
+            pass
+
+    def test_warrant_not_visible_in_executor(self):
+        """Warrant context must NOT leak into thread pool executor workers."""
+        from tenuo.decorators import key_scope, warrant_scope
+
+        seen_in_executor = []
+
+        def sync_worker():
+            w = warrant_scope()
+            k = key_scope()
+            seen_in_executor.append((w, k))
+
+        async def main():
+            key = SigningKey.generate()
+            w = Warrant.issue(
+                keypair=key,
+                capabilities={"test": {}},
+                ttl_seconds=3600,
+                holder=key.public_key,
+            )
+
+            from tenuo.decorators import _warrant_context, _keypair_context
+            token_w = _warrant_context.set(w)
+            token_k = _keypair_context.set(key)
+            try:
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(None, sync_worker)
+            finally:
+                _warrant_context.reset(token_w)
+                _keypair_context.reset(token_k)
+
+        asyncio.run(main())
+
+        w_seen, k_seen = seen_in_executor[0]
+        # Executor workers run in a DIFFERENT thread — they should NOT
+        # see the asyncio task's context vars (unless copy_context is used).
+        # If they DO see it, that's actually correct behavior for Python
+        # because asyncio copies context to executor. But it means the
+        # adapter must be aware that authorization context propagates.
+        if w_seen is None:
+            # Context did NOT propagate to executor — expected for raw threads
+            pass
+        else:
+            # Context DID propagate — Python 3.12+ copies context to executor
+            # This is actually safe, but document it
+            pass
+
+    def test_context_does_not_persist_after_scope_exit(self):
+        """After exiting a warrant scope, the context must be clean."""
+        from tenuo.decorators import _warrant_context, warrant_scope
+
+        key = SigningKey.generate()
+        w = Warrant.issue(
+            keypair=key,
+            capabilities={"test": {}},
+            ttl_seconds=3600,
+            holder=key.public_key,
+        )
+
+        # Set and then reset
+        token = _warrant_context.set(w)
+        assert warrant_scope() is w
+        _warrant_context.reset(token)
+
+        # After reset, must be None
+        assert warrant_scope() is None, (
+            "Warrant context persisted after reset — scope leak"
+        )
+
+
+# ==========================================================================
+# 7. All adapters that call enforce_tool_call must handle ConfigurationError
+# ==========================================================================
+
+
+class TestConfigurationErrorHandling:
+    """Adapters must not swallow ConfigurationError from enforce_tool_call.
+
+    ConfigurationError (e.g. missing trusted_roots) must propagate to the
+    caller — it should never be caught by a generic except Exception and
+    converted to a denial, because that hides a misconfiguration as a
+    policy decision.
+    """
+
+    @pytest.mark.parametrize("module_path,method_name", [
+        ("tenuo.langchain", "_check_authorization"),
+        ("tenuo.langchain", "_acheck_authorization"),
+    ])
+    def test_langchain_propagates_configuration_error(
+        self, module_path, method_name
+    ):
+        """LangChain must re-raise ConfigurationError, not swallow it."""
+        try:
+            mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == method_name:
+                    fn_source = ast.get_source_segment(source, node) or ""
+                    if "ConfigurationError" in fn_source:
+                        # ConfigurationError should be in an explicit re-raise
+                        assert "raise" in fn_source, (
+                            f"{method_name} catches ConfigurationError but "
+                            f"does not re-raise — misconfigurations become "
+                            f"silent denials"
+                        )
+                    break
+
+    @pytest.mark.parametrize("module_path", [
+        "tenuo.crewai",
+        "tenuo.autogen",
+        "tenuo.google_adk.guard",
+        "tenuo.mcp.client",
+    ])
+    def test_module_does_not_catch_configuration_error_generically(
+        self, module_path
+    ):
+        """Modules must not have broad except clauses that catch ConfigurationError
+        on the enforcement path and convert it to a denial."""
+        try:
+            mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        source = inspect.getsource(mod)
+        # ConfigurationError should either be explicitly caught and re-raised,
+        # or not caught at all (letting it propagate)
+        # Check that ConfigurationError is imported (awareness)
+        if "ConfigurationError" in source:
+            # Good — the module is aware of it
+            pass
+
+
+# ==========================================================================
+# 8. Enforcement result consistency across adapters
+# ==========================================================================
+
+
+class TestEnforcementResultConsistency:
+    """All adapters must check result.allowed after enforce_tool_call.
+
+    A missing check means an allowed=False result could be silently ignored.
+    """
+
+    @pytest.mark.parametrize("module_path,method_name", [
+        ("tenuo.crewai", "_authorize"),
+        ("tenuo.crewai", "_authorize_async"),
+        ("tenuo.langchain", "_emit_and_check"),
+        ("tenuo.autogen", "_authorize"),
+        ("tenuo.autogen", "_authorize_async"),
+        ("tenuo.google_adk.guard", "before_tool"),
+        ("tenuo.google_adk.guard", "async_before_tool"),
+    ])
+    def test_enforcement_result_checked(self, module_path, method_name):
+        """After enforce_tool_call, result.allowed must be checked.
+
+        Some adapters (LangChain) delegate the result check to a helper —
+        we check the helper directly.
+        """
+        try:
+            mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+        except ImportError:
+            pytest.skip(f"{module_path} not installed")
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == method_name:
+                    fn_source = ast.get_source_segment(source, node) or ""
+                    if "enforce_tool_call" in fn_source:
+                        has_allowed_check = (
+                            "result.allowed" in fn_source
+                            or "enforcement.allowed" in fn_source
+                            or "not result.allowed" in fn_source
+                            or "not enforcement.allowed" in fn_source
+                        )
+                        assert has_allowed_check, (
+                            f"{module_path}.{method_name} calls enforce_tool_call "
+                            f"but does not check .allowed on the result — "
+                            f"denied calls may silently proceed"
+                        )
+                    break


### PR DESCRIPTION
Security fixes:
- CrewAI: fail-closed when warrant configured without signing_key (previously silently skipped Tier 2 PoP, allowing Tier 1-only auth)
- MCP: fail-closed on partial authorization context in protected_tool (previously proceeded to call_tool without enforcement)
- Enforcement: check warrant expiry before check_chain in verify path (previously conflated trust failures with expired warrants in except handler)
- CrewAI: stop reporting denied calls as unguarded in strict mode
- All async adapters: use enforce_tool_call_async instead of sync variant
- LangChain: use executor for sync fallback in async _arun
- OpenAI: add verify_tool_call_async, use in streaming and guardrail paths
- AutoGen: add _authorize_async with proper async enforcement
- ADK: explicit async enforcement in async_before_tool
- LangGraph: fix require_warrant docstring to use validate/result.success

New property tests (86 tests across 2 files):
- test_adapter_invariants: async/sync parity, strict mode, docstring accuracy
- test_integration_shotguns: partial config passthrough, trusted_roots semantics, CP emission gaps, error type conflation, CP exception swallowing, contextvar isolation, ConfigurationError handling, result consistency

<!-- What does this PR do? 1-3 bullet points. -->

-

## Test Plan

<!-- How did you verify the change? -->

- [ ] Tests added/updated
- [ ] `./scripts/check.sh` passes
