### PR TITLE
fix(mcp): address post-merge integration feedback

### DIFF
--- a/tenuo-python/tenuo/_enforcement.py
+++ b/tenuo-python/tenuo/_enforcement.py
@@ -475,6 +475,8 @@ def enforce_tool_call(
     tool_args: Dict[str, Any],
     bound_warrant: BoundWarrant,
     *,
+    pop_args: Optional[Dict[str, Any]] = None,
+    constraint_args: Optional[Dict[str, Any]] = None,
     allowed_tools: Optional[List[str]] = None,
     schemas: Optional[Dict[str, ToolSchema]] = None,
     require_constraints: bool = False,
@@ -498,7 +500,11 @@ def enforce_tool_call(
 
     Args:
         tool_name: Name of the tool being called
-        tool_args: Arguments passed to the tool
+        tool_args: Arguments passed to the tool (legacy single-view path).
+        pop_args: Optional raw/wire args for PoP/authentication checks.
+            When omitted, ``tool_args`` is used.
+        constraint_args: Optional extracted args for warrant constraint matching.
+            When omitted, ``tool_args`` is used.
         bound_warrant: BoundWarrant instance (warrant + signing key).
             Must be created via warrant.bind(signing_key).
         allowed_tools: Optional explicit allowlist that overrides warrant.tools.
@@ -675,13 +681,16 @@ def enforce_tool_call(
 
         _warrant_obj = bound_warrant.warrant
         _gate_approvals: Optional[List[Any]] = None
-        # Keep the original tool_args for diagnostics/audit payloads, but use the
-        # None-stripped canonical view for every Rust-bound auth operation. This
-        # mirrors MCP client/server PoP canonicalization and prevents local
-        # warrant_context=True paths from crashing on optional args passed as None.
-        _auth_args = _strip_none_values(tool_args)
+        _raw_pop_args = pop_args if pop_args is not None else tool_args
+        _raw_constraint_args = (
+            constraint_args if constraint_args is not None else tool_args
+        )
+        # Keep original tool_args for diagnostics/audit payloads, but canonicalize
+        # each auth view independently before crossing the Rust FFI boundary.
+        _pop_auth_args = _strip_none_values(_raw_pop_args)
+        _constraint_auth_args = _strip_none_values(_raw_constraint_args)
 
-        if _evaluate_approval_gates(_warrant_obj, tool_name, _auth_args):
+        if _evaluate_approval_gates(_warrant_obj, tool_name, _pop_auth_args):
             _gate_approvers = _warrant_obj.required_approvers()
             _gate_threshold = _warrant_obj.approval_threshold()
 
@@ -701,7 +710,7 @@ def enforce_tool_call(
             # Collect and verify approvals — raises if missing or invalid.
             # Returns verified SignedApproval objects to pass to validate().
             _gate_approvals = _collect_approvals_for_approval_gate(
-                tool_name, _auth_args, bound_warrant,
+                tool_name, _pop_auth_args, bound_warrant,
                 _gate_approvers, _gate_threshold,
                 approval_handler, approvals,
             )
@@ -742,21 +751,52 @@ def enforce_tool_call(
             try:
                 _warrant = bound_warrant.warrant
                 _key = bound_warrant._key
-                _pop = bytes(_warrant.sign(_key, tool_name, _auth_args, int(_time.time())))
+                _pop = bytes(
+                    _warrant.sign(_key, tool_name, _pop_auth_args, int(_time.time()))
+                )
                 _auth = _Authorizer(trusted_roots=trusted_roots)
+                use_split_view = (
+                    pop_args is not None
+                    or constraint_args is not None
+                    or _pop_auth_args != _constraint_auth_args
+                )
                 if warrant_chain:
                     full_chain = list(warrant_chain) + [_warrant]
-                    _chain_result = _auth.check_chain(
-                        full_chain, tool_name, _auth_args,
-                        signature=_pop,
-                        approvals=_gate_approvals or [],
-                    )
+                    if use_split_view:
+                        _chain_result = _auth.check_chain_with_pop_args(
+                            full_chain,
+                            tool_name,
+                            _pop_auth_args,
+                            _constraint_auth_args,
+                            signature=_pop,
+                            approvals=_gate_approvals or [],
+                        )
+                    else:
+                        _chain_result = _auth.check_chain(
+                            full_chain,
+                            tool_name,
+                            _constraint_auth_args,
+                            signature=_pop,
+                            approvals=_gate_approvals or [],
+                        )
                 else:
-                    _chain_result = _auth.authorize_one(
-                        _warrant, tool_name, _auth_args,
-                        signature=_pop,
-                        approvals=_gate_approvals or [],
-                    )
+                    if use_split_view:
+                        _chain_result = _auth.authorize_one_with_pop_args(
+                            _warrant,
+                            tool_name,
+                            _pop_auth_args,
+                            _constraint_auth_args,
+                            signature=_pop,
+                            approvals=_gate_approvals or [],
+                        )
+                    else:
+                        _chain_result = _auth.authorize_one(
+                            _warrant,
+                            tool_name,
+                            _constraint_auth_args,
+                            signature=_pop,
+                            approvals=_gate_approvals or [],
+                        )
                 # ── Replay prevention ────────────────────────────────────────
                 # Resolve nonce_store: explicit param > module-level default.
                 # Ed25519 PoP is deterministic, so an exact replay of the same
@@ -785,7 +825,7 @@ def enforce_tool_call(
                 # regexing the error string — why_denied is available even when
                 # authorize_one raises because it interrogates the warrant directly.
                 try:
-                    _why = _warrant.why_denied(tool_name, _auth_args)
+                    _why = _warrant.why_denied(tool_name, _constraint_auth_args)
                     violated_field = getattr(_why, "field", None)
                 except Exception:
                     violated_field = None
@@ -824,13 +864,28 @@ def enforce_tool_call(
                         warrant_id=warrant_id,
                     )
 
-                _chain_result = authorizer.check_chain(
-                    full_chain,
-                    tool_name,
-                    _auth_args,
-                    signature=precomputed_signature,
-                    approvals=_gate_approvals or [],
+                use_split_view = (
+                    pop_args is not None
+                    or constraint_args is not None
+                    or _pop_auth_args != _constraint_auth_args
                 )
+                if use_split_view and hasattr(authorizer, "check_chain_with_pop_args"):
+                    _chain_result = authorizer.check_chain_with_pop_args(
+                        full_chain,
+                        tool_name,
+                        _pop_auth_args,
+                        _constraint_auth_args,
+                        signature=precomputed_signature,
+                        approvals=_gate_approvals or [],
+                    )
+                else:
+                    _chain_result = authorizer.check_chain(
+                        full_chain,
+                        tool_name,
+                        _constraint_auth_args,
+                        signature=precomputed_signature,
+                        approvals=_gate_approvals or [],
+                    )
             except Exception as chain_err:
                 denial_reason = str(chain_err)
                 error_type = "authorization_failed"
@@ -918,6 +973,8 @@ async def enforce_tool_call_async(
     tool_args: Dict[str, Any],
     bound_warrant: BoundWarrant,
     *,
+    pop_args: Optional[Dict[str, Any]] = None,
+    constraint_args: Optional[Dict[str, Any]] = None,
     allowed_tools: Optional[List[str]] = None,
     schemas: Optional[Dict[str, ToolSchema]] = None,
     require_constraints: bool = False,
@@ -1003,9 +1060,14 @@ async def enforce_tool_call_async(
 
         _warrant_obj = bound_warrant.warrant
         _gate_approvals: Optional[List[Any]] = None
-        _auth_args = _strip_none_values(tool_args)
+        _raw_pop_args = pop_args if pop_args is not None else tool_args
+        _raw_constraint_args = (
+            constraint_args if constraint_args is not None else tool_args
+        )
+        _pop_auth_args = _strip_none_values(_raw_pop_args)
+        _constraint_auth_args = _strip_none_values(_raw_constraint_args)
 
-        if _evaluate_approval_gates(_warrant_obj, tool_name, _auth_args):
+        if _evaluate_approval_gates(_warrant_obj, tool_name, _pop_auth_args):
             _gate_approvers = _warrant_obj.required_approvers()
             _gate_threshold = _warrant_obj.approval_threshold()
 
@@ -1020,7 +1082,7 @@ async def enforce_tool_call_async(
                 )
 
             _gate_approvals = await _collect_approvals_for_approval_gate_async(
-                tool_name, _auth_args, bound_warrant,
+                tool_name, _pop_auth_args, bound_warrant,
                 _gate_approvers, _gate_threshold,
                 approval_handler, approvals,
             )
@@ -1051,19 +1113,52 @@ async def enforce_tool_call_async(
             try:
                 _warrant = bound_warrant.warrant
                 _key = bound_warrant._key
-                _pop = bytes(_warrant.sign(_key, tool_name, _auth_args, int(_time.time())))
+                _pop = bytes(
+                    _warrant.sign(_key, tool_name, _pop_auth_args, int(_time.time()))
+                )
                 _auth = _Authorizer(trusted_roots=trusted_roots)
+                use_split_view = (
+                    pop_args is not None
+                    or constraint_args is not None
+                    or _pop_auth_args != _constraint_auth_args
+                )
                 if warrant_chain:
                     full_chain = list(warrant_chain) + [_warrant]
-                    _chain_result = _auth.check_chain(
-                        full_chain, tool_name, _auth_args,
-                        signature=_pop, approvals=_gate_approvals or [],
-                    )
+                    if use_split_view:
+                        _chain_result = _auth.check_chain_with_pop_args(
+                            full_chain,
+                            tool_name,
+                            _pop_auth_args,
+                            _constraint_auth_args,
+                            signature=_pop,
+                            approvals=_gate_approvals or [],
+                        )
+                    else:
+                        _chain_result = _auth.check_chain(
+                            full_chain,
+                            tool_name,
+                            _constraint_auth_args,
+                            signature=_pop,
+                            approvals=_gate_approvals or [],
+                        )
                 else:
-                    _chain_result = _auth.authorize_one(
-                        _warrant, tool_name, _auth_args,
-                        signature=_pop, approvals=_gate_approvals or [],
-                    )
+                    if use_split_view:
+                        _chain_result = _auth.authorize_one_with_pop_args(
+                            _warrant,
+                            tool_name,
+                            _pop_auth_args,
+                            _constraint_auth_args,
+                            signature=_pop,
+                            approvals=_gate_approvals or [],
+                        )
+                    else:
+                        _chain_result = _auth.authorize_one(
+                            _warrant,
+                            tool_name,
+                            _constraint_auth_args,
+                            signature=_pop,
+                            approvals=_gate_approvals or [],
+                        )
                 _ns = nonce_store
                 if _ns is None:
                     from .nonce import get_default_nonce_store as _get_ns
@@ -1081,7 +1176,7 @@ async def enforce_tool_call_async(
                 if isinstance(_exc, (_ExpiredError, _SignatureInvalid, _MissingSignature)):
                     raise
                 try:
-                    _why = _warrant.why_denied(tool_name, _auth_args)
+                    _why = _warrant.why_denied(tool_name, _constraint_auth_args)
                     violated_field = getattr(_why, "field", None)
                 except Exception:
                     violated_field = None
@@ -1105,10 +1200,28 @@ async def enforce_tool_call_async(
                         error_type="expired", warrant_id=warrant_id,
                     )
 
-                _chain_result = authorizer.check_chain(
-                    full_chain, tool_name, _auth_args,
-                    signature=precomputed_signature, approvals=_gate_approvals or [],
+                use_split_view = (
+                    pop_args is not None
+                    or constraint_args is not None
+                    or _pop_auth_args != _constraint_auth_args
                 )
+                if use_split_view and hasattr(authorizer, "check_chain_with_pop_args"):
+                    _chain_result = authorizer.check_chain_with_pop_args(
+                        full_chain,
+                        tool_name,
+                        _pop_auth_args,
+                        _constraint_auth_args,
+                        signature=precomputed_signature,
+                        approvals=_gate_approvals or [],
+                    )
+                else:
+                    _chain_result = authorizer.check_chain(
+                        full_chain,
+                        tool_name,
+                        _constraint_auth_args,
+                        signature=precomputed_signature,
+                        approvals=_gate_approvals or [],
+                    )
             except Exception as chain_err:
                 denial_reason = str(chain_err)
                 error_type = "authorization_failed"

--- a/tenuo-python/tenuo/mcp/client.py
+++ b/tenuo-python/tenuo/mcp/client.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional
 
 from .._enforcement import EnforcementResult, enforce_tool_call_async
 from .._pop_canonicalize import strip_none_values
+from ..approval import ApprovalHandler
 from ..config import is_configured
 from ..decorators import key_scope, warrant_scope
 from ..exceptions import (
@@ -57,7 +58,7 @@ def _raise_for_denial(result: "EnforcementResult", tool_name: str) -> None:
     if etype == "constraint_violation":
         field = result.constraint_violated or tool_name
         raise ConstraintViolation(field, reason)
-    if etype == "tool_not_allowed":
+    if etype in {"tool_not_allowed", "tool_not_authorized"}:
         raise ToolNotAuthorized(reason)
     if etype == "expired":
         raise ExpiredError(reason)
@@ -136,7 +137,7 @@ class SecureMCPClient:
         timeout: float = 30.0,
         sse_read_timeout: float = 300.0,
         auth: Optional[Any] = None,
-        approval_handler: Optional[Any] = None,
+        approval_handler: Optional[ApprovalHandler] = None,
     ):
         """
         Initialize MCP client.
@@ -422,8 +423,17 @@ class SecureMCPClient:
             )
 
         if self._tools is None:
-            response = await self.session.list_tools()  # type: ignore[union-attr]
-            self._tools = response.tools
+            # Serialize lazy discovery to avoid duplicate list_tools calls when
+            # concurrent callers race on first access.
+            async with self._connect_lock:
+                if self._tools is None:
+                    if self.session is None:
+                        raise RuntimeError(
+                            "Not connected to MCP server. "
+                            "Use 'async with SecureMCPClient(...) as client:' or call await client.connect() first."
+                        )
+                    response = await self.session.list_tools()  # type: ignore[union-attr]
+                    self._tools = response.tools
         return self._tools
 
     @property
@@ -438,11 +448,14 @@ class SecureMCPClient:
         if not wrapped and self.session is not None:
             try:
                 if self._tools:
+                    built: Dict[str, Callable] = {}
                     for tool in self._tools:
-                        wrapped[tool.name] = self.create_protected_tool(tool)
-                    self._wrapped_tools = wrapped
+                        built[tool.name] = self.create_protected_tool(tool)
+                    # Publish atomically so callers never observe partial wraps.
+                    self._wrapped_tools = built
+                    wrapped = built
             except Exception as exc:
-                logger.warning("Failed to wrap tool '%s': %s", tool.name, exc, exc_info=True)
+                logger.warning("Failed to wrap MCP tools: %s", exc, exc_info=True)
 
         return dict(wrapped)
 
@@ -481,16 +494,22 @@ class SecureMCPClient:
             )
 
         # Create BoundWarrant for enforcement
-        bound_warrant = warrant.bind(keypair)
+        try:
+            bound_warrant = warrant.bind(keypair)
+        except Exception as exc:
+            return ValidationResult.fail(
+                f"Failed to bind warrant to signing key: {exc}",
+                suggestions=["Ensure the active key matches the warrant holder"],
+            )
 
-        # Re-map arguments if we have a config. Strip None values at the
-        # FFI boundary so optional tool params with None defaults don't
-        # crash the Rust canonicalizer.
-        extraction_args = strip_none_values(arguments)
+        pop_args = strip_none_values(arguments)
+        constraint_args = pop_args
         if self.compiled_config:
             try:
                 result = self.compiled_config.extract_constraints(tool_name, arguments)
-                extraction_args = strip_none_values(dict(result.constraints))
+                combined = dict(pop_args)
+                combined.update(strip_none_values(dict(result.constraints)))
+                constraint_args = combined
             except Exception:
                 logger.warning(
                     "Constraint extraction failed for '%s'; falling back to raw arguments",
@@ -498,10 +517,14 @@ class SecureMCPClient:
                     exc_info=True,
                 )
 
-        # Use unified enforcement logic (async for approval handler support)
+        # Dry-run local enforcement mirroring real call semantics:
+        # - PoP/auth path uses raw wire args (pop_args)
+        # - constraint matching uses extracted args when config is present
         enforcement: EnforcementResult = await enforce_tool_call_async(
             tool_name=tool_name,
-            tool_args=extraction_args,
+            tool_args=arguments,
+            pop_args=pop_args,
+            constraint_args=constraint_args,
             bound_warrant=bound_warrant,
         )
 
@@ -695,9 +718,27 @@ class SecureMCPClient:
                     "Use `with warrant_scope(w), key_scope(k):` or set warrant_context=False."
                 )
             bw = BoundWarrant(w, k)
+            pop_args = strip_none_values(arguments)
+            constraint_args = pop_args
+            if self.compiled_config:
+                try:
+                    extracted = self.compiled_config.extract_constraints(
+                        tool_name, arguments
+                    )
+                    combined = dict(pop_args)
+                    combined.update(strip_none_values(dict(extracted.constraints)))
+                    constraint_args = combined
+                except Exception:
+                    logger.warning(
+                        "Constraint extraction failed for '%s'; falling back to raw arguments",
+                        tool_name,
+                        exc_info=True,
+                    )
             result = await enforce_tool_call_async(
                 tool_name=tool_name,
                 tool_args=arguments,
+                pop_args=pop_args,
+                constraint_args=constraint_args,
                 bound_warrant=bw,
                 trusted_roots=resolve_trusted_roots(),
                 approval_handler=self._approval_handler,
@@ -741,7 +782,7 @@ class SecureMCPClient:
         properties = input_schema.get("properties", {})
         allowed_keys: Optional[set] = set(properties.keys()) if properties else None
 
-        def _extract_auth_args(**kwargs):
+        def _extract_constraint_args(**kwargs):
             # Strip _approvals — it is a Tenuo transport kwarg, not a tool argument.
             # Passing SignedApproval objects to extract_constraints would fail JSON
             # serialization and is not part of the constraint schema.
@@ -751,10 +792,8 @@ class SecureMCPClient:
                 # We do NOT suppress exceptions here (Fail Closed).
                 # If extraction fails, it means the request doesn't match the required configuration.
                 result = self.compiled_config.extract_constraints(tool_name, tool_kwargs)
-
-                # Merge extracted constraints (which have defaults/types) over raw kwargs
                 combined = tool_kwargs.copy()
-                combined.update(result.constraints)
+                combined.update(dict(result.constraints))
                 return combined
             return tool_kwargs
 
@@ -765,7 +804,10 @@ class SecureMCPClient:
 
             _approvals = kwargs.pop("_approvals", None)
 
-            auth_args = _extract_auth_args(**kwargs)
+            constraint_args = _extract_constraint_args(**kwargs)
+            pop_args = {
+                k: v for k, v in kwargs.items() if k != "_approvals"
+            }
 
             w = warrant_scope()
             k = key_scope()
@@ -773,7 +815,9 @@ class SecureMCPClient:
                 bw = BoundWarrant(w, k)
                 result = await enforce_tool_call_async(
                     tool_name=tool_name,
-                    tool_args=auth_args,
+                    tool_args=kwargs,
+                    pop_args=pop_args,
+                    constraint_args=constraint_args,
                     bound_warrant=bw,
                     trusted_roots=resolve_trusted_roots(),
                     approval_handler=self._approval_handler,

--- a/tenuo-python/tenuo/mcp/server.py
+++ b/tenuo-python/tenuo/mcp/server.py
@@ -132,15 +132,15 @@ def _access_denial_reason(exc: BaseException) -> str:
     base = f"Access denied: {exc}"
     if isinstance(exc, SignatureInvalid):
         return (
-            f"{base} If you use CompiledMcpConfig, the client PoP must sign the "
-            "same extracted constraint dict as the server (identical mcp-config.yaml / "
-            "register_config path)."
+            f"{base} PoP covers the raw tool arguments (with None values stripped). "
+            "Check that the client signs with the same key bound in the warrant and "
+            "that the timestamp has not drifted beyond the PoP window."
         )
     if isinstance(exc, SignatureMismatch):
         return (
             f"{base} PoP was verified structurally but does not match this warrant/holder "
-            "or constraint view. With CompiledMcpConfig, use the same extraction on client "
-            "and server when signing."
+            "or the raw wire-args view. Confirm the client and server agree on argument "
+            "canonicalization (both apply tenuo._pop_canonicalize.strip_none_values)."
         )
     if isinstance(exc, MissingSignature):
         return f"{base} Ensure the client sends a PoP signature in _meta.tenuo.signature."
@@ -744,6 +744,7 @@ class MCPVerifier:
             ExpiredError,
             MissingSignature,
             SignatureInvalid,
+            SignatureMismatch,
             ToolNotAuthorized,
         ) as exc:
             logger.info(

--- a/tenuo-python/tests/adapters/test_mcp.py
+++ b/tenuo-python/tests/adapters/test_mcp.py
@@ -818,3 +818,115 @@ class TestCallToolIsErrorHandling:
         )
         out = await client.call_tool("t", {}, warrant_context=False, raise_on_tool_error=False)
         assert out == blocks
+
+
+@pytest.mark.skipif(not MCP_AVAILABLE, reason="MCP SDK not installed")
+class TestValidateToolSplitView:
+    @pytest.mark.asyncio
+    async def test_validate_tool_uses_split_views_when_config_present(self):
+        client = _make_client()
+        mock_warrant = MagicMock()
+        mock_key = MagicMock()
+        mock_bound = MagicMock()
+        mock_warrant.bind.return_value = mock_bound
+
+        mock_extraction = MagicMock()
+        mock_extraction.constraints = {"path": "/tmp/x.txt", "max_size": 1024}
+        mock_config = MagicMock()
+        mock_config.extract_constraints.return_value = mock_extraction
+        client.compiled_config = mock_config
+
+        mock_enforcement = MagicMock(allowed=True, chain_result=None, denial_reason=None)
+
+        with (
+            patch("tenuo.mcp.client.warrant_scope", return_value=mock_warrant),
+            patch("tenuo.mcp.client.key_scope", return_value=mock_key),
+            patch("tenuo.mcp.client.enforce_tool_call_async", new=AsyncMock(return_value=mock_enforcement)) as mock_enforce,
+        ):
+            result = await client.validate_tool(
+                "read_file",
+                {"path": "/tmp/x.txt", "maxSize": None},
+            )
+
+        assert result.success is True
+        kwargs = mock_enforce.call_args.kwargs
+        assert kwargs["tool_name"] == "read_file"
+        assert kwargs["tool_args"] == {"path": "/tmp/x.txt", "maxSize": None}
+        assert kwargs["pop_args"] == {"path": "/tmp/x.txt"}
+        assert kwargs["constraint_args"] == {
+            "path": "/tmp/x.txt",
+            "max_size": 1024,
+        }
+
+    @pytest.mark.asyncio
+    async def test_validate_tool_handles_bind_failure(self):
+        client = _make_client()
+        mock_warrant = MagicMock()
+        mock_key = MagicMock()
+        mock_warrant.bind.side_effect = RuntimeError("wrong keypair")
+
+        with (
+            patch("tenuo.mcp.client.warrant_scope", return_value=mock_warrant),
+            patch("tenuo.mcp.client.key_scope", return_value=mock_key),
+        ):
+            result = await client.validate_tool("read_file", {"path": "/tmp/x.txt"})
+
+        assert result.success is False
+        assert "Failed to bind warrant" in result.reason
+
+
+@pytest.mark.skipif(not MCP_AVAILABLE, reason="MCP SDK not installed")
+class TestDenialErrorTypeAliases:
+    def test_tool_not_authorized_alias_maps_to_tool_not_authorized_exception(self):
+        from tenuo.exceptions import ToolNotAuthorized
+        from tenuo.mcp.client import _raise_for_denial
+
+        result = MagicMock(
+            denial_reason="not allowed",
+            error_type="tool_not_authorized",
+            constraint_violated=None,
+        )
+        with pytest.raises(ToolNotAuthorized):
+            _raise_for_denial(result, "read_file")
+
+
+@pytest.mark.skipif(not MCP_AVAILABLE, reason="MCP SDK not installed")
+class TestToolDiscoveryAndWrappingRaces:
+    @pytest.mark.asyncio
+    async def test_get_tools_serialized_under_concurrency(self):
+        client = _make_client()
+        fake_tool = MagicMock()
+        fake_tool.name = "read_file"
+        client.session.list_tools = AsyncMock(return_value=MagicMock(tools=[fake_tool]))
+        client._tools = None
+
+        await asyncio.gather(client.get_tools(), client.get_tools(), client.get_tools())
+
+        assert client.session.list_tools.await_count == 1
+        assert client._tools is not None
+        assert len(client._tools) == 1
+
+    def test_tools_property_does_not_publish_partial_wraps(self):
+        client = _make_client()
+        t1 = MagicMock()
+        t1.name = "read_file"
+        t2 = MagicMock()
+        t2.name = "write_file"
+        client._tools = [t1, t2]
+        client._wrapped_tools = {}
+
+        calls = {"n": 0}
+
+        def boom_if_second(tool):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("wrap failed on second tool")
+            return AsyncMock()
+
+        client.create_protected_tool = boom_if_second  # type: ignore[assignment]
+        wrapped = client.tools
+
+        # On failure we keep previous stable snapshot (empty) instead of
+        # leaking partially wrapped tool dicts.
+        assert wrapped == {}
+        assert client._wrapped_tools == {}

--- a/tenuo-python/tests/adapters/test_mcp_fastmcp_middleware.py
+++ b/tenuo-python/tests/adapters/test_mcp_fastmcp_middleware.py
@@ -15,6 +15,7 @@ import pytest
 from tenuo_core import Authorizer, SigningKey, Warrant
 
 from tenuo import Pattern
+from tenuo._pop_canonicalize import strip_none_values
 from tenuo.mcp.server import MCPVerifier
 
 pytest.importorskip("mcp")
@@ -62,6 +63,16 @@ def _make_meta(
         "signature": _encode_pop(warrant, key, tool, tool_args),
     }
     return RequestParams.Meta.model_validate({"tenuo": tenuo})
+
+
+def _make_meta_strip_none(
+    warrant: Warrant,
+    key: SigningKey,
+    tool: str,
+    tool_args: Dict[str, Any],
+) -> RequestParams.Meta:
+    """Build metadata using the same canonicalization as MCP client/server."""
+    return _make_meta(warrant, key, tool, strip_none_values(tool_args))
 
 
 @pytest.fixture
@@ -212,6 +223,38 @@ async def test_middleware_denies_tampered_pop(
     te = res.structuredContent.get("tenuo")
     assert te.get("code") == -32001
     assert "Access denied" in (te.get("message") or "")
+
+
+@pytest.mark.asyncio
+async def test_middleware_accepts_none_optional_args(
+    authorizer: Authorizer,
+    simple_warrant: Warrant,
+    agent_key: SigningKey,
+) -> None:
+    """Regression: None-valued args must not crash through middleware path."""
+    verifier = MCPVerifier(authorizer=authorizer, require_warrant=True)
+    mw = TenuoMiddleware(verifier)
+    args = {"path": "/data/x.txt", "max_size": None}
+    meta = _make_meta_strip_none(simple_warrant, agent_key, "read_file", args)
+    params = CallToolRequestParams(name="read_file", arguments=args, _meta=meta)
+    ctx = MiddlewareContext(
+        message=params,
+        source="client",
+        type="request",
+        method="tools/call",
+        fastmcp_context=None,
+    )
+    seen: dict[str, Any] = {}
+
+    async def call_next(c: MiddlewareContext) -> ToolResult:
+        seen["args"] = dict(c.message.arguments or {})
+        return ToolResult(content=[TextContent(type="text", text="ok")])
+
+    out = await mw.on_call_tool(ctx, call_next)
+    assert isinstance(out, ToolResult)
+    # Middleware keeps original call args for handler; verifier strips internally.
+    assert seen["args"]["path"] == "/data/x.txt"
+    assert "max_size" in seen["args"]
 
 
 class _RecordingControlPlane:

--- a/tenuo-python/tests/adapters/test_mcp_server.py
+++ b/tenuo-python/tests/adapters/test_mcp_server.py
@@ -96,6 +96,26 @@ def _make_arguments(
     return dict(tool_args), {"tenuo": tenuo}
 
 
+def test_access_denial_reason_signature_invalid_mentions_raw_args():
+    from tenuo.exceptions import SignatureInvalid
+    from tenuo.mcp.server import _access_denial_reason
+
+    msg = _access_denial_reason(
+        SignatureInvalid("Proof-of-Possession verification failed")
+    )
+    assert "raw tool arguments" in msg
+    assert "same extracted constraint dict" not in msg
+
+
+def test_access_denial_reason_signature_mismatch_mentions_strip_none_values():
+    from tenuo.exceptions import SignatureMismatch
+    from tenuo.mcp.server import _access_denial_reason
+
+    msg = _access_denial_reason(SignatureMismatch())
+    assert "raw wire-args view" in msg
+    assert "strip_none_values" in msg
+
+
 # ---------------------------------------------------------------------------
 # MCPVerificationResult unit tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Update MCP denial hints in `server.py` to match the raw-wire PoP architecture and include explicit `SignatureMismatch` handling in the known-denial branch.
- Add split-view local enforcement support (`pop_args` + `constraint_args`) in `enforce_tool_call`/`enforce_tool_call_async`, then wire `SecureMCPClient` (`validate_tool`, `call_tool`, protected tool wrappers) to pass both views.
- Fix remaining client quality gaps: serialized lazy `get_tools` discovery, no partial wrapped-tool publication on wrap errors, `_extract_auth_args` rename to `_extract_constraint_args`, `tool_not_authorized` alias mapping, and graceful `warrant.bind` failure in `validate_tool`.
- Add regressions for the above plus FastMCP middleware `None` argument behavior.

## Test plan
- [x] `python -m pytest tests/adapters/test_mcp.py tests/adapters/test_mcp_server.py tests/adapters/test_mcp_fastmcp_middleware.py tests/adapters/test_mcp_ci_smoke.py tests/adapters/test_mcp_local_server_parity.py tests/property/test_pop_ffi_fuzzer.py tests/adapters/test_mcp_pop_split_view.py tests/unit/test_enforcement.py -q --timeout=120`
- [x] `bash scripts/check.sh --check`