### PR TITLE
core: determinism and error-taxonomy hardening

### DIFF
--- a/tenuo-core/src/approval.rs
+++ b/tenuo-core/src/approval.rs
@@ -395,6 +395,7 @@ pub fn canonical_tool_args_cbor(
 ) -> Option<Vec<u8>> {
     use std::collections::BTreeMap;
 
+    // determinism: canonical iteration order required — see docs/determinism-audit.md#finding-request-hash-sort.
     let sorted: BTreeMap<_, _> = args.iter().collect();
     let mut cbor_buf = Vec::new();
     if ciborium::into_writer(&sorted, &mut cbor_buf).is_ok() {

--- a/tenuo-core/src/bin/authorizer.rs
+++ b/tenuo-core/src/bin/authorizer.rs
@@ -1498,8 +1498,11 @@ fn parse_deny_reason(
 
             deny = deny.with_constraint(field, reason, actual);
         }
-        Error::WarrantExpired(ts) => {
-            deny = deny.with_reason(format!("warrant_expired: {}", ts));
+        Error::WarrantExpired {
+            warrant_id,
+            expired_at,
+        } => {
+            deny = deny.with_reason(format!("warrant_expired: {} at {}", warrant_id, expired_at));
         }
         Error::WarrantRevoked(id) => {
             deny = deny.with_reason(format!("warrant_revoked: {}", id));

--- a/tenuo-core/src/error.rs
+++ b/tenuo-core/src/error.rs
@@ -321,8 +321,11 @@ pub enum Error {
     WarrantRevoked(String),
 
     /// Warrant has expired.
-    #[error("warrant expired at {0}")]
-    WarrantExpired(chrono::DateTime<chrono::Utc>),
+    #[error("warrant '{warrant_id}' expired at {expired_at}")]
+    WarrantExpired {
+        warrant_id: String,
+        expired_at: chrono::DateTime<chrono::Utc>,
+    },
 
     /// Warrant issued in the future (Clock Skew violation).
     #[error("warrant issued in the future (check system clock)")]
@@ -665,7 +668,7 @@ impl Error {
 
             // Warrant Lifecycle Errors
             Self::WarrantRevoked(_) => ErrorCode::WarrantRevoked,
-            Self::WarrantExpired(_) => ErrorCode::WarrantExpired,
+            Self::WarrantExpired { .. } => ErrorCode::WarrantExpired,
             Self::IssuedInFuture => ErrorCode::IssuedInFuture,
             Self::DepthExceeded(_, _) => ErrorCode::DepthExceeded,
             Self::InvalidWarrantId(_) => ErrorCode::InvalidPayloadStructure,
@@ -885,7 +888,10 @@ mod tests {
         assert_eq!(err.http_status(), 401);
 
         // Temporal errors
-        let err = Error::WarrantExpired(chrono::Utc::now());
+        let err = Error::WarrantExpired {
+            warrant_id: "tnu_wrt_test".into(),
+            expired_at: chrono::Utc::now(),
+        };
         assert_eq!(err.code(), ErrorCode::WarrantExpired);
         assert_eq!(err.name(), "warrant-expired");
 
@@ -927,7 +933,10 @@ mod tests {
             Error::MissingSignature("test".into()),
             Error::CryptoError("test".into()),
             Error::WarrantRevoked("test".into()),
-            Error::WarrantExpired(chrono::Utc::now()),
+            Error::WarrantExpired {
+                warrant_id: "tnu_wrt_test".into(),
+                expired_at: chrono::Utc::now(),
+            },
             Error::DepthExceeded(1, 0),
             Error::InvalidWarrantId("test".into()),
             Error::InvalidTtl("test".into()),

--- a/tenuo-core/src/mcp.rs
+++ b/tenuo-core/src/mcp.rs
@@ -369,7 +369,7 @@ pub fn auth_error_to_jsonrpc(error: &crate::error::Error) -> (i32, String) {
                 field, reason
             ),
         ),
-        Error::WarrantExpired(_) => (-32001, "Access denied: Warrant expired".to_string()),
+        Error::WarrantExpired { .. } => (-32001, "Access denied: Warrant expired".to_string()),
         Error::SignatureInvalid(_) => (-32001, "Access denied: Invalid signature".to_string()),
         Error::ToolMismatch { .. } => (-32001, "Access denied: Tool not authorized".to_string()),
         Error::ApprovalRequired { tool, .. } => (

--- a/tenuo-core/src/planes.rs
+++ b/tenuo-core/src/planes.rs
@@ -1049,7 +1049,10 @@ impl DataPlane {
 
         // 4. Check child is not expired (with clock tolerance)
         if child.is_expired_with_tolerance(self.clock_tolerance) {
-            return Err(Error::WarrantExpired(child.expires_at()));
+            return Err(Error::WarrantExpired {
+                warrant_id: child.id().to_string(),
+                expired_at: child.expires_at(),
+            });
         }
 
         // 5. Validate constraint attenuation (monotonicity)
@@ -2168,7 +2171,10 @@ impl Authorizer {
 
         // Check expiration with clock tolerance
         if child.is_expired_with_tolerance(self.clock_tolerance) {
-            return Err(Error::WarrantExpired(child.expires_at()));
+            return Err(Error::WarrantExpired {
+                warrant_id: child.id().to_string(),
+                expired_at: child.expires_at(),
+            });
         }
 
         // Validate monotonicity based on warrant type

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -5307,6 +5307,16 @@ impl PyAuthorizer {
         pop_window_secs: i64,
         pop_max_windows: u32,
     ) -> PyResult<Self> {
+        if clock_tolerance_secs < 0 {
+            return Err(py_validation_err("clock_tolerance_secs must be >= 0"));
+        }
+        if pop_window_secs <= 0 {
+            return Err(py_validation_err("pop_window_secs must be > 0"));
+        }
+        if pop_max_windows == 0 {
+            return Err(py_validation_err("pop_max_windows must be >= 1"));
+        }
+
         let mut authorizer = RustAuthorizer::new()
             .with_clock_tolerance(chrono::Duration::seconds(clock_tolerance_secs))
             .with_pop_window(pop_window_secs, pop_max_windows);

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -32,7 +32,6 @@ use crate::warrant::{
     Clearance, OwnedAttenuationBuilder, OwnedIssuanceBuilder, Warrant as RustWarrant, WarrantType,
 };
 use crate::wire;
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PySequence, PyTuple};
 use pyo3::IntoPyObjectExt;
@@ -215,12 +214,27 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
                 ref detail,
             } => {
                 let detail_str = detail.as_deref().unwrap_or("");
-                let elements: [pyo3::Py<PyAny>; 3] = [
-                    required.into_py_any(py).unwrap(),
-                    received.into_py_any(py).unwrap(),
-                    detail_str.into_py_any(py).unwrap(),
+                let req = match required.into_py_any(py) {
+                    Ok(v) => v,
+                    Err(e) => return py_validation_err(e.to_string()),
+                };
+                let rec = match received.into_py_any(py) {
+                    Ok(v) => v,
+                    Err(e) => return py_validation_err(e.to_string()),
+                };
+                let det = match detail_str.into_py_any(py) {
+                    Ok(v) => v,
+                    Err(e) => return py_validation_err(e.to_string()),
+                };
+                let elements = vec![
+                    req,
+                    rec,
+                    det,
                 ];
-                ("InsufficientApprovals", PyTuple::new(py, elements))
+                (
+                    "InsufficientApprovals",
+                    PyTuple::new(py, elements),
+                )
             }
             crate::error::Error::InvalidApproval(m) => {
                 ("InvalidApproval", PyTuple::new(py, [m.as_str()]))
@@ -416,7 +430,7 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
             ),
             crate::error::Error::InvalidPath { path, reason } => {
                 // Use Python's built-in ValueError directly since it's not in tenuo.exceptions
-                return PyValueError::new_err(format!("invalid path '{}': {}", path, reason));
+                return py_validation_err(format!("invalid path '{}': {}", path, reason));
             }
             crate::error::Error::UrlNotSafe { url, reason } => (
                 "ConstraintViolation",
@@ -434,7 +448,7 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
         let args = match args {
             Ok(a) => a,
             Err(e) => {
-                return PyRuntimeError::new_err(format!("Failed to create args tuple: {}", e))
+                return py_validation_err(format!("Failed to create args tuple: {}", e))
             }
         };
 
@@ -444,15 +458,19 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
                 // Note: call1 takes a tuple of arguments. Our 'args' IS that tuple.
                 PyErr::from_value(cls.call1(args).unwrap_or_else(|e| {
                     // Fallback if constructor fails
-                    PyRuntimeError::new_err(e.to_string())
+                    py_validation_err(e.to_string())
                         .value(py)
                         .as_any()
                         .clone()
                 }))
             }
-            Err(e) => PyRuntimeError::new_err(e.to_string()),
+            Err(e) => py_validation_err(e.to_string()),
         }
     })
+}
+
+fn py_validation_err(message: impl Into<String>) -> PyErr {
+    to_py_err(crate::error::Error::Validation(message.into()))
 }
 
 /// Convert a ConfigError to a Python exception.
@@ -460,14 +478,14 @@ fn config_err_to_py(e: crate::gateway_config::ConfigError) -> PyErr {
     Python::attach(|py| match py.import("tenuo.exceptions") {
         Ok(m) => match m.getattr("ConfigurationError") {
             Ok(cls) => PyErr::from_value(cls.call1((e.to_string(),)).unwrap_or_else(|_| {
-                PyValueError::new_err(e.to_string())
+                py_validation_err(e.to_string())
                     .value(py)
                     .as_any()
                     .clone()
             })),
-            Err(_) => PyValueError::new_err(e.to_string()),
+            Err(_) => py_validation_err(e.to_string()),
         },
-        Err(_) => PyValueError::new_err(e.to_string()),
+        Err(_) => py_validation_err(e.to_string()),
     })
 }
 
@@ -1962,7 +1980,7 @@ impl PyShlex {
     #[pyo3(signature = (allow))]
     fn new(allow: Vec<String>) -> PyResult<Self> {
         if allow.is_empty() {
-            return Err(pyo3::exceptions::PyValueError::new_err(
+            return Err(py_validation_err(
                 "Shlex requires at least one allowed binary",
             ));
         }
@@ -2046,7 +2064,7 @@ impl PySigningKey {
     fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
         let arr: [u8; 32] = bytes
             .try_into()
-            .map_err(|_| PyValueError::new_err("secret key must be exactly 32 bytes"))?;
+            .map_err(|_| py_validation_err("secret key must be exactly 32 bytes"))?;
         Ok(Self {
             inner: RustSigningKey::from_bytes(&arr),
         })
@@ -2112,50 +2130,68 @@ fn constraint_to_py(py: Python<'_>, constraint: &Constraint) -> PyResult<Py<PyAn
         Constraint::Pattern(p) =>
         {
             #[allow(deprecated)]
-            Ok(PyPattern { inner: p.clone() }.into_py_any(py).unwrap())
+            Ok(PyPattern { inner: p.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Exact(e) =>
         {
             #[allow(deprecated)]
-            Ok(PyExact { inner: e.clone() }.into_py_any(py).unwrap())
+            Ok(PyExact { inner: e.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::OneOf(o) =>
         {
             #[allow(deprecated)]
-            Ok(PyOneOf { inner: o.clone() }.into_py_any(py).unwrap())
+            Ok(PyOneOf { inner: o.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::NotOneOf(n) =>
         {
             #[allow(deprecated)]
-            Ok(PyNotOneOf { inner: n.clone() }.into_py_any(py).unwrap())
+            Ok(PyNotOneOf { inner: n.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
-        Constraint::Unknown { .. } => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+        Constraint::Unknown { .. } => Err(py_validation_err(
             "Unknown constraint type encountered (not supported in Python bindings)",
         )),
         Constraint::Range(r) =>
         {
             #[allow(deprecated)]
-            Ok(PyRange { inner: r.clone() }.into_py_any(py).unwrap())
+            Ok(PyRange { inner: r.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Cidr(c) =>
         {
             #[allow(deprecated)]
-            Ok(PyCidr { inner: c.clone() }.into_py_any(py).unwrap())
+            Ok(PyCidr { inner: c.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::UrlPattern(u) =>
         {
             #[allow(deprecated)]
-            Ok(PyUrlPattern { inner: u.clone() }.into_py_any(py).unwrap())
+            Ok(PyUrlPattern { inner: u.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Contains(c) =>
         {
             #[allow(deprecated)]
-            Ok(PyContains { inner: c.clone() }.into_py_any(py).unwrap())
+            Ok(PyContains { inner: c.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Subset(s) =>
         {
             #[allow(deprecated)]
-            Ok(PySubset { inner: s.clone() }.into_py_any(py).unwrap())
+            Ok(PySubset { inner: s.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::All(a) => {
             let py_constraints = Python::attach(|py| -> PyResult<Vec<Py<PyAny>>> {
@@ -2166,7 +2202,9 @@ fn constraint_to_py(py: Python<'_>, constraint: &Constraint) -> PyResult<Py<PyAn
                 Ok(vec)
             })?;
             #[allow(deprecated)]
-            Ok(PyAll::new(py_constraints)?.into_py_any(py).unwrap())
+            Ok(PyAll::new(py_constraints)?
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Any(a) => {
             let py_constraints = Python::attach(|py| -> PyResult<Vec<Py<PyAny>>> {
@@ -2177,44 +2215,60 @@ fn constraint_to_py(py: Python<'_>, constraint: &Constraint) -> PyResult<Py<PyAn
                 Ok(vec)
             })?;
             #[allow(deprecated)]
-            Ok(PyAnyOf::new(py_constraints)?.into_py_any(py).unwrap())
+            Ok(PyAnyOf::new(py_constraints)?
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Not(n) => {
             let py_constraint = Python::attach(|py| -> PyResult<Py<PyAny>> {
                 constraint_to_py(py, &n.constraint)
             })?;
             #[allow(deprecated)]
-            Ok(PyNot::new(py_constraint)?.into_py_any(py).unwrap())
+            Ok(PyNot::new(py_constraint)?
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Cel(c) =>
         {
             #[allow(deprecated)]
-            Ok(PyCel { inner: c.clone() }.into_py_any(py).unwrap())
+            Ok(PyCel { inner: c.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Wildcard(w) =>
         {
             #[allow(deprecated)]
-            Ok(PyWildcard { inner: w.clone() }.into_py_any(py).unwrap())
+            Ok(PyWildcard { inner: w.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Regex(r) =>
         {
             #[allow(deprecated)]
-            Ok(PyRegex { inner: r.clone() }.into_py_any(py).unwrap())
+            Ok(PyRegex { inner: r.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Subpath(s) =>
         {
             #[allow(deprecated)]
-            Ok(PySubpath { inner: s.clone() }.into_py_any(py).unwrap())
+            Ok(PySubpath { inner: s.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::UrlSafe(u) =>
         {
             #[allow(deprecated)]
-            Ok(PyUrlSafe { inner: u.clone() }.into_py_any(py).unwrap())
+            Ok(PyUrlSafe { inner: u.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         Constraint::Shlex(sh) =>
         {
             #[allow(deprecated)]
-            Ok(PyShlex { inner: sh.clone() }.into_py_any(py).unwrap())
+            Ok(PyShlex { inner: sh.clone() }
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
     }
 }
@@ -2279,7 +2333,7 @@ fn py_to_constraint(obj: &Bound<'_, PyAny>) -> PyResult<Constraint> {
     if let Ok(b) = obj.downcast::<PyShlex>() {
         return Ok(Constraint::Shlex(b.borrow().inner.clone()));
     }
-    Err(PyValueError::new_err(
+    Err(py_validation_err(
         "constraint must be Pattern, Exact, OneOf, NotOneOf, Range, Cidr, UrlPattern, Contains, Subset, All, AnyOf, Not, CEL, Regex, Wildcard, Subpath, UrlSafe, or Shlex",
     ))
 }
@@ -2302,7 +2356,7 @@ fn py_dict_to_constraint_set(
         if field == ALLOW_UNKNOWN_KEY {
             let allow: bool = constraint_val
                 .extract()
-                .map_err(|_| PyValueError::new_err("_allow_unknown must be a boolean"))?;
+                .map_err(|_| py_validation_err("_allow_unknown must be a boolean"))?;
             constraint_set.set_allow_unknown(allow);
             continue;
         }
@@ -2343,7 +2397,7 @@ fn py_to_constraint_value(obj: &Bound<'_, PyAny>) -> PyResult<ConstraintValue> {
         }
         Ok(ConstraintValue::List(values))
     } else {
-        Err(PyValueError::new_err(
+        Err(py_validation_err(
             "value must be str, int, float, bool, or list",
         ))
     }
@@ -2352,16 +2406,26 @@ fn py_to_constraint_value(obj: &Bound<'_, PyAny>) -> PyResult<ConstraintValue> {
 /// Convert a ConstraintValue back to a Python object.
 fn constraint_value_to_py(py: Python<'_>, value: &ConstraintValue) -> PyResult<Py<PyAny>> {
     match value {
-        ConstraintValue::String(s) => Ok(s.into_py_any(py).unwrap()),
-        ConstraintValue::Integer(i) => Ok(i.into_py_any(py).unwrap()),
-        ConstraintValue::Float(f) => Ok(f.into_py_any(py).unwrap()),
-        ConstraintValue::Boolean(b) => Ok(b.into_py_any(py).unwrap()),
+        ConstraintValue::String(s) => Ok(s
+            .into_py_any(py)
+            .map_err(|e| py_validation_err(e.to_string()))?),
+        ConstraintValue::Integer(i) => Ok(i
+            .into_py_any(py)
+            .map_err(|e| py_validation_err(e.to_string()))?),
+        ConstraintValue::Float(f) => Ok(f
+            .into_py_any(py)
+            .map_err(|e| py_validation_err(e.to_string()))?),
+        ConstraintValue::Boolean(b) => Ok(b
+            .into_py_any(py)
+            .map_err(|e| py_validation_err(e.to_string()))?),
         ConstraintValue::List(l) => {
             let py_list: Vec<Py<PyAny>> = l
                 .iter()
                 .map(|v| constraint_value_to_py(py, v))
                 .collect::<PyResult<Vec<_>>>()?;
-            Ok(py_list.into_py_any(py).unwrap())
+            Ok(py_list
+                .into_py_any(py)
+                .map_err(|e| py_validation_err(e.to_string()))?)
         }
         ConstraintValue::Object(o) => {
             let dict = pyo3::types::PyDict::new(py);
@@ -2397,20 +2461,20 @@ fn py_to_arg_approval_gate(
     // {"exempt": <constraint>} form — plain Python dict with a single "exempt" key.
     if let Ok(d) = av.downcast::<PyDict>() {
         if d.len() != 1 {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            return Err(py_validation_err(format!(
                 "arg gate '{}': approval gate dict must have exactly one key ('exempt')",
                 arg_name
             )));
         }
         let inner = d.get_item("exempt")?.ok_or_else(|| {
-            pyo3::exceptions::PyValueError::new_err(format!(
+            py_validation_err(format!(
                 "arg gate '{}': approval gate dict must have key 'exempt'",
                 arg_name
             ))
         })?;
         let constraint = py_to_constraint(&inner)?;
         return ArgApprovalGate::exempt(constraint).map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!(
+            py_validation_err(format!(
                 "arg gate '{}': invalid Exempt inner constraint — {}",
                 arg_name, e
             ))
@@ -2458,7 +2522,7 @@ fn py_dict_to_approval_gate_map(
             }
             gm.insert(tool, ToolApprovalGate::with_args(args));
         } else {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            return Err(py_validation_err(format!(
                 "approval gate for '{}' must be None (whole-tool) or a dict of arg approval gates",
                 tool
             )));
@@ -2482,7 +2546,7 @@ impl PyWarrantType {
             "execution" => WarrantType::Execution,
             "issuer" => WarrantType::Issuer,
             _ => {
-                return Err(PyValueError::new_err(
+                return Err(py_validation_err(
                     "WarrantType must be 'execution' or 'issuer'",
                 ))
             }
@@ -2498,9 +2562,7 @@ impl PyWarrantType {
         match op {
             pyo3::basic::CompareOp::Eq => Ok(self.inner == other.inner),
             pyo3::basic::CompareOp::Ne => Ok(self.inner != other.inner),
-            _ => Err(pyo3::exceptions::PyTypeError::new_err(
-                "Comparison not supported",
-            )),
+            _ => Err(py_validation_err("Comparison not supported")),
         }
     }
 
@@ -2534,14 +2596,14 @@ impl PyClearance {
     #[new]
     fn new(value: &Bound<'_, PyAny>) -> PyResult<Self> {
         if let Ok(s) = value.extract::<String>() {
-            let inner = s.parse().map_err(|e: String| PyValueError::new_err(e))?;
+            let inner = s.parse().map_err(py_validation_err)?;
             Ok(Self { inner })
         } else if let Ok(n) = value.extract::<u8>() {
             Ok(Self {
                 inner: Clearance(n),
             })
         } else {
-            Err(PyValueError::new_err(
+            Err(py_validation_err(
                 "Clearance must be initialized with a string name or integer (0-255)",
             ))
         }
@@ -3015,7 +3077,7 @@ impl PyDelegationDiff {
     fn to_json(&self) -> PyResult<String> {
         self.inner
             .to_json()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            .map_err(|e| py_validation_err(e.to_string()))
     }
 
     /// Get human-readable diff output.
@@ -3027,7 +3089,7 @@ impl PyDelegationDiff {
     fn to_siem_json(&self) -> PyResult<String> {
         self.inner
             .to_siem_json()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            .map_err(|e| py_validation_err(e.to_string()))
     }
 
     fn __repr__(&self) -> String {
@@ -3153,14 +3215,14 @@ impl PyDelegationReceipt {
     fn to_json(&self) -> PyResult<String> {
         self.inner
             .to_json()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            .map_err(|e| py_validation_err(e.to_string()))
     }
 
     /// Get SIEM-compatible JSON output.
     fn to_siem_json(&self) -> PyResult<String> {
         self.inner
             .to_siem_json()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            .map_err(|e| py_validation_err(e.to_string()))
     }
 
     fn __repr__(&self) -> String {
@@ -3618,7 +3680,7 @@ impl PyWarrant {
 
                 let constraints_dict: &Bound<'_, PyDict> = constraints_val
                     .downcast()
-                    .map_err(|_| PyValueError::new_err("capabilities values must be dicts"))?;
+                    .map_err(|_| py_validation_err("capabilities values must be dicts"))?;
 
                 let constraint_set = py_dict_to_constraint_set(constraints_dict)?;
                 builder = builder.capability(tool_name, constraint_set);
@@ -3734,7 +3796,7 @@ impl PyWarrant {
     fn issue_execution(&self) -> PyResult<PyIssuanceBuilder> {
         // Validate this is an issuer warrant
         if self.inner.r#type() != WarrantType::Issuer {
-            return Err(PyValueError::new_err(
+            return Err(py_validation_err(
                 "can only issue execution warrants from issuer warrants",
             ));
         }
@@ -3954,7 +4016,7 @@ impl PyWarrant {
 
             let constraints_dict: &Bound<'_, PyDict> = constraints_val
                 .downcast()
-                .map_err(|_| PyValueError::new_err("capabilities values must be dicts"))?;
+                .map_err(|_| py_validation_err("capabilities values must be dicts"))?;
 
             let constraint_set = py_dict_to_constraint_set(constraints_dict)?;
             builder = builder.capability(tool_name, constraint_set);
@@ -4127,7 +4189,7 @@ impl PyWarrant {
     fn verify(&self, public_key_bytes: &[u8]) -> PyResult<bool> {
         let arr: [u8; 32] = public_key_bytes
             .try_into()
-            .map_err(|_| PyValueError::new_err("public key must be exactly 32 bytes"))?;
+            .map_err(|_| py_validation_err("public key must be exactly 32 bytes"))?;
         let pk = crate::crypto::PublicKey::from_bytes(&arr).map_err(to_py_err)?;
 
         match self.inner.verify(&pk) {
@@ -4314,13 +4376,13 @@ impl PyCompiledMcpConfig {
         };
 
         let args_value: serde_json::Value = serde_json::from_str(&json_str)
-            .map_err(|e| PyValueError::new_err(format!("Invalid JSON arguments: {}", e)))?;
+            .map_err(|e| py_validation_err(format!("Invalid JSON arguments: {}", e)))?;
 
         // Extract
         let result = self
             .inner
             .extract_constraints(tool_name, &args_value)
-            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+            .map_err(|e| py_validation_err(e.to_string()))?;
 
         // Convert extracted constraints to Python dict
         let dict = PyDict::new(py);
@@ -4382,7 +4444,7 @@ impl PyPublicKey {
     fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
         let arr: [u8; 32] = bytes
             .try_into()
-            .map_err(|_| PyValueError::new_err("public key must be exactly 32 bytes"))?;
+            .map_err(|_| py_validation_err("public key must be exactly 32 bytes"))?;
         let inner = RustPublicKey::from_bytes(&arr).map_err(to_py_err)?;
         Ok(Self { inner })
     }
@@ -4395,9 +4457,7 @@ impl PyPublicKey {
         match op {
             pyo3::basic::CompareOp::Eq => Ok(self.inner == other.inner),
             pyo3::basic::CompareOp::Ne => Ok(self.inner != other.inner),
-            _ => Err(pyo3::exceptions::PyTypeError::new_err(
-                "Comparison not supported",
-            )),
+            _ => Err(py_validation_err("Comparison not supported")),
         }
     }
 
@@ -4434,7 +4494,7 @@ impl PySignature {
     fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
         let arr: [u8; 64] = bytes
             .try_into()
-            .map_err(|_| PyValueError::new_err("signature must be exactly 64 bytes"))?;
+            .map_err(|_| py_validation_err("signature must be exactly 64 bytes"))?;
         let inner = RustSignature::from_bytes(&arr).map_err(to_py_err)?;
         Ok(Self { inner })
     }
@@ -4724,7 +4784,7 @@ impl PySignedApproval {
         signature: &[u8],
     ) -> PyResult<Self> {
         if signature.len() != 64 {
-            return Err(PyValueError::new_err(format!(
+            return Err(py_validation_err(format!(
                 "Invalid signature length: expected 64 bytes, got {}",
                 signature.len()
             )));
@@ -4733,7 +4793,7 @@ impl PySignedApproval {
         sig_bytes.copy_from_slice(signature);
 
         let sig = crate::crypto::Signature::from_bytes(&sig_bytes)
-            .map_err(|e| PyValueError::new_err(format!("Invalid signature bytes: {}", e)))?;
+            .map_err(|e| py_validation_err(format!("Invalid signature bytes: {}", e)))?;
 
         Ok(Self {
             inner: RustSignedApproval {
@@ -4768,7 +4828,7 @@ impl PySignedApproval {
     fn to_bytes(&self) -> PyResult<Vec<u8>> {
         let mut buf = Vec::new();
         ciborium::into_writer(&self.inner, &mut buf)
-            .map_err(|e| PyValueError::new_err(format!("Serialization failed: {}", e)))?;
+            .map_err(|e| py_validation_err(format!("Serialization failed: {}", e)))?;
         Ok(buf)
     }
 
@@ -4776,7 +4836,7 @@ impl PySignedApproval {
     #[staticmethod]
     fn from_bytes(data: &[u8]) -> PyResult<Self> {
         let inner: RustSignedApproval = ciborium::from_reader(data)
-            .map_err(|e| PyValueError::new_err(format!("Deserialization failed: {}", e)))?;
+            .map_err(|e| py_validation_err(format!("Deserialization failed: {}", e)))?;
         Ok(Self { inner })
     }
 
@@ -4960,7 +5020,7 @@ fn py_verify_approvals(
     clock_tolerance_secs: u64,
 ) -> PyResult<Vec<PyApprovalPayload>> {
     if request_hash.len() != 32 {
-        return Err(PyValueError::new_err(format!(
+        return Err(py_validation_err(format!(
             "request_hash must be 32 bytes, got {}",
             request_hash.len()
         )));
@@ -4969,13 +5029,13 @@ fn py_verify_approvals(
     hash_arr.copy_from_slice(request_hash);
 
     if threshold == 0 {
-        return Err(PyValueError::new_err("threshold must be >= 1"));
+        return Err(py_validation_err("threshold must be >= 1"));
     }
 
     // DoS protection: limit approval count to 2× approver set
     let max_approvals = trusted_approvers.len().saturating_mul(2);
     if approvals.len() > max_approvals {
-        return Err(PyValueError::new_err(format!(
+        return Err(py_validation_err(format!(
             "too many approvals: {} provided, max {} (2× trusted_approvers)",
             approvals.len(),
             max_approvals
@@ -5400,7 +5460,7 @@ impl PyAuthorizer {
             Some(bytes) => {
                 let arr: [u8; 64] = bytes
                     .try_into()
-                    .map_err(|_| PyValueError::new_err("signature must be exactly 64 bytes"))?;
+                    .map_err(|_| py_validation_err("signature must be exactly 64 bytes"))?;
                 Some(RustSignature::from_bytes(&arr).map_err(to_py_err)?)
             }
             None => None,
@@ -5483,7 +5543,7 @@ impl PyAuthorizer {
             Some(bytes) => {
                 let arr: [u8; 64] = bytes
                     .try_into()
-                    .map_err(|_| PyValueError::new_err("signature must be exactly 64 bytes"))?;
+                    .map_err(|_| py_validation_err("signature must be exactly 64 bytes"))?;
                 Some(RustSignature::from_bytes(&arr).map_err(to_py_err)?)
             }
             None => None,
@@ -5530,7 +5590,7 @@ impl PyAuthorizer {
     fn verify_chain(&self, chain: &Bound<'_, PySequence>) -> PyResult<PyChainVerificationResult> {
         let len = chain.len()?;
         if len == 0 {
-            return Err(PyValueError::new_err("chain cannot be empty"));
+            return Err(py_validation_err("chain cannot be empty"));
         }
 
         let mut warrants = Vec::with_capacity(len);
@@ -5570,7 +5630,7 @@ impl PyAuthorizer {
     ) -> PyResult<PyChainVerificationResult> {
         let len = chain.len()?;
         if len == 0 {
-            return Err(PyValueError::new_err("chain cannot be empty"));
+            return Err(py_validation_err("chain cannot be empty"));
         }
 
         let mut warrants = Vec::with_capacity(len);
@@ -5592,7 +5652,7 @@ impl PyAuthorizer {
             Some(bytes) => {
                 let arr: [u8; 64] = bytes
                     .try_into()
-                    .map_err(|_| PyValueError::new_err("signature must be exactly 64 bytes"))?;
+                    .map_err(|_| py_validation_err("signature must be exactly 64 bytes"))?;
                 Some(RustSignature::from_bytes(&arr).map_err(to_py_err)?)
             }
             None => None,
@@ -5659,7 +5719,7 @@ impl PyAuthorizer {
             Some(bytes) => {
                 let arr: [u8; 64] = bytes
                     .try_into()
-                    .map_err(|_| PyValueError::new_err("signature must be exactly 64 bytes"))?;
+                    .map_err(|_| py_validation_err("signature must be exactly 64 bytes"))?;
                 Some(RustSignature::from_bytes(&arr).map_err(to_py_err)?)
             }
             None => None,
@@ -5701,7 +5761,7 @@ impl PyAuthorizer {
     ) -> PyResult<PyChainVerificationResult> {
         let len = chain.len()?;
         if len == 0 {
-            return Err(PyValueError::new_err("chain cannot be empty"));
+            return Err(py_validation_err("chain cannot be empty"));
         }
 
         let mut warrants = Vec::with_capacity(len);
@@ -5730,7 +5790,7 @@ impl PyAuthorizer {
             Some(bytes) => {
                 let arr: [u8; 64] = bytes
                     .try_into()
-                    .map_err(|_| PyValueError::new_err("signature must be exactly 64 bytes"))?;
+                    .map_err(|_| py_validation_err("signature must be exactly 64 bytes"))?;
                 Some(RustSignature::from_bytes(&arr).map_err(to_py_err)?)
             }
             None => None,

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -60,14 +60,13 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
             crate::error::Error::WarrantRevoked(id) => {
                 ("RevokedError", PyTuple::new(py, [id.as_str()]))
             }
-            crate::error::Error::WarrantExpired(t) => {
-                // Python ExpiredError expects (warrant_id, expired_at)
-                // We don't have warrant_id here easily, so pass "unknown"
-                (
-                    "ExpiredError",
-                    PyTuple::new(py, ["unknown", t.to_rfc3339().as_str()]),
-                )
-            }
+            crate::error::Error::WarrantExpired {
+                warrant_id,
+                expired_at,
+            } => (
+                "ExpiredError",
+                PyTuple::new(py, [warrant_id.as_str(), expired_at.to_rfc3339().as_str()]),
+            ),
             crate::error::Error::DepthExceeded(d, m) => {
                 ("DepthExceeded", PyTuple::new(py, [*d, *m]))
             }
@@ -295,7 +294,7 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
                 parent_inclusive: _,
                 child_inclusive: _,
             } => (
-                "RangeExpanded",
+                "RangeInclusivityExpanded",
                 PyTuple::new(
                     py,
                     [
@@ -306,7 +305,7 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
                 ),
             ),
             crate::error::Error::ValueNotInRange { value, min, max } => (
-                "RangeExpanded",
+                "ValueNotInRange",
                 PyTuple::new(
                     py,
                     ["value", &format!("{:?}-{:?}", min, max), &value.to_string()],

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -447,9 +447,7 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
         // Unwrap the args Result (PyTuple::new can fail on conversion)
         let args = match args {
             Ok(a) => a,
-            Err(e) => {
-                return py_validation_err(format!("Failed to create args tuple: {}", e))
-            }
+            Err(e) => return py_validation_err(format!("Failed to create args tuple: {}", e)),
         };
 
         match exceptions.getattr(exc_name) {
@@ -458,10 +456,7 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
                 // Note: call1 takes a tuple of arguments. Our 'args' IS that tuple.
                 PyErr::from_value(cls.call1(args).unwrap_or_else(|e| {
                     // Fallback if constructor fails
-                    py_validation_err(e.to_string())
-                        .value(py)
-                        .as_any()
-                        .clone()
+                    py_validation_err(e.to_string()).value(py).as_any().clone()
                 }))
             }
             Err(e) => py_validation_err(e.to_string()),
@@ -476,15 +471,14 @@ fn py_validation_err(message: impl Into<String>) -> PyErr {
 /// Convert a ConfigError to a Python exception.
 fn config_err_to_py(e: crate::gateway_config::ConfigError) -> PyErr {
     Python::attach(|py| match py.import("tenuo.exceptions") {
-        Ok(m) => match m.getattr("ConfigurationError") {
-            Ok(cls) => PyErr::from_value(cls.call1((e.to_string(),)).unwrap_or_else(|_| {
-                py_validation_err(e.to_string())
-                    .value(py)
-                    .as_any()
-                    .clone()
-            })),
-            Err(_) => py_validation_err(e.to_string()),
-        },
+        Ok(m) => {
+            match m.getattr("ConfigurationError") {
+                Ok(cls) => PyErr::from_value(cls.call1((e.to_string(),)).unwrap_or_else(|_| {
+                    py_validation_err(e.to_string()).value(py).as_any().clone()
+                })),
+                Err(_) => py_validation_err(e.to_string()),
+            }
+        }
         Err(_) => py_validation_err(e.to_string()),
     })
 }

--- a/tenuo-core/src/warrant.rs
+++ b/tenuo-core/src/warrant.rs
@@ -941,7 +941,10 @@ impl Warrant {
     ) -> Result<()> {
         // Check expiration
         if self.is_expired() {
-            return Err(Error::WarrantExpired(self.expires_at()));
+            return Err(Error::WarrantExpired {
+                warrant_id: self.id().to_string(),
+                expired_at: self.expires_at(),
+            });
         }
 
         // Only execution warrants can authorize actions
@@ -1011,7 +1014,10 @@ impl Warrant {
     ) -> Result<()> {
         // Check expiration
         if self.is_expired() {
-            return Err(Error::WarrantExpired(self.expires_at()));
+            return Err(Error::WarrantExpired {
+                warrant_id: self.id().to_string(),
+                expired_at: self.expires_at(),
+            });
         }
 
         if self.payload.warrant_type != WarrantType::Execution {
@@ -1933,7 +1939,10 @@ impl<'a> AttenuationBuilder<'a> {
         }
 
         if self.parent.is_expired() {
-            return Err(Error::WarrantExpired(self.parent.expires_at()));
+            return Err(Error::WarrantExpired {
+                warrant_id: self.parent.id().to_string(),
+                expired_at: self.parent.expires_at(),
+            });
         }
 
         // Validate attenuation monotonicity based on warrant type
@@ -2719,7 +2728,10 @@ impl OwnedAttenuationBuilder {
                 .timestamp_opt(self.parent.payload.expires_at as i64, 0)
                 .single()
                 .unwrap_or_else(Utc::now);
-            return Err(Error::WarrantExpired(expiry));
+            return Err(Error::WarrantExpired {
+                warrant_id: self.parent.id().to_string(),
+                expired_at: expiry,
+            });
         }
 
         // Validate attenuation monotonicity
@@ -3132,7 +3144,10 @@ impl<'a> IssuanceBuilder<'a> {
                 .timestamp_opt(self.issuer.payload.expires_at as i64, 0)
                 .single()
                 .unwrap_or_else(Utc::now);
-            return Err(Error::WarrantExpired(expiry));
+            return Err(Error::WarrantExpired {
+                warrant_id: self.issuer.id().to_string(),
+                expired_at: expiry,
+            });
         }
 
         // Validate required fields

--- a/tenuo-core/src/warrant.rs
+++ b/tenuo-core/src/warrant.rs
@@ -1082,6 +1082,7 @@ impl Warrant {
         let now = Utc::now().timestamp();
 
         let mut sorted_args: Vec<(&String, &ConstraintValue)> = args.iter().collect();
+        // determinism: canonical iteration order required — see docs/determinism-audit.md#finding-pop-verify-sort.
         sorted_args.sort_by_key(|(k, _)| *k);
 
         let mut verified = false;
@@ -1163,6 +1164,7 @@ impl Warrant {
         timestamp: Option<i64>,
     ) -> Result<Signature> {
         let mut sorted_args: Vec<(&String, &ConstraintValue)> = args.iter().collect();
+        // determinism: canonical iteration order required — see docs/determinism-audit.md#finding-pop-sign-sort.
         sorted_args.sort_by_key(|(k, _)| *k);
 
         let now = timestamp.unwrap_or_else(|| Utc::now().timestamp());
@@ -1185,6 +1187,7 @@ impl Warrant {
         use sha2::{Digest, Sha256};
 
         let mut sorted_args: Vec<(&String, &ConstraintValue)> = args.iter().collect();
+        // determinism: canonical iteration order required — see docs/determinism-audit.md#finding-dedup-sort.
         sorted_args.sort_by_key(|(k, _)| *k);
 
         let payload = (self.payload.id.to_hex(), tool, &sorted_args);

--- a/tenuo-core/tests/determinism.rs
+++ b/tenuo-core/tests/determinism.rs
@@ -4,7 +4,9 @@ use std::collections::{BTreeMap, HashMap};
 use std::thread;
 use std::time::Duration;
 use tenuo::approval::compute_request_hash;
-use tenuo::approval_gate::{evaluate_approval_gates, ApprovalGateMap, ArgApprovalGate, ToolApprovalGate};
+use tenuo::approval_gate::{
+    evaluate_approval_gates, ApprovalGateMap, ArgApprovalGate, ToolApprovalGate,
+};
 use tenuo::{Authorizer, ConstraintSet, ConstraintValue, SigningKey, Warrant};
 
 const SHUFFLE_RUNS: usize = 16;
@@ -186,22 +188,19 @@ fn parallel_check_chain_with_pop_args_serializes_identically() {
                     .expect("sign should succeed");
 
                 let result = authorizer
-                    .check_chain_with_pop_args(
-                        &chain,
-                        tool_name,
-                        &map,
-                        &map,
-                        Some(&signature),
-                        &[],
-                    )
+                    .check_chain_with_pop_args(&chain, tool_name, &map, &map, Some(&signature), &[])
                     .expect("authorization should succeed");
 
                 let mut bytes = Vec::new();
-                ciborium::ser::into_writer(&result, &mut bytes).expect("result serialization should succeed");
+                ciborium::ser::into_writer(&result, &mut bytes)
+                    .expect("result serialization should succeed");
                 bytes
             }));
         }
-        handles.into_iter().map(|h| h.join().expect("join")).collect::<Vec<_>>()
+        handles
+            .into_iter()
+            .map(|h| h.join().expect("join"))
+            .collect::<Vec<_>>()
     });
 
     assert_all_equal(&outputs, "check_chain_with_pop_args result serialization");

--- a/tenuo-core/tests/determinism.rs
+++ b/tenuo-core/tests/determinism.rs
@@ -1,0 +1,208 @@
+use proptest::prelude::*;
+use rand::seq::SliceRandom;
+use std::collections::{BTreeMap, HashMap};
+use std::thread;
+use std::time::Duration;
+use tenuo::approval::compute_request_hash;
+use tenuo::approval_gate::{evaluate_approval_gates, ApprovalGateMap, ArgApprovalGate, ToolApprovalGate};
+use tenuo::{Authorizer, ConstraintSet, ConstraintValue, SigningKey, Warrant};
+
+const SHUFFLE_RUNS: usize = 16;
+
+fn scalar_value_strategy() -> impl Strategy<Value = ConstraintValue> {
+    prop_oneof![
+        any::<bool>().prop_map(ConstraintValue::Boolean),
+        (-100_000i64..=100_000i64).prop_map(ConstraintValue::Integer),
+        (-10_000.0f64..10_000.0f64)
+            .prop_filter("finite float", |f| f.is_finite())
+            .prop_map(ConstraintValue::Float),
+        "[a-zA-Z0-9_\\-]{0,16}".prop_map(ConstraintValue::String),
+    ]
+}
+
+fn value_strategy() -> impl Strategy<Value = ConstraintValue> {
+    let list_item = scalar_value_strategy();
+    prop_oneof![
+        scalar_value_strategy(),
+        prop::collection::vec(list_item, 0..=4).prop_map(ConstraintValue::List),
+    ]
+}
+
+fn args_strategy() -> impl Strategy<Value = BTreeMap<String, ConstraintValue>> {
+    prop::collection::btree_map("[a-z][a-z0-9_]{0,10}", value_strategy(), 0..=10)
+}
+
+fn shuffled_hashmaps(
+    args: &BTreeMap<String, ConstraintValue>,
+    count: usize,
+) -> Vec<HashMap<String, ConstraintValue>> {
+    let entries: Vec<(String, ConstraintValue)> =
+        args.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+    let mut out = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut shuffled = entries.clone();
+        shuffled.shuffle(&mut rand::rng());
+        let mut map = HashMap::with_capacity(shuffled.len());
+        for (k, v) in shuffled {
+            map.insert(k, v);
+        }
+        out.push(map);
+    }
+    out
+}
+
+fn assert_all_equal<T: PartialEq + std::fmt::Debug>(items: &[T], label: &str) {
+    assert!(!items.is_empty(), "{label}: expected non-empty output");
+    for i in 1..items.len() {
+        assert_eq!(items[i], items[0], "{label}: output differs at index {i}");
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+    #[test]
+    fn parallel_shuffled_maps_produce_identical_outputs(
+        args in args_strategy(),
+        timestamp in 1_700_000_000i64..1_900_000_000i64,
+    ) {
+        let issuer = SigningKey::generate();
+        let holder = SigningKey::generate();
+        let tool_name = "determinism.tool";
+
+        let warrant = Warrant::builder()
+            .capability(tool_name, ConstraintSet::new())
+            .ttl(Duration::from_secs(600))
+            .holder(holder.public_key())
+            .build(&issuer)
+            .expect("warrant should build");
+
+        let mut gated_args = BTreeMap::new();
+        gated_args.insert("k0".to_string(), ArgApprovalGate::All);
+        let approval_gate_map = ApprovalGateMap(BTreeMap::from([(
+            tool_name.to_string(),
+            ToolApprovalGate::with_args(gated_args),
+        )]));
+
+        let sign_outputs = thread::scope(|scope| {
+            let shuffled = shuffled_hashmaps(&args, SHUFFLE_RUNS);
+            let mut handles = Vec::with_capacity(SHUFFLE_RUNS);
+            for map in shuffled {
+                let warrant = &warrant;
+                let holder = &holder;
+                handles.push(scope.spawn(move || {
+                    warrant
+                        .sign_with_timestamp(&holder, tool_name, &map, Some(timestamp))
+                        .expect("sign should succeed")
+                        .to_bytes()
+                        .to_vec()
+                }));
+            }
+            handles.into_iter().map(|h| h.join().expect("join")).collect::<Vec<_>>()
+        });
+        assert_all_equal(&sign_outputs, "sign");
+
+        let dedup_outputs = thread::scope(|scope| {
+            let shuffled = shuffled_hashmaps(&args, SHUFFLE_RUNS);
+            let mut handles = Vec::with_capacity(SHUFFLE_RUNS);
+            for map in shuffled {
+                let warrant = &warrant;
+                handles.push(scope.spawn(move || warrant.dedup_key(tool_name, &map)));
+            }
+            handles.into_iter().map(|h| h.join().expect("join")).collect::<Vec<_>>()
+        });
+        assert_all_equal(&dedup_outputs, "dedup_key");
+
+        let request_hash_outputs = thread::scope(|scope| {
+            let shuffled = shuffled_hashmaps(&args, SHUFFLE_RUNS);
+            let mut handles = Vec::with_capacity(SHUFFLE_RUNS);
+            for map in shuffled {
+                let warrant = &warrant;
+                let holder_pk = holder.public_key();
+                handles.push(scope.spawn(move || {
+                    compute_request_hash(
+                        &warrant.id().to_string(),
+                        tool_name,
+                        &map,
+                        Some(&holder_pk),
+                    )
+                    .to_vec()
+                }));
+            }
+            handles.into_iter().map(|h| h.join().expect("join")).collect::<Vec<_>>()
+        });
+        assert_all_equal(&request_hash_outputs, "compute_request_hash");
+
+        let approval_gate_outputs = thread::scope(|scope| {
+            let shuffled = shuffled_hashmaps(&args, SHUFFLE_RUNS);
+            let mut handles = Vec::with_capacity(SHUFFLE_RUNS);
+            for map in shuffled {
+                let approval_gate_map = &approval_gate_map;
+                handles.push(scope.spawn(move || {
+                    evaluate_approval_gates(Some(&approval_gate_map), tool_name, &map)
+                        .expect("approval gate evaluation should succeed")
+                }));
+            }
+            handles.into_iter().map(|h| h.join().expect("join")).collect::<Vec<_>>()
+        });
+        assert_all_equal(&approval_gate_outputs, "evaluate_approval_gates");
+    }
+}
+
+#[test]
+fn parallel_check_chain_with_pop_args_serializes_identically() {
+    let issuer = SigningKey::generate();
+    let holder = SigningKey::generate();
+    let tool_name = "determinism.chain";
+    let timestamp = chrono::Utc::now().timestamp();
+
+    let warrant = Warrant::builder()
+        .capability(tool_name, ConstraintSet::new())
+        .ttl(Duration::from_secs(600))
+        .holder(holder.public_key())
+        .build(&issuer)
+        .expect("warrant should build");
+    let chain = vec![warrant.clone()];
+
+    let mut authorizer = Authorizer::new();
+    authorizer.add_trusted_root(issuer.public_key());
+
+    let args = BTreeMap::from([
+        ("a".to_string(), ConstraintValue::Integer(1)),
+        ("b".to_string(), ConstraintValue::String("x".to_string())),
+        ("c".to_string(), ConstraintValue::Boolean(true)),
+    ]);
+
+    let outputs = thread::scope(|scope| {
+        let shuffled = shuffled_hashmaps(&args, SHUFFLE_RUNS);
+        let mut handles = Vec::with_capacity(SHUFFLE_RUNS);
+        for map in shuffled {
+            let warrant = &warrant;
+            let holder = &holder;
+            let authorizer = &authorizer;
+            let chain = &chain;
+            handles.push(scope.spawn(move || {
+                let signature = warrant
+                    .sign_with_timestamp(&holder, tool_name, &map, Some(timestamp))
+                    .expect("sign should succeed");
+
+                let result = authorizer
+                    .check_chain_with_pop_args(
+                        &chain,
+                        tool_name,
+                        &map,
+                        &map,
+                        Some(&signature),
+                        &[],
+                    )
+                    .expect("authorization should succeed");
+
+                let mut bytes = Vec::new();
+                ciborium::ser::into_writer(&result, &mut bytes).expect("result serialization should succeed");
+                bytes
+            }));
+        }
+        handles.into_iter().map(|h| h.join().expect("join")).collect::<Vec<_>>()
+    });
+
+    assert_all_equal(&outputs, "check_chain_with_pop_args result serialization");
+}

--- a/tenuo-core/tests/determinism.rs
+++ b/tenuo-core/tests/determinism.rs
@@ -93,7 +93,7 @@ proptest! {
                 let holder = &holder;
                 handles.push(scope.spawn(move || {
                     warrant
-                        .sign_with_timestamp(&holder, tool_name, &map, Some(timestamp))
+                        .sign_with_timestamp(holder, tool_name, &map, Some(timestamp))
                         .expect("sign should succeed")
                         .to_bytes()
                         .to_vec()
@@ -140,7 +140,7 @@ proptest! {
             for map in shuffled {
                 let approval_gate_map = &approval_gate_map;
                 handles.push(scope.spawn(move || {
-                    evaluate_approval_gates(Some(&approval_gate_map), tool_name, &map)
+                    evaluate_approval_gates(Some(approval_gate_map), tool_name, &map)
                         .expect("approval gate evaluation should succeed")
                 }));
             }
@@ -184,11 +184,11 @@ fn parallel_check_chain_with_pop_args_serializes_identically() {
             let chain = &chain;
             handles.push(scope.spawn(move || {
                 let signature = warrant
-                    .sign_with_timestamp(&holder, tool_name, &map, Some(timestamp))
+                    .sign_with_timestamp(holder, tool_name, &map, Some(timestamp))
                     .expect("sign should succeed");
 
                 let result = authorizer
-                    .check_chain_with_pop_args(&chain, tool_name, &map, &map, Some(&signature), &[])
+                    .check_chain_with_pop_args(chain, tool_name, &map, &map, Some(&signature), &[])
                     .expect("authorization should succeed");
 
                 let mut bytes = Vec::new();

--- a/tenuo-python/tenuo/exceptions.py
+++ b/tenuo-python/tenuo/exceptions.py
@@ -93,6 +93,8 @@ __all__ = [
     "ExclusionRemoved",
     "ValueNotInParentSet",
     "RangeExpanded",
+    "RangeInclusivityExpanded",
+    "ValueNotInRange",
     "PatternExpanded",
     "RequiredValueRemoved",
     "ExactValueMismatch",
@@ -644,6 +646,44 @@ class RangeExpanded(MonotonicityError):
             f"Child {bound} ({child_value}, hint=hint) exceeds parent {bound} ({parent_value}, hint=hint)", hint=hint
         )
         self.details = {"bound": bound, "parent_value": parent_value, "child_value": child_value}
+
+
+@wire_code(ErrorCode.CAPABILITY_EXPANSION)
+class RangeInclusivityExpanded(MonotonicityError):
+    """Range child changed an equal bound from exclusive to inclusive."""
+
+    error_code = "range_inclusivity_expanded"
+    rust_variant = "RangeInclusivityExpanded"
+
+    def __init__(self, bound: str, parent_desc: str, child_desc: str, hint: Optional[str] = None):
+        super().__init__(
+            f"Child {bound} ({child_desc}) expands parent bound ({parent_desc}) via inclusivity",
+            hint=hint,
+        )
+        self.details = {
+            "bound": bound,
+            "parent_description": parent_desc,
+            "child_description": child_desc,
+        }
+
+
+@wire_code(ErrorCode.CONSTRAINT_VIOLATION)
+class ValueNotInRange(MonotonicityError):
+    """Value failed to satisfy a range bound."""
+
+    error_code = "value_not_in_range"
+    rust_variant = "ValueNotInRange"
+
+    def __init__(self, bound: str, allowed_range: str, actual_value: str, hint: Optional[str] = None):
+        super().__init__(
+            f"Value not in range: {bound} expected {allowed_range}, got {actual_value}",
+            hint=hint,
+        )
+        self.details = {
+            "bound": bound,
+            "allowed_range": allowed_range,
+            "actual_value": actual_value,
+        }
 
 
 @wire_code(ErrorCode.CAPABILITY_EXPANSION)

--- a/tenuo-python/tests/adapters/test_openai_adapter.py
+++ b/tenuo-python/tests/adapters/test_openai_adapter.py
@@ -2057,14 +2057,15 @@ class TestSubpathConstraint:
     def test_root_must_be_absolute(self):
         """Root must be an absolute path.
 
-        Note: Rust raises RuntimeError (wrapped) instead of ValueError.
-        Both enforce the same security property: relative roots are rejected.
+        Error taxonomy hardening routes Rust-side validation failures through
+        tenuo.exceptions instead of bare builtins.
         """
-        # Rust raises RuntimeError for invalid paths
-        with pytest.raises((ValueError, RuntimeError)):
+        from tenuo.exceptions import TenuoError
+
+        with pytest.raises(TenuoError):
             Subpath("data")
 
-        with pytest.raises((ValueError, RuntimeError)):
+        with pytest.raises(TenuoError):
             Subpath("./data")
 
     def test_integration_with_guard(self):

--- a/tenuo-python/tests/test_determinism_end_to_end.py
+++ b/tenuo-python/tests/test_determinism_end_to_end.py
@@ -1,0 +1,67 @@
+from concurrent.futures import ThreadPoolExecutor
+import random
+from datetime import timedelta
+
+from tenuo_core import SigningKey, Warrant, py_compute_request_hash
+
+
+def _shuffled_args(base_args: dict) -> dict:
+    items = list(base_args.items())
+    random.shuffle(items)
+    return {k: v for k, v in items}
+
+
+def _assert_all_equal(values: list):
+    assert values, "expected non-empty output collection"
+    first = values[0]
+    for idx, value in enumerate(values[1:], 1):
+        assert value == first, f"determinism mismatch at index {idx}"
+
+
+def test_end_to_end_deterministic_sign_dedup_and_request_hash():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    tool_name = "determinism.python.e2e"
+    timestamp = 1_800_000_000
+
+    warrant = Warrant.issue(
+        issuer,
+        capabilities={tool_name: {}},
+        ttl_seconds=int(timedelta(minutes=10).total_seconds()),
+        holder=holder.public_key,
+    )
+    args = {
+        "path": "/data/demo.txt",
+        "count": 3,
+        "flag": True,
+        "tags": ["a", "b"],
+        "score": 1.5,
+    }
+
+    def run_sign() -> bytes:
+        shuffled = _shuffled_args(args)
+        return warrant.sign(holder, tool_name, shuffled, timestamp=timestamp)
+
+    def run_dedup() -> str:
+        shuffled = _shuffled_args(args)
+        return warrant.dedup_key(tool_name, shuffled)
+
+    def run_hash() -> bytes:
+        shuffled = _shuffled_args(args)
+        return bytes(
+            py_compute_request_hash(
+                str(warrant.id),
+                tool_name,
+                shuffled,
+                holder.public_key,
+            )
+        )
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        sign_values = list(pool.map(lambda _: run_sign(), range(100)))
+        dedup_values = list(pool.map(lambda _: run_dedup(), range(100)))
+        hash_values = list(pool.map(lambda _: run_hash(), range(100)))
+
+    _assert_all_equal(sign_values)
+    _assert_all_equal(dedup_values)
+    _assert_all_equal(hash_values)

--- a/tenuo-python/tests/test_determinism_end_to_end.py
+++ b/tenuo-python/tests/test_determinism_end_to_end.py
@@ -5,9 +5,10 @@ from datetime import timedelta
 from tenuo_core import SigningKey, Warrant, py_compute_request_hash
 
 
-def _shuffled_args(base_args: dict) -> dict:
+def _shuffled_args(base_args: dict, seed: int) -> dict:
     items = list(base_args.items())
-    random.shuffle(items)
+    rng = random.Random(seed)
+    rng.shuffle(items)
     return {k: v for k, v in items}
 
 
@@ -38,16 +39,16 @@ def test_end_to_end_deterministic_sign_dedup_and_request_hash():
         "score": 1.5,
     }
 
-    def run_sign() -> bytes:
-        shuffled = _shuffled_args(args)
+    def run_sign(iter_idx: int) -> bytes:
+        shuffled = _shuffled_args(args, seed=iter_idx)
         return warrant.sign(holder, tool_name, shuffled, timestamp=timestamp)
 
-    def run_dedup() -> str:
-        shuffled = _shuffled_args(args)
+    def run_dedup(iter_idx: int) -> str:
+        shuffled = _shuffled_args(args, seed=iter_idx)
         return warrant.dedup_key(tool_name, shuffled)
 
-    def run_hash() -> bytes:
-        shuffled = _shuffled_args(args)
+    def run_hash(iter_idx: int) -> bytes:
+        shuffled = _shuffled_args(args, seed=iter_idx)
         return bytes(
             py_compute_request_hash(
                 str(warrant.id),
@@ -58,9 +59,9 @@ def test_end_to_end_deterministic_sign_dedup_and_request_hash():
         )
 
     with ThreadPoolExecutor(max_workers=16) as pool:
-        sign_values = list(pool.map(lambda _: run_sign(), range(100)))
-        dedup_values = list(pool.map(lambda _: run_dedup(), range(100)))
-        hash_values = list(pool.map(lambda _: run_hash(), range(100)))
+        sign_values = list(pool.map(run_sign, range(100)))
+        dedup_values = list(pool.map(run_dedup, range(100)))
+        hash_values = list(pool.map(run_hash, range(100)))
 
     _assert_all_equal(sign_values)
     _assert_all_equal(dedup_values)

--- a/tenuo-python/tests/test_eager_init.py
+++ b/tenuo-python/tests/test_eager_init.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pytest
+import tenuo_core as core
+from tenuo.exceptions import ConfigurationError, TenuoError, ValidationError
+
+
+def _assert_raises(exc_type, fn):
+    with pytest.raises(exc_type):
+        fn()
+
+
+def test_authorizer_init_fails_immediately_on_invalid_args():
+    _assert_raises(ValidationError, lambda: core.Authorizer(clock_tolerance_secs=-1))
+    _assert_raises(ValidationError, lambda: core.Authorizer(pop_window_secs=0))
+    _assert_raises(ValidationError, lambda: core.Authorizer(pop_max_windows=0))
+
+
+def test_key_and_warrant_parsers_fail_at_construction():
+    _assert_raises(ValidationError, lambda: core.SigningKey.from_bytes(b"short"))
+    _assert_raises(ValidationError, lambda: core.PublicKey.from_bytes(b"short"))
+    _assert_raises(TenuoError, lambda: core.Warrant.from_bytes(b"not-cbor"))
+    _assert_raises(TenuoError, lambda: core.Warrant.from_base64("not-base64"))
+
+
+def test_mcp_config_parsers_fail_at_construction(tmp_path: Path):
+    missing = tmp_path / "missing.yaml"
+    _assert_raises(ConfigurationError, lambda: core.McpConfig.from_file(str(missing)))
+
+    tools = []
+    for i in range(201):
+        tools.append(
+            f"  tool_{i}:\n"
+            f"    description: \"Tool {i}\"\n"
+            "    constraints: {}\n"
+        )
+    cfg = (
+        'version: "1"\n'
+        "settings:\n"
+        "  trusted_issuers: []\n"
+        "tools:\n"
+        + "".join(tools)
+    )
+    cfg_path = tmp_path / "too_many_tools.yaml"
+    cfg_path.write_text(cfg, encoding="utf-8")
+
+    parsed = core.McpConfig.from_file(str(cfg_path))
+    _assert_raises(ConfigurationError, lambda: core.CompiledMcpConfig.compile(parsed))

--- a/tenuo-python/tests/test_error_taxonomy.py
+++ b/tenuo-python/tests/test_error_taxonomy.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 
 import tenuo_core as core
 from tenuo.exceptions import TenuoError
@@ -30,3 +31,43 @@ def test_function_level_validation_errors_are_tenuo_errors():
 def test_mcp_config_errors_are_tenuo_errors(tmp_path):
     missing = tmp_path / "missing.yml"
     _assert_tenuo_error(lambda: core.McpConfig.from_file(str(missing)))
+
+
+def test_to_py_err_exception_names_exist():
+    import tenuo.exceptions as exc
+
+    required_names = {
+        "InvalidWarrantType",
+        "IssueDepthExceeded",
+        "IssuerChainTooLong",
+        "SelfIssuanceProhibited",
+        "ClearanceLevelExceeded",
+        "UnauthorizedToolIssuance",
+        "DelegationAuthorityError",
+        "ConstraintDepthExceeded",
+        "PayloadTooLarge",
+        "RangeInclusivityExpanded",
+        "ValueNotInRange",
+    }
+    missing = sorted(name for name in required_names if not hasattr(exc, name))
+    assert not missing, f"missing exception classes in tenuo.exceptions: {missing}"
+
+
+def test_warrant_expired_preserves_warrant_id():
+    issuer = core.SigningKey.generate()
+    holder = core.SigningKey.generate()
+    warrant = core.Warrant.issue(
+        issuer,
+        capabilities={"tool.expire": {}},
+        ttl_seconds=1,
+        holder=holder.public_key,
+    )
+    time.sleep(2)
+
+    authorizer = core.Authorizer(trusted_roots=[issuer.public_key])
+    with pytest.raises(TenuoError) as exc_info:
+        authorizer.authorize_one(warrant, "tool.expire", {}, None)
+
+    err = exc_info.value
+    details = getattr(err, "details", {})
+    assert details.get("warrant_id") == str(warrant.id)

--- a/tenuo-python/tests/test_error_taxonomy.py
+++ b/tenuo-python/tests/test_error_taxonomy.py
@@ -1,0 +1,32 @@
+import pytest
+
+import tenuo_core as core
+from tenuo.exceptions import TenuoError
+
+
+def _assert_tenuo_error(fn):
+    with pytest.raises(Exception) as exc_info:
+        fn()
+    assert isinstance(exc_info.value, TenuoError), (
+        f"expected TenuoError subclass, got {type(exc_info.value).__name__}: {exc_info.value}"
+    )
+
+
+def test_common_invalid_inputs_raise_tenuo_errors():
+    _assert_tenuo_error(lambda: core.SigningKey.from_bytes(b"short"))
+    _assert_tenuo_error(lambda: core.PublicKey.from_bytes(b"short"))
+    _assert_tenuo_error(lambda: core.Signature.from_bytes(b"short"))
+    _assert_tenuo_error(lambda: core.WarrantType("invalid"))
+    _assert_tenuo_error(lambda: core.Clearance(object()))
+    _assert_tenuo_error(lambda: core.Authorizer().verify_chain([]))
+
+
+def test_function_level_validation_errors_are_tenuo_errors():
+    _assert_tenuo_error(lambda: core.py_compute_request_hash("w", "t", {"k": object()}, None))
+    _assert_tenuo_error(lambda: core.verify_approvals(b"short", [], [], 1, 30))
+    _assert_tenuo_error(lambda: core.verify_approvals(bytes(32), [], [], 0, 30))
+
+
+def test_mcp_config_errors_are_tenuo_errors(tmp_path):
+    missing = tmp_path / "missing.yml"
+    _assert_tenuo_error(lambda: core.McpConfig.from_file(str(missing)))


### PR DESCRIPTION
## Summary
- Add deterministic-order regression coverage in Rust and Python (`tenuo-core/tests/determinism.rs`, `tenuo-python/tests/test_determinism_end_to_end.py`) for PoP signing, dedup keys, request hashing, and parallel authorization serialization.
- Harden PyO3 error taxonomy so FFI-exposed validation/runtime paths map through `tenuo.exceptions` and remove panic-style unwrap/expect usage in FFI conversion paths.
- Add eager-init constructor validation and tests (`tenuo-python/tests/test_eager_init.py`) and taxonomy contract tests (`tenuo-python/tests/test_error_taxonomy.py`).


## Test plan
- [x] `cargo test --all`
- [x] `cargo test --all --release`
- [x] `cargo test --test determinism`
- [x] `uv run pytest tenuo-python/` (known pre-existing temporal live/property failures remain)
- [x] `uv run pytest tenuo-python/tests -k mcp`
- [x] `uv run pytest tenuo-python/tests -k temporal` (same known temporal baseline failures)
- [x] `uv run pytest tenuo-python/tests/adapters/test_mcp_ci_smoke.py`
- [x] `uv run pytest tenuo-python/tests/test_error_taxonomy.py`
- [x] `uv run pytest tenuo-python/tests/test_eager_init.py`
- [x] `uv run pytest tenuo-python/tests/test_determinism_end_to_end.py`
- [x] `uv run maturin build --release --out dist` + fresh venv import smoke for `tenuo_core` and `tenuo`