### PR TITLE
temporal: address review feedback on TenuoTemporalPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   error points at the `Client.connect(plugins=[plugin])` inheritance
   pattern. `DictKeyResolver` in the replay tests now raises
   `KeyResolutionError` instead of `ValueError`.
+- **`tenuo.temporal.TenuoPlugin` renamed to `TenuoWorkerInterceptor`**
+  (DABH "plugin confusion" feedback): the class is a Temporal SDK
+  `WorkerInterceptor`, not a Temporal SDK `Plugin`, and its old name was
+  easy to confuse with `tenuo.temporal_plugin.TenuoTemporalPlugin` — with
+  real failure modes (`Worker(plugins=[TenuoPlugin(...)])` silently
+  accepting an unusable argument). The old name is still importable from
+  `tenuo.temporal` as a deprecated alias that emits a `DeprecationWarning`
+  on first use; it will be removed in a future beta. Update imports to
+  `from tenuo.temporal import TenuoWorkerInterceptor`. (Most users use
+  `TenuoTemporalPlugin` via `Client.connect(plugins=[plugin])` and are
+  unaffected.)
 - **MCP PoP parity across config asymmetry.** A client without a
   `CompiledMcpConfig` loaded (or with a different one) can now call a server
   that does have a config; PoP byte parity no longer depends on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,36 +83,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Temporal plugin no longer mutates user-owned config.** `TenuoTemporalPlugin`
-  now works on a shallow copy of the supplied `TenuoPluginConfig`, so two
-  workers that share a single config object cannot leak activity registries
-  or trigger each other's "duplicate plugin registration" guard.
-- **`TenuoTemporalPlugin` registers Tenuo exceptions as Temporal workflow
-  failures.** `TenuoContextError`, `PopVerificationError`,
-  `TemporalConstraintViolation`, `WarrantExpired`, `ChainValidationError`,
-  `KeyResolutionError`, and `LocalActivityError` are now passed to
-  `SimplePlugin` as `workflow_failure_exception_types` on SDKs that support
-  it, so denied or misconfigured activities fail the workflow cleanly
-  instead of being wrapped as infrastructure errors.
-- **Key preload failures escalate correctly.** `TenuoTemporalPlugin` now logs
-  `preload_all()` failures at `ERROR` (not `WARNING`) with the resolver
-  class name, and raises `ConfigurationError` immediately for
-  `EnvKeyResolver` since `resolve_sync()` cannot fall back to `os.environ`
-  inside the Temporal workflow sandbox.
-- **`ensure_tenuo_workflow_runner` rejects `UnsandboxedWorkflowRunner`.**
-  The helper now raises `ConfigurationError` when an unsandboxed runner is
-  passed and logs a warning for unknown custom runners, so silent loss of
-  `tenuo` / `tenuo_core` passthrough at worker init time is no longer
-  possible.
-- **Clearer guidance on duplicate plugin registration.** The error raised
-  when the same `TenuoTemporalPlugin` instance configures two workers now
-  points at the recommended `Client.connect(plugins=[plugin])` inheritance
-  pattern instead of advising separate instances per worker.
-- **Replay tests now assert verification actually runs.** `test_temporal_replay.py`
-  adds a tampered-history test (flips one PoP byte in a captured history,
-  expects replay failure) and a rotated-trusted-roots test (replays with
-  the recording issuer removed, expects replay failure). `DictKeyResolver`
-  also raises `KeyResolutionError` instead of `ValueError`.
+- **`TenuoTemporalPlugin` hardening** (DABH review follow-ups): no longer
+  mutates the user's `TenuoPluginConfig` (works on a copy so two workers
+  sharing a config stay isolated); registers Tenuo's domain exceptions as
+  `workflow_failure_exception_types` on supporting SDKs; escalates
+  `preload_all()` failures to `ERROR` and raises `ConfigurationError` for
+  `EnvKeyResolver` (no safe `os.environ` fallback in the sandbox);
+  `ensure_tenuo_workflow_runner` now rejects `UnsandboxedWorkflowRunner`
+  outright and warns for unknown custom runners; duplicate-registration
+  error points at the `Client.connect(plugins=[plugin])` inheritance
+  pattern. New replay tests flip a byte in the recorded PoP header and
+  rotate the trusted root set to confirm verification still runs on
+  replay. `DictKeyResolver` now raises `KeyResolutionError` instead of
+  `ValueError`.
 - **MCP PoP parity across config asymmetry.** A client without a
   `CompiledMcpConfig` loaded (or with a different one) can now call a server
   that does have a config; PoP byte parity no longer depends on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,10 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ensure_tenuo_workflow_runner` now rejects `UnsandboxedWorkflowRunner`
   outright and warns for unknown custom runners; duplicate-registration
   error points at the `Client.connect(plugins=[plugin])` inheritance
-  pattern. New replay tests flip a byte in the recorded PoP header and
-  rotate the trusted root set to confirm verification still runs on
-  replay. `DictKeyResolver` now raises `KeyResolutionError` instead of
-  `ValueError`.
+  pattern. `DictKeyResolver` in the replay tests now raises
+  `KeyResolutionError` instead of `ValueError`.
 - **MCP PoP parity across config asymmetry.** A client without a
   `CompiledMcpConfig` loaded (or with a different one) can now call a server
   that does have a config; PoP byte parity no longer depends on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `workflow_failure_exception_types` on supporting SDKs; escalates
   `preload_all()` failures to `ERROR` and raises `ConfigurationError` for
   `EnvKeyResolver` (no safe `os.environ` fallback in the sandbox);
-  `ensure_tenuo_workflow_runner` now rejects `UnsandboxedWorkflowRunner`
-  outright and warns for unknown custom runners; duplicate-registration
+  `ensure_tenuo_workflow_runner` now emits a `UserWarning` (plus a logger
+  warning) for `UnsandboxedWorkflowRunner` instead of silently accepting
+  it, and warns for unknown custom runners; duplicate-registration
   error points at the `Client.connect(plugins=[plugin])` inheritance
   pattern. `DictKeyResolver` in the replay tests now raises
   `KeyResolutionError` instead of `ValueError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Temporal plugin no longer mutates user-owned config.** `TenuoTemporalPlugin`
+  now works on a shallow copy of the supplied `TenuoPluginConfig`, so two
+  workers that share a single config object cannot leak activity registries
+  or trigger each other's "duplicate plugin registration" guard.
+- **`TenuoTemporalPlugin` registers Tenuo exceptions as Temporal workflow
+  failures.** `TenuoContextError`, `PopVerificationError`,
+  `TemporalConstraintViolation`, `WarrantExpired`, `ChainValidationError`,
+  `KeyResolutionError`, and `LocalActivityError` are now passed to
+  `SimplePlugin` as `workflow_failure_exception_types` on SDKs that support
+  it, so denied or misconfigured activities fail the workflow cleanly
+  instead of being wrapped as infrastructure errors.
+- **Key preload failures escalate correctly.** `TenuoTemporalPlugin` now logs
+  `preload_all()` failures at `ERROR` (not `WARNING`) with the resolver
+  class name, and raises `ConfigurationError` immediately for
+  `EnvKeyResolver` since `resolve_sync()` cannot fall back to `os.environ`
+  inside the Temporal workflow sandbox.
+- **`ensure_tenuo_workflow_runner` rejects `UnsandboxedWorkflowRunner`.**
+  The helper now raises `ConfigurationError` when an unsandboxed runner is
+  passed and logs a warning for unknown custom runners, so silent loss of
+  `tenuo` / `tenuo_core` passthrough at worker init time is no longer
+  possible.
+- **Clearer guidance on duplicate plugin registration.** The error raised
+  when the same `TenuoTemporalPlugin` instance configures two workers now
+  points at the recommended `Client.connect(plugins=[plugin])` inheritance
+  pattern instead of advising separate instances per worker.
+- **Replay tests now assert verification actually runs.** `test_temporal_replay.py`
+  adds a tampered-history test (flips one PoP byte in a captured history,
+  expects replay failure) and a rotated-trusted-roots test (replays with
+  the recording issuer removed, expects replay failure). `DictKeyResolver`
+  also raises `KeyResolutionError` instead of `ValueError`.
 - **MCP PoP parity across config asymmetry.** A client without a
   `CompiledMcpConfig` loaded (or with a different one) can now call a server
   that does have a config; PoP byte parity no longer depends on the

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -311,14 +311,14 @@ tools = guard(
 ### Temporal
 
 ```python
-from tenuo.temporal import TenuoPluginConfig, TenuoPlugin
+from tenuo.temporal import TenuoPluginConfig, TenuoWorkerInterceptor
 
 config = TenuoPluginConfig(
     key_resolver=resolver,
     trusted_roots=[control_key.public_key],
     approval_handler=cli_prompt(approver_key=approver_key),
 )
-plugin = TenuoPlugin(config)
+plugin = TenuoWorkerInterceptor(config)
 ```
 
 ---

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -91,7 +91,7 @@ Tracks compatibility between Tenuo and upstream integration libraries.
 
 **Version Notes**:
 - **1.23.0**: Minimum required version. Introduces `SimplePlugin` API used by `TenuoTemporalPlugin`.
-- **<1.23.0**: `TenuoTemporalPlugin` is not available. Manual `TenuoPlugin` + `Worker(interceptors=[...])` pattern works.
+- **<1.23.0**: `TenuoTemporalPlugin` is not available. Manual `TenuoWorkerInterceptor` + `Worker(interceptors=[...])` pattern works.
 - Replay safety (determinism of PoP signatures, `workflow.now()` usage) is verified on both minimum and latest.
 
 **Replay Safety Testing**:

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -44,7 +44,7 @@ Integrates with the frameworks teams already use:
 | LangGraph | `tenuo.langgraph` | `TenuoToolNode` / `TenuoMiddleware` |
 | OpenAI | `tenuo.openai` | `verify_tool_call()` |
 | CrewAI | `tenuo.crewai` | `@guard` decorator |
-| Google ADK | `tenuo.google_adk` | `TenuoPlugin` |
+| Google ADK | `tenuo.google_adk` | `TenuoWorkerInterceptor` |
 | AutoGen | `tenuo.autogen` | `@guard` decorator |
 | Temporal | `tenuo.temporal` | Workflow-level warrants |
 | FastAPI | `tenuo.fastapi` | Middleware / dependency injection |

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -42,7 +42,7 @@ Checklist for moving past local demos (each item stands alone; links go deeper):
 
 1. **Issuer vs holder keys** — Issuer (`control_key`) only mints warrants; the holder key is resolved on the worker via a production [`KeyResolver`](#key-management-required) (Vault, AWS Secrets Manager, or GCP Secret Manager), not [`EnvKeyResolver`](#development-environment-variables).
 2. **Preload if you still use env keys in lower envs** — Call [`preload_keys`](#development-environment-variables) with every holder `key_id` **before** `Worker(...)`, because PoP signing runs in the workflow sandbox where `os.environ` is unavailable for non-determinism reasons.
-3. **Sandbox passthrough** — `TenuoTemporalPlugin` handles this automatically. If using `TenuoPlugin` manually, you must set `SandboxRestrictions.default.with_passthrough_modules("tenuo", "tenuo_core")` so PyO3 can load once; without it, workflow tasks fail with `ImportError: PyO3 modules may only be initialized once...` ([details](#sandbox-passthrough-explained)).
+3. **Sandbox passthrough** — `TenuoTemporalPlugin` handles this automatically. If using `TenuoWorkerInterceptor` manually, you must set `SandboxRestrictions.default.with_passthrough_modules("tenuo", "tenuo_core")` so PyO3 can load once; without it, workflow tasks fail with `ImportError: PyO3 modules may only be initialized once...` ([details](#sandbox-passthrough-explained)).
 4. **Named argument constraints** — If the warrant constrains fields like `path=` or `bucket=`, set [`activity_fns`](#activity-registry-activity_fns-and-pop-argument-names) to the **same** callables as `Worker(activities=[...])`, or use `tenuo_execute_activity()`, so PoP can name arguments correctly.
 5. **Starting workflows under concurrency** — Prefer `execute_workflow_authorized(...)` so Tenuo headers are bound to `workflow_id` and are not mixed across parallel starts.
 6. **Authorized child workflows** — Use only `tenuo_execute_child_workflow()`; the stock `workflow.execute_child_workflow()` does not propagate warrant headers.
@@ -62,7 +62,7 @@ All documented symbols can be imported from the top-level package (`from tenuo.t
 | `tenuo.temporal._headers` | `tenuo_headers` |
 | `tenuo.temporal._workflow` | `execute_workflow_authorized`, `start_workflow_authorized`, `tenuo_execute_activity`, `tenuo_execute_child_workflow`, `AuthorizedWorkflow`, `current_warrant`, `current_key_id`, `workflow_grant`, `set_activity_approvals` |
 | `tenuo.temporal._client` | `TenuoClientInterceptor`, `TenuoWarrantContextPropagator`, `tenuo_warrant_context` |
-| `tenuo.temporal._interceptors` | `TenuoPlugin` |
+| `tenuo.temporal._interceptors` | `TenuoWorkerInterceptor` |
 | `tenuo.temporal._dedup` | `PopDedupStore`, `InMemoryPopDedupStore` |
 | `tenuo.temporal._decorators` | `tool`, `unprotected` |
 | `tenuo.temporal._observability` | `TemporalAuditEvent`, `TenuoMetrics` |
@@ -72,7 +72,9 @@ All documented symbols can be imported from the top-level package (`from tenuo.t
 
 ---
 
-## `TenuoPlugin` (manual setup)
+## `TenuoWorkerInterceptor` (manual setup)
+
+> Renamed from `TenuoPlugin` to `TenuoWorkerInterceptor`. The old name is still importable from `tenuo.temporal` but emits a `DeprecationWarning` — it was a Temporal SDK `WorkerInterceptor`, not a Temporal SDK `Plugin`, and the resemblance to [`TenuoTemporalPlugin`](#tenuotemporalplugin-recommended) caused real misconfiguration.
 
 For cases where you need manual control over interceptors and the sandbox runner (instead of `TenuoTemporalPlugin`):
 
@@ -81,14 +83,14 @@ from temporalio.client import Client
 from temporalio.worker import Worker
 from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner, SandboxRestrictions
 from tenuo import SigningKey
-from tenuo.temporal import TenuoPlugin, TenuoPluginConfig, TenuoClientInterceptor, EnvKeyResolver
+from tenuo.temporal import TenuoWorkerInterceptor, TenuoPluginConfig, TenuoClientInterceptor, EnvKeyResolver
 
 control = SigningKey.generate()
 
 client_interceptor = TenuoClientInterceptor()
 client = await Client.connect("localhost:7233", interceptors=[client_interceptor])
 
-worker_interceptor = TenuoPlugin(TenuoPluginConfig(
+worker_interceptor = TenuoWorkerInterceptor(TenuoPluginConfig(
     key_resolver=EnvKeyResolver(),
     trusted_roots=[control.public_key],
 ))
@@ -171,7 +173,7 @@ For distributed deployments (separate client and worker processes):
 | Component | Responsibility | Required |
 |-----------|----------------|----------|
 | Client | Start workflows with Tenuo headers (`execute_workflow_authorized` or `set_headers_for_workflow`) | Yes |
-| Workflow worker | Register `TenuoPlugin` and passthrough modules (`tenuo`, `tenuo_core`) | Yes |
+| Workflow worker | Register `TenuoWorkerInterceptor` and passthrough modules (`tenuo`, `tenuo_core`) | Yes |
 | Activity worker | Receive propagated headers and enforce PoP/constraints | Yes |
 | Key management | Resolve `key_id` to signing key using `KeyResolver` | Yes |
 | Trusted roots | Provide `trusted_roots` (or global `configure(trusted_roots=...)`) | Yes |
@@ -296,7 +298,7 @@ export TENUO_KEY_agent1=$(python -c "from tenuo import SigningKey; import base64
 export TENUO_ENV=development   # suppress production warning
 ```
 
-`TenuoTemporalPlugin` calls `preload_all()` automatically, scanning all `TENUO_KEY_*` variables into an in-memory cache before the sandbox activates. If using `TenuoPlugin` manually, call `resolver.preload_all()` before `Worker(...)` — PoP signing runs inside the workflow sandbox where `os.environ` is blocked.
+`TenuoTemporalPlugin` calls `preload_all()` automatically, scanning all `TENUO_KEY_*` variables into an in-memory cache before the sandbox activates. If using `TenuoWorkerInterceptor` manually, call `resolver.preload_all()` before `Worker(...)` — PoP signing runs inside the workflow sandbox where `os.environ` is blocked.
 
 > **Warning:** `EnvKeyResolver` is for development only. In production, use Vault, AWS Secrets Manager, or GCP Secret Manager.
 
@@ -393,7 +395,7 @@ Each activity call gets a PoP signature over a payload that includes the **tool 
 ```python
 activities = [read_file, write_file]
 
-interceptor = TenuoPlugin(
+interceptor = TenuoWorkerInterceptor(
     TenuoPluginConfig(
         key_resolver=EnvKeyResolver(),
         trusted_roots=[control_key.public_key],
@@ -918,7 +920,7 @@ For the full constraint reference, see [`docs/constraints.md`](./constraints.md)
 
 ## Migration Path (from plain Temporal)
 
-1. **Plugin**: add `TenuoTemporalPlugin` to `Client.connect(plugins=[...])` — this handles interceptors, sandbox passthrough, and key preloading in one step. (For manual control, use `TenuoPlugin` + `SandboxedWorkflowRunner` instead; see [examples README](https://github.com/tenuo-ai/tenuo/tree/main/tenuo-python/examples/temporal).)
+1. **Plugin**: add `TenuoTemporalPlugin` to `Client.connect(plugins=[...])` — this handles interceptors, sandbox passthrough, and key preloading in one step. (For manual control, use `TenuoWorkerInterceptor` + `SandboxedWorkflowRunner` instead; see [examples README](https://github.com/tenuo-ai/tenuo/tree/main/tenuo-python/examples/temporal).)
 2. **Client**: start workflows with `execute_workflow_authorized(...)` (or `start_workflow_authorized(...)` for the signal/query pattern).
 3. **Children**: replace `execute_child_workflow()` with `tenuo_execute_child_workflow()`.
 4. **Rollout**: one task queue or tenant first, then expand.

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -74,6 +74,15 @@ export TENUO_KEY_agent1=$(python -c "from tenuo import SigningKey; import base64
 
 > **Important:** Pass the plugin on `Client.connect(plugins=[plugin])` only. Workers created from that client automatically merge client plugins — do not duplicate.
 
+> **About the names.** Two public classes have similar names on purpose — they are *not* the same:
+>
+> | Class | Type | When to use |
+> |---|---|---|
+> | `tenuo.temporal_plugin.TenuoTemporalPlugin` | Temporal SDK **`SimplePlugin`** | **Default.** Pass to `Client.connect(plugins=[...])`. Wires the client interceptor, worker interceptor, and sandboxed workflow runner in one step. |
+> | `tenuo.temporal.TenuoWorkerInterceptor` | Temporal SDK **`WorkerInterceptor`** | Advanced only. Use when you are hand-composing your own `Plugin` / `SimplePlugin` and just want Tenuo's authorization interceptor. |
+>
+> `TenuoWorkerInterceptor` was previously named `TenuoPlugin`. That old name is still importable from `tenuo.temporal` but now emits a `DeprecationWarning` because it is a worker interceptor, not a plugin, and the resemblance to `TenuoTemporalPlugin` caused real misconfiguration (`Worker(plugins=[TenuoPlugin(...)])` — which silently does nothing). Update imports to `TenuoWorkerInterceptor`.
+
 ## Start an authorized workflow
 
 Pass a warrant and key ID when starting a workflow. The warrant defines what the agent is allowed to do — your control plane or policy layer mints it.

--- a/tenuo-python/examples/temporal/README.md
+++ b/tenuo-python/examples/temporal/README.md
@@ -86,7 +86,7 @@ result = await execute_workflow_authorized(
 )
 ```
 
-With `TenuoPlugin` on the worker, you can call normal `workflow.execute_activity(...)`. No Tenuo imports are required inside the workflow for that path. If the warrant uses named field constraints (`path=`, `bucket=`, …), configure `activity_fns` (below).
+With `TenuoWorkerInterceptor` on the worker, you can call normal `workflow.execute_activity(...)`. No Tenuo imports are required inside the workflow for that path. If the warrant uses named field constraints (`path=`, `bucket=`, …), configure `activity_fns` (below).
 
 ```python
 @workflow.defn
@@ -184,7 +184,7 @@ worker = Worker(
 
 > **Important:** Pass the plugin on `Client.connect(plugins=[plugin])` only. Workers created from that client inherit it automatically — do not pass it again on `Worker(plugins=[...])`.
 
-### Advanced: manual `TenuoPlugin` + sandbox runner
+### Advanced: manual `TenuoWorkerInterceptor` + sandbox runner
 
 Use this when you need full control over the sandbox runner or interceptor composition (e.g. combining with other interceptors):
 
@@ -193,12 +193,12 @@ from temporalio.worker.workflow_sandbox import (
     SandboxedWorkflowRunner, SandboxRestrictions,
 )
 
-from tenuo.temporal import EnvKeyResolver, TenuoPlugin, TenuoPluginConfig
+from tenuo.temporal import EnvKeyResolver, TenuoWorkerInterceptor, TenuoPluginConfig
 
 resolver = EnvKeyResolver()
 resolver.preload_all()  # cache all TENUO_KEY_* env vars before Worker starts
 
-interceptor = TenuoPlugin(
+interceptor = TenuoWorkerInterceptor(
     TenuoPluginConfig(
         key_resolver=resolver,
         on_denial="raise",
@@ -275,11 +275,11 @@ pytest tests/e2e/test_temporal_e2e.py -v   # mocked Temporal integration tests (
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `ConfigurationError` … `trusted_roots` | `TenuoPluginConfig` built without roots and no global `configure` | Pass `trusted_roots=[control_key.public_key]` or call `tenuo.configure(trusted_roots=[...])` before constructing the config |
-| `ImportError: PyO3 modules ... initialized once` | Missing passthrough modules | `TenuoTemporalPlugin` handles this automatically. If using manual `TenuoPlugin`, add `with_passthrough_modules("tenuo", "tenuo_core")` to sandbox config |
+| `ImportError: PyO3 modules ... initialized once` | Missing passthrough modules | `TenuoTemporalPlugin` handles this automatically. If using manual `TenuoWorkerInterceptor`, add `with_passthrough_modules("tenuo", "tenuo_core")` to sandbox config |
 | `TenuoContextError: No Tenuo headers in store` | Workflow started without headers | Use `execute_workflow_authorized(...)` or call `set_headers_for_workflow(workflow_id, tenuo_headers(...))` before `execute_workflow` |
 | `TemporalConstraintViolation: No warrant provided` | Headers not reaching worker | Ensure `TenuoTemporalPlugin` is passed to `Client.connect(plugins=[plugin])`, or if using manual setup, that `TenuoClientInterceptor` is in the client's interceptor list |
 | `PopVerificationError: replay detected` | Same activity attempt reached two workers (fleet-wide dedup not configured) | Expected with in-memory dedup and multiple worker pods; configure `pop_dedup_store` with a shared backend for fleet-wide suppression |
-| `KeyResolutionError: Cannot resolve key: <id>` | Signing key not found by `KeyResolver` | For `EnvKeyResolver`: set `TENUO_KEY_<key_id>` env vars before constructing the plugin. `TenuoTemporalPlugin` calls `preload_all()` automatically; if using manual `TenuoPlugin`, call `resolver.preload_all()` before `Worker(...)`. For cloud resolvers: verify secret name, permissions, and region |
+| `KeyResolutionError: Cannot resolve key: <id>` | Signing key not found by `KeyResolver` | For `EnvKeyResolver`: set `TENUO_KEY_<key_id>` env vars before constructing the plugin. `TenuoTemporalPlugin` calls `preload_all()` automatically; if using manual `TenuoWorkerInterceptor`, call `resolver.preload_all()` before `Worker(...)`. For cloud resolvers: verify secret name, permissions, and region |
 | Warning: `PoP signing … uses positional argument keys (arg0, …)` | Warrant uses named field constraints but activity function reference not available | Add `activity_fns=[read_file, ...]` to `TenuoPluginConfig` (same list as `Worker(activities=...)`), or use `tenuo_execute_activity()` |
 | `TenuoContextError` (in `strict_mode`) | Same as above but fail-fast is on | See above; remove `strict_mode=True` temporarily to diagnose, then fix `activity_fns` |
 | Activity denied despite valid warrant | PoP computation failed silently | Check worker logs for WARNING/ERROR messages from outbound interceptor; verify `key_id` matches a key accessible to `KeyResolver` |

--- a/tenuo-python/examples/temporal/cloud_iam_layering.py
+++ b/tenuo-python/examples/temporal/cloud_iam_layering.py
@@ -4,7 +4,7 @@ Tenuo + Temporal + MCP + IAM: three enforcement layers
 The worker process has broad IAM permissions to read any object in an S3 bucket.
 This example adds **two** Tenuo boundaries before AWS:
 
-1. **Temporal activity** — ``TenuoPlugin`` verifies warrant + PoP for
+1. **Temporal activity** — ``TenuoWorkerInterceptor`` verifies warrant + PoP for
    ``read_s3_via_mcp`` with ``bucket`` / ``key`` before the activity runs.
 2. **MCP tool** — ``MCPVerifier`` on ``cloud_iam_mcp_server.py`` verifies the
    same holder's warrant + PoP for ``s3_get_object`` before ``GetObject``.

--- a/tenuo-python/examples/temporal/cloud_iam_mcp_server.py
+++ b/tenuo-python/examples/temporal/cloud_iam_mcp_server.py
@@ -4,7 +4,7 @@ Stdio MCP server for examples/temporal/cloud_iam_layering.py.
 
 Exposes ``s3_get_object`` as an MCP tool. Each ``tools/call`` is verified with
 ``MCPVerifier`` (warrant + PoP in ``params._meta["tenuo"]``) before any AWS
-access. This is the **second** Tenuo boundary after ``TenuoPlugin`` on the
+access. This is the **second** Tenuo boundary after ``TenuoWorkerInterceptor`` on the
 Temporal activity; IAM on the worker remains the third layer at the AWS API.
 
 Environment:

--- a/tenuo-python/examples/temporal/demo.py
+++ b/tenuo-python/examples/temporal/demo.py
@@ -6,7 +6,7 @@ Demonstrates TRANSPARENT warrant-based authorization for Temporal workflows.
 Two patterns are shown side-by-side:
 
   Pattern A — Standard Temporal API (zero workflow changes):
-    workflow.execute_activity() works exactly as normal. The TenuoPlugin
+    workflow.execute_activity() works exactly as normal. The TenuoWorkerInterceptor
     intercepts each call, computes PoP inline with deterministic timing,
     and injects warrant + signature into activity headers. No Tenuo imports
     needed in the workflow.
@@ -105,7 +105,7 @@ class ResearchWorkflow:
     """Lists and reads all .txt files in the warranted directory.
 
     Uses standard workflow.execute_activity() — no Tenuo imports needed.
-    The TenuoPlugin computes PoP transparently for every activity call.
+    The TenuoWorkerInterceptor computes PoP transparently for every activity call.
     """
 
     @workflow.run

--- a/tenuo-python/examples/temporal/multi_warrant.py
+++ b/tenuo-python/examples/temporal/multi_warrant.py
@@ -12,7 +12,7 @@ Neither can access the other's directory.
 
 KEY POINT: The workflow code is identical for both tenants. Isolation comes
 entirely from the warrant assigned at workflow start, not from code changes.
-Both workflows use standard workflow.execute_activity() - the TenuoPlugin
+Both workflows use standard workflow.execute_activity() - the TenuoWorkerInterceptor
 handles authorization transparently.
 
 Requirements:
@@ -68,7 +68,7 @@ async def read_file(path: str) -> str:
 class ScopedReadWorkflow:
     """Reads all .txt files within its warrant-scoped directory.
 
-    Uses standard workflow.execute_activity() - the TenuoPlugin
+    Uses standard workflow.execute_activity() - the TenuoWorkerInterceptor
     handles authorization transparently. This same workflow code works
     for all tenants; isolation comes from the warrant, not the code.
     """

--- a/tenuo-python/examples/temporal/temporal_mcp_layering.py
+++ b/tenuo-python/examples/temporal/temporal_mcp_layering.py
@@ -8,7 +8,7 @@ instead of the echo tool here.
 This example shows defense in depth when a Temporal activity calls an MCP tool
 over stdio:
 
-1. **Temporal activity inbound** — ``TenuoPlugin`` verifies warrant + PoP in
+1. **Temporal activity inbound** — ``TenuoWorkerInterceptor`` verifies warrant + PoP in
    Temporal headers before ``invoke_mcp_echo`` runs.
 2. **MCP tools/call** — ``MCPVerifier`` on ``temporal_mcp_server.py`` verifies
    warrant + PoP in ``params._meta["tenuo"]`` before ``safe_echo`` runs.

--- a/tenuo-python/tenuo/temporal/__init__.py
+++ b/tenuo-python/tenuo/temporal/__init__.py
@@ -30,7 +30,7 @@ For direct imports (preferred in library / internal code)::
                                   set_activity_approvals, tenuo_continue_as_new, …
     tenuo.temporal._client        TenuoClientInterceptor, TenuoWarrantContextPropagator,
                                   tenuo_warrant_context
-    tenuo.temporal._interceptors  TenuoPlugin
+    tenuo.temporal._interceptors  TenuoWorkerInterceptor (alias ``TenuoPlugin`` is deprecated)
     tenuo.temporal._dedup         PopDedupStore, InMemoryPopDedupStore
     tenuo.temporal._decorators    tool, unprotected
     tenuo.temporal._observability TemporalAuditEvent, TenuoMetrics
@@ -50,7 +50,7 @@ from tenuo.temporal._resolvers import (  # noqa: F401
     KeyResolver,
 )
 from tenuo.temporal._headers import tenuo_headers  # noqa: F401
-from tenuo.temporal._interceptors import TenuoPlugin  # noqa: F401
+from tenuo.temporal._interceptors import TenuoWorkerInterceptor  # noqa: F401
 from tenuo.temporal._client import TenuoClientInterceptor  # noqa: F401
 from tenuo.temporal.exceptions import TenuoContextError  # noqa: F401
 
@@ -105,7 +105,40 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
 }
 
 
+# Deprecated aliases: name -> (new_name, replacement_object_location)
+# Resolved via ``__getattr__`` so that importing the old name emits a
+# DeprecationWarning exactly once per site of use.
+_DEPRECATED_ALIASES: dict[str, tuple[str, str]] = {
+    # ``TenuoPlugin`` was an awkward name because the class is a Temporal SDK
+    # *WorkerInterceptor*, not a Temporal SDK *Plugin*. The similarity to
+    # ``TenuoTemporalPlugin`` (which actually is a ``SimplePlugin``) caused
+    # confusion (e.g. passed to ``Worker(plugins=...)``).
+    "TenuoPlugin": ("TenuoWorkerInterceptor", "tenuo.temporal._interceptors"),
+}
+
+
 def __getattr__(name: str) -> Any:
+    deprecated = _DEPRECATED_ALIASES.get(name)
+    if deprecated is not None:
+        new_name, module_path = deprecated
+        import importlib
+        import warnings
+
+        warnings.warn(
+            (
+                f"`tenuo.temporal.{name}` is deprecated and will be removed "
+                f"in a future beta release; import "
+                f"`tenuo.temporal.{new_name}` instead. "
+                f"(The class is a Temporal SDK worker interceptor, not a "
+                f"Temporal SDK plugin — the new name makes that explicit "
+                f"and disambiguates from `tenuo.temporal_plugin.TenuoTemporalPlugin`.)"
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        mod = importlib.import_module(module_path)
+        return getattr(mod, new_name)
+
     entry = _LAZY_IMPORTS.get(name)
     if entry is not None:
         module_path, attr = entry
@@ -117,7 +150,7 @@ def __getattr__(name: str) -> Any:
 
 def __dir__() -> list[str]:
     eager = list(globals())
-    return sorted(set(eager) | set(_LAZY_IMPORTS))
+    return sorted(set(eager) | set(_LAZY_IMPORTS) | set(_DEPRECATED_ALIASES))
 
 
 __all__ = [
@@ -126,9 +159,11 @@ __all__ = [
     "KeyResolver",
     "EnvKeyResolver",
     "tenuo_headers",
-    "TenuoPlugin",
+    "TenuoWorkerInterceptor",
     "TenuoClientInterceptor",
     "TenuoContextError",
     # Lazy-loaded (documented public API)
     *_LAZY_IMPORTS,
+    # Deprecated aliases (still importable; emit DeprecationWarning)
+    *_DEPRECATED_ALIASES,
 ]

--- a/tenuo-python/tenuo/temporal/_config.py
+++ b/tenuo-python/tenuo/temporal/_config.py
@@ -37,7 +37,7 @@ def _build_activity_registry(
 
 @dataclass
 class TenuoPluginConfig:
-    """Configuration for TenuoPlugin."""
+    """Configuration for TenuoTemporalPlugin / TenuoWorkerInterceptor."""
 
     key_resolver: Optional[KeyResolver] = None
     """Optional — required for outbound PoP signing (most workers). Omit for

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -1,8 +1,9 @@
 """Temporal worker interceptors for Tenuo authorization enforcement.
 
 Contains the outbound workflow interceptor (PoP injection), inbound workflow
-interceptor (header extraction), TenuoPlugin (worker-level interceptor), and
-TenuoActivityInboundInterceptor (activity authorization checks).
+interceptor (header extraction), TenuoWorkerInterceptor (worker-level
+interceptor), and TenuoActivityInboundInterceptor (activity authorization
+checks).
 """
 
 from __future__ import annotations
@@ -420,13 +421,27 @@ class _TenuoWorkflowInboundInterceptor:
         return await self.next.handle_update_handler(input)
 
 
-# ── TenuoPlugin (worker interceptor) ────────────────────────────────────
+# ── TenuoWorkerInterceptor (worker interceptor) ─────────────────────────
 
-class TenuoPlugin(_TemporalWorkerInterceptor):
-    """Temporal Python SDK Plugin: warrant authorization (middleware / security).
+class TenuoWorkerInterceptor(_TemporalWorkerInterceptor):
+    """Temporal Python SDK worker interceptor: warrant authorization (middleware / security).
+
+    This is the low-level worker interceptor. Most users should use
+    :class:`tenuo.temporal_plugin.TenuoTemporalPlugin` (a ``SimplePlugin`` that
+    wires this interceptor up for you). Use this class directly only when you
+    are hand-composing your own ``SimplePlugin`` or already have a custom
+    ``Plugin`` and just want Tenuo's authorization interceptor.
 
     Stable identifier: :data:`TENUO_TEMPORAL_PLUGIN_ID` (``tenuo.TenuoTemporalPlugin``)
     for worker logs and Temporal Web activity summaries.
+
+    .. note::
+
+        This class was previously named ``TenuoPlugin``. The old name is still
+        importable from :mod:`tenuo.temporal` as a deprecated alias and will
+        be removed in a future beta. Imports should be updated to
+        ``TenuoWorkerInterceptor`` — the new name correctly reflects that this
+        is a Temporal SDK **interceptor**, not a Temporal SDK **plugin**.
     """
 
     def __init__(self, config: "TenuoPluginConfig") -> None:
@@ -538,7 +553,7 @@ class TenuoActivityInboundInterceptor:
         except ImportError as e:
             from tenuo.exceptions import ConfigurationError
             raise ConfigurationError(
-                "tenuo_core is required for TenuoPlugin (Authorizer). "
+                "tenuo_core is required for TenuoWorkerInterceptor (Authorizer). "
                 "Install tenuo with the native extension, or ensure the "
                 "interpreter can import tenuo_core."
             ) from e

--- a/tenuo-python/tenuo/temporal/_workflow.py
+++ b/tenuo-python/tenuo/temporal/_workflow.py
@@ -106,7 +106,7 @@ class AuthorizedWorkflow:
     workflow *start* (fail-fast), then exposes ``execute_authorized_activity()``
     as a named alias for ``workflow.execute_activity()``.
 
-    **What it does not change:** TenuoPlugin enforces authorization on *every*
+    **What it does not change:** TenuoTemporalPlugin enforces authorization on *every*
     activity regardless of which base class you use.  AuthorizedWorkflow adds no
     security guarantee beyond what the interceptor already provides — it only
     surfaces missing-header errors earlier (at workflow start vs at the first
@@ -353,12 +353,12 @@ def _workflow_mint_context(purpose: str) -> tuple[str, "TenuoPluginConfig"]:
 
     if not raw_headers:
         raise TenuoContextError(
-            "No Tenuo headers in store. Ensure TenuoPlugin is "
+            "No Tenuo headers in store. Ensure TenuoTemporalPlugin is "
             "registered and tenuo_headers() was passed at workflow start."
         )
     if not config_store_entry:
         raise TenuoContextError(
-            "No interceptor config found. Ensure TenuoPlugin is registered."
+            "No interceptor config found. Ensure TenuoTemporalPlugin is registered."
         )
 
     key_id = raw_headers.get(TENUO_KEY_ID_HEADER, b"").decode("utf-8")
@@ -431,7 +431,7 @@ try:
         if config is None or config.key_resolver is None:
             raise TenuoContextError(
                 "_tenuo_internal_mint_activity: no worker config or key_resolver. "
-                "Ensure TenuoPlugin is registered with a key_resolver."
+                "Ensure TenuoTemporalPlugin is registered with a key_resolver."
             )
 
         try:

--- a/tenuo-python/tenuo/temporal_plugin.py
+++ b/tenuo-python/tenuo/temporal_plugin.py
@@ -62,7 +62,7 @@ from tenuo.temporal._config import (
     TenuoPluginConfig,
     _build_activity_registry,
 )
-from tenuo.temporal._interceptors import TenuoPlugin
+from tenuo.temporal._interceptors import TenuoWorkerInterceptor
 from tenuo.temporal._resolvers import EnvKeyResolver
 from tenuo.temporal._state import _set_worker_config
 from tenuo.temporal._workflow import _tenuo_internal_mint_activity
@@ -99,7 +99,7 @@ _TENUO_WORKFLOW_FAILURE_EXCEPTION_TYPES: tuple[type[BaseException], ...] = (
 
 def _simple_plugin_kwargs(
     client_interceptor: TenuoClientInterceptor,
-    worker_interceptor: TenuoPlugin,
+    worker_interceptor: TenuoWorkerInterceptor,
 ) -> dict[str, Any]:
     """Build ``super().__init__(..., **kwargs)`` for the installed ``SimplePlugin`` shape."""
     params = inspect.signature(SimplePlugin.__init__).parameters
@@ -138,7 +138,7 @@ def ensure_tenuo_workflow_runner(
     """Return a workflow runner with ``tenuo`` and ``tenuo_core`` sandbox passthrough.
 
     Use when **not** adopting :class:`TenuoTemporalPlugin` — for example if you
-    register ``TenuoPlugin`` manually but still need PyO3 passthrough.
+    register ``TenuoWorkerInterceptor`` manually but still need PyO3 passthrough.
 
     - If ``existing`` is ``None``, returns a :class:`SandboxedWorkflowRunner`
       with default restrictions plus passthrough.
@@ -213,7 +213,7 @@ class TenuoTemporalPlugin(SimplePlugin):
     Configures:
 
     - **Client:** :class:`TenuoClientInterceptor` (warrant headers, workflow-ID binding).
-    - **Worker / Replayer:** :class:`TenuoPlugin` with your :class:`TenuoPluginConfig`.
+    - **Worker / Replayer:** :class:`TenuoWorkerInterceptor` with your :class:`TenuoPluginConfig`.
     - **Workflow runner:** sandbox passthrough for ``tenuo`` and ``tenuo_core``.
 
     After construction, :attr:`client_interceptor` is the instance registered
@@ -264,7 +264,7 @@ class TenuoTemporalPlugin(SimplePlugin):
             self._tenuo_config.activity_fns
         )
 
-        worker_interceptor = TenuoPlugin(self._tenuo_config)
+        worker_interceptor = TenuoWorkerInterceptor(self._tenuo_config)
         self.client_interceptor = client_interceptor or TenuoClientInterceptor()
         self.context_propagator = TenuoWarrantContextPropagator()
         self._tenuo_worker_configured = False

--- a/tenuo-python/tenuo/temporal_plugin.py
+++ b/tenuo-python/tenuo/temporal_plugin.py
@@ -170,14 +170,15 @@ def ensure_tenuo_workflow_runner(
             restrictions=existing.restrictions.with_passthrough_modules(*passthrough),
         )
 
+    unsandboxed_cls: Optional[type] = None
     try:
         from temporalio.worker import UnsandboxedWorkflowRunner
-    except ImportError:  # pragma: no cover - older temporalio
-        UnsandboxedWorkflowRunner = None  # type: ignore[assignment]
 
-    if UnsandboxedWorkflowRunner is not None and isinstance(
-        existing, UnsandboxedWorkflowRunner
-    ):
+        unsandboxed_cls = UnsandboxedWorkflowRunner
+    except ImportError:  # pragma: no cover - older temporalio without this export
+        pass
+
+    if unsandboxed_cls is not None and isinstance(existing, unsandboxed_cls):
         raise ConfigurationError(
             "UnsandboxedWorkflowRunner is not supported by TenuoTemporalPlugin. "
             "Tenuo needs sandbox passthrough for the 'tenuo' and 'tenuo_core' "

--- a/tenuo-python/tenuo/temporal_plugin.py
+++ b/tenuo-python/tenuo/temporal_plugin.py
@@ -63,8 +63,18 @@ from tenuo.temporal._config import (
     _build_activity_registry,
 )
 from tenuo.temporal._interceptors import TenuoPlugin
+from tenuo.temporal._resolvers import EnvKeyResolver
 from tenuo.temporal._state import _set_worker_config
 from tenuo.temporal._workflow import _tenuo_internal_mint_activity
+from tenuo.temporal.exceptions import (
+    ChainValidationError,
+    KeyResolutionError,
+    LocalActivityError,
+    PopVerificationError,
+    TemporalConstraintViolation,
+    TenuoContextError,
+    WarrantExpired,
+)
 
 _logger = logging.getLogger("tenuo.temporal")
 
@@ -73,8 +83,21 @@ if TYPE_CHECKING:
 
 TENUO_TEMPORAL_SIMPLE_PLUGIN_NAME = "tenuo.TenuoTemporalPlugin"
 
+# Tenuo exceptions that should fail the workflow cleanly (non-retryable) rather
+# than being wrapped by ``ActivityError``. Registered on ``SimplePlugin`` so the
+# Temporal SDK treats them as domain-level workflow failures.
+_TENUO_WORKFLOW_FAILURE_EXCEPTION_TYPES: tuple[type[BaseException], ...] = (
+    TenuoContextError,
+    PopVerificationError,
+    TemporalConstraintViolation,
+    WarrantExpired,
+    ChainValidationError,
+    KeyResolutionError,
+    LocalActivityError,
+)
 
-def _simple_plugin_interceptor_kwargs(
+
+def _simple_plugin_kwargs(
     client_interceptor: TenuoClientInterceptor,
     worker_interceptor: TenuoPlugin,
 ) -> dict[str, Any]:
@@ -85,19 +108,28 @@ def _simple_plugin_interceptor_kwargs(
         "client_interceptors" in params and "worker_interceptors" in params
     )
     if has_unified and not has_split:
-        return {"interceptors": [client_interceptor, worker_interceptor]}
-    if has_split and not has_unified:
-        return {
+        kwargs: dict[str, Any] = {
+            "interceptors": [client_interceptor, worker_interceptor]
+        }
+    elif has_split and not has_unified:
+        kwargs = {
             "client_interceptors": [client_interceptor],
             "worker_interceptors": [worker_interceptor],
         }
-    if has_unified:
-        return {"interceptors": [client_interceptor, worker_interceptor]}
-    raise RuntimeError(
-        "Unsupported temporalio SimplePlugin: expected 'interceptors' or "
-        "('client_interceptors' and 'worker_interceptors') on SimplePlugin.__init__. "
-        "Upgrade temporalio or report this to Tenuo."
-    )
+    elif has_unified:
+        kwargs = {"interceptors": [client_interceptor, worker_interceptor]}
+    else:
+        raise RuntimeError(
+            "Unsupported temporalio SimplePlugin: expected 'interceptors' or "
+            "('client_interceptors' and 'worker_interceptors') on "
+            "SimplePlugin.__init__. Upgrade temporalio or report this to Tenuo."
+        )
+
+    if "workflow_failure_exception_types" in params:
+        kwargs["workflow_failure_exception_types"] = list(
+            _TENUO_WORKFLOW_FAILURE_EXCEPTION_TYPES
+        )
+    return kwargs
 
 
 def ensure_tenuo_workflow_runner(
@@ -112,8 +144,13 @@ def ensure_tenuo_workflow_runner(
       with default restrictions plus passthrough.
     - If ``existing`` is already a :class:`SandboxedWorkflowRunner`, adds
       passthrough modules (idempotent if already present).
-    - Otherwise returns ``existing`` unchanged (unsandboxed runners cannot load
-      PyO3 in sub-interpreters; prefer sandbox + passthrough for Tenuo).
+    - If ``existing`` is an :class:`UnsandboxedWorkflowRunner`, raises
+      :class:`~tenuo.exceptions.ConfigurationError`. The unsandboxed runner
+      cannot load the ``tenuo_core`` PyO3 extension reliably inside the
+      Temporal workflow worker; users who need the unsandboxed runner should
+      register Tenuo interceptors manually and understand the constraints.
+    - For any other custom runner, returns ``existing`` unchanged and logs a
+      warning so the caller notices passthrough was skipped.
     """
     from temporalio.worker.workflow_sandbox import (
         SandboxedWorkflowRunner,
@@ -132,6 +169,31 @@ def ensure_tenuo_workflow_runner(
             existing,
             restrictions=existing.restrictions.with_passthrough_modules(*passthrough),
         )
+
+    try:
+        from temporalio.worker import UnsandboxedWorkflowRunner
+    except ImportError:  # pragma: no cover - older temporalio
+        UnsandboxedWorkflowRunner = None  # type: ignore[assignment]
+
+    if UnsandboxedWorkflowRunner is not None and isinstance(
+        existing, UnsandboxedWorkflowRunner
+    ):
+        raise ConfigurationError(
+            "UnsandboxedWorkflowRunner is not supported by TenuoTemporalPlugin. "
+            "Tenuo needs sandbox passthrough for the 'tenuo' and 'tenuo_core' "
+            "modules so the PyO3 extension can be imported inside the workflow "
+            "worker. Either drop the unsandboxed runner (omit ``workflow_runner`` "
+            "to let the plugin supply one) or register TenuoPlugin manually and "
+            "ensure 'tenuo_core' is importable from your runtime."
+        )
+
+    _logger.warning(
+        "TenuoTemporalPlugin: unknown workflow runner %s; passthrough for "
+        "'tenuo' and 'tenuo_core' was not configured. Workflow code may fail to "
+        "import Tenuo modules. Use SandboxedWorkflowRunner or omit "
+        "``workflow_runner`` to get automatic passthrough.",
+        type(existing).__name__,
+    )
     return existing
 
 
@@ -178,54 +240,70 @@ class TenuoTemporalPlugin(SimplePlugin):
             interceptors and causes subtle, hard-to-diagnose failures. Only pass
             ``plugins=`` on ``Worker`` when the client was created **without**
             this plugin.
+
+        The user's ``config`` is never mutated: the plugin works on a shallow
+        copy so two workers sharing the same config object cannot leak
+        activity registries into each other.
         """
-        worker_interceptor = TenuoPlugin(config)
+        # Work on a copy so we never mutate the user's config object. This
+        # isolates two workers that happen to share a ``TenuoPluginConfig``.
+        self._tenuo_config = dataclasses.replace(config)
+        if self._tenuo_config.activity_fns is not None:
+            self._tenuo_config.activity_fns = list(self._tenuo_config.activity_fns)
+        # The activity registry is rebuilt from our copy; any later auto-discovery
+        # writes only to ``self._tenuo_config``.
+        self._tenuo_config._activity_registry = _build_activity_registry(
+            self._tenuo_config.activity_fns
+        )
+
+        worker_interceptor = TenuoPlugin(self._tenuo_config)
         self.client_interceptor = client_interceptor or TenuoClientInterceptor()
         self.context_propagator = TenuoWarrantContextPropagator()
-        self._tenuo_config = config
-        # Item 1.5: guard against duplicate configure_worker calls on same instance
         self._tenuo_worker_configured = False
 
         def _add_activities(
             activities: "Sequence[Callable[..., Any]] | None",
         ) -> "Sequence[Callable[..., Any]]":
-            """Append _tenuo_internal_mint_activity and store worker config.
+            """Append _tenuo_internal_mint_activity and record the worker config.
 
-            Also handles:
-            - Item 1.2: auto-discovers activity_fns from existing activities if unset.
-            - Item 1.5: raises ConfigurationError on duplicate configure_worker calls.
-            - Item 1.6: auto-calls preload_keys() if the resolver supports it.
+            Responsibilities:
+
+            - Detect duplicate ``configure_worker`` calls on the same instance.
+            - Auto-populate ``activity_fns`` on the plugin's private config
+              copy when the user didn't set them explicitly.
+            - Eagerly preload all signing keys so the workflow sandbox never
+              has to touch ``os.environ`` or external secret storage.
             """
-            # Item 1.5: detect duplicate registration
             if self._tenuo_worker_configured:
                 raise ConfigurationError(
-                    "duplicate Tenuo plugin registered: the same TenuoTemporalPlugin "
-                    "instance was used to configure_worker more than once. Create "
-                    "separate TenuoTemporalPlugin instances for each worker."
+                    "Duplicate Tenuo plugin registration: the same "
+                    "TenuoTemporalPlugin instance configured more than one "
+                    "worker. The recommended pattern is to pass the plugin "
+                    "once to Client.connect(plugins=[plugin]) and let workers "
+                    "built from that client inherit it; passing the same "
+                    "plugin to Worker(plugins=[...]) in addition causes this "
+                    "double-registration. For genuinely different worker "
+                    "configurations (different activity_fns, different key "
+                    "resolvers), create one TenuoTemporalPlugin per worker."
                 )
             self._tenuo_worker_configured = True
 
-            _set_worker_config(config)
+            _set_worker_config(self._tenuo_config)
             existing = list(activities or [])
 
-            # Item 1.2: auto-populate activity_fns if not already set
-            if not config.activity_fns and existing:
-                config.activity_fns = list(existing)
-                # Rebuild the activity registry without re-running full __post_init__
-                config._activity_registry = _build_activity_registry(config.activity_fns)
+            # Auto-populate activity_fns on our private copy if not set by the
+            # user. Never touch the user's original ``config`` object.
+            if not self._tenuo_config.activity_fns and existing:
+                self._tenuo_config.activity_fns = list(existing)
+                self._tenuo_config._activity_registry = _build_activity_registry(
+                    self._tenuo_config.activity_fns
+                )
                 _logger.info(
                     "Tenuo: auto-discovered %d activity function(s) from worker config",
-                    len(config.activity_fns),
+                    len(self._tenuo_config.activity_fns),
                 )
 
-            # Auto-preload signing keys so resolve_sync() never touches
-            # os.environ (or external storage) inside the workflow sandbox.
-            _preload_all = getattr(config.key_resolver, "preload_all", None)
-            if _preload_all is not None:
-                try:
-                    _preload_all()
-                except Exception as _exc:
-                    _logger.warning("key preload failed: %s", _exc)
+            self._preload_keys()
 
             if _tenuo_internal_mint_activity is not None:
                 existing.append(_tenuo_internal_mint_activity)
@@ -235,10 +313,43 @@ class TenuoTemporalPlugin(SimplePlugin):
             TENUO_TEMPORAL_SIMPLE_PLUGIN_NAME,
             workflow_runner=ensure_tenuo_workflow_runner,
             activities=_add_activities,
-            **_simple_plugin_interceptor_kwargs(
-                self.client_interceptor, worker_interceptor
-            ),
+            **_simple_plugin_kwargs(self.client_interceptor, worker_interceptor),
         )
+
+    def _preload_keys(self) -> None:
+        """Eagerly preload signing keys from the configured resolver.
+
+        Preloading is best-effort by default, but for :class:`EnvKeyResolver`
+        it is a hard requirement: ``resolve_sync`` falls back to ``os.environ``
+        which is blocked inside the Temporal workflow sandbox. A preload
+        failure for an env resolver will deterministically turn into
+        ``KeyResolutionError`` on every subsequent workflow, so we raise
+        immediately with a clear message instead of logging a warning.
+        """
+        resolver = self._tenuo_config.key_resolver
+        _preload_all = getattr(resolver, "preload_all", None)
+        if _preload_all is None:
+            return
+        resolver_cls = type(resolver).__name__
+        try:
+            _preload_all()
+        except Exception as exc:
+            if isinstance(resolver, EnvKeyResolver):
+                raise ConfigurationError(
+                    f"EnvKeyResolver.preload_all() failed ({exc!r}). Preloading "
+                    "is required for EnvKeyResolver because resolve_sync() "
+                    "falls back to os.environ, which is blocked inside the "
+                    "Temporal workflow sandbox. Fix the environment variables "
+                    "(e.g. TENUO_KEY_* entries must be valid base64/seed) or "
+                    "switch to a resolver that does not rely on process env."
+                ) from exc
+            _logger.error(
+                "Tenuo %s.preload_all() failed: %s. Workflows that resolve "
+                "keys through this resolver at runtime will fail with "
+                "KeyResolutionError.",
+                resolver_cls,
+                exc,
+            )
 
 
 __all__ = [

--- a/tenuo-python/tenuo/temporal_plugin.py
+++ b/tenuo-python/tenuo/temporal_plugin.py
@@ -144,14 +144,16 @@ def ensure_tenuo_workflow_runner(
       with default restrictions plus passthrough.
     - If ``existing`` is already a :class:`SandboxedWorkflowRunner`, adds
       passthrough modules (idempotent if already present).
-    - If ``existing`` is an :class:`UnsandboxedWorkflowRunner`, raises
-      :class:`~tenuo.exceptions.ConfigurationError`. The unsandboxed runner
-      cannot load the ``tenuo_core`` PyO3 extension reliably inside the
-      Temporal workflow worker; users who need the unsandboxed runner should
-      register Tenuo interceptors manually and understand the constraints.
+    - If ``existing`` is an :class:`UnsandboxedWorkflowRunner`, emits a
+      :class:`UserWarning` (and a logger warning) and returns it unchanged.
+      Tenuo can operate under the unsandboxed runner, but the user loses
+      Temporal's determinism guardrails for their own workflow code, so we
+      make sure the choice is visible rather than silent.
     - For any other custom runner, returns ``existing`` unchanged and logs a
       warning so the caller notices passthrough was skipped.
     """
+    import warnings
+
     from temporalio.worker.workflow_sandbox import (
         SandboxedWorkflowRunner,
         SandboxRestrictions,
@@ -179,14 +181,19 @@ def ensure_tenuo_workflow_runner(
         pass
 
     if unsandboxed_cls is not None and isinstance(existing, unsandboxed_cls):
-        raise ConfigurationError(
-            "UnsandboxedWorkflowRunner is not supported by TenuoTemporalPlugin. "
-            "Tenuo needs sandbox passthrough for the 'tenuo' and 'tenuo_core' "
-            "modules so the PyO3 extension can be imported inside the workflow "
-            "worker. Either drop the unsandboxed runner (omit ``workflow_runner`` "
-            "to let the plugin supply one) or register TenuoPlugin manually and "
-            "ensure 'tenuo_core' is importable from your runtime."
+        msg = (
+            "TenuoTemporalPlugin is running with UnsandboxedWorkflowRunner. "
+            "Tenuo itself still enforces warrant + PoP authorization, but "
+            "you are opting out of Temporal's workflow sandbox, so any "
+            "non-deterministic code in your own workflows (time.time(), "
+            "random, unguarded I/O, module-level state) can cause replay "
+            "divergence. Prefer SandboxedWorkflowRunner in production and "
+            "omit ``workflow_runner`` to let the plugin supply one with "
+            "passthrough for 'tenuo' and 'tenuo_core' configured."
         )
+        warnings.warn(msg, UserWarning, stacklevel=2)
+        _logger.warning("%s", msg)
+        return existing
 
     _logger.warning(
         "TenuoTemporalPlugin: unknown workflow runner %s; passthrough for "

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -34,7 +34,7 @@ from tenuo.temporal.exceptions import (  # noqa: E402
 )
 from tenuo.temporal._resolvers import EnvKeyResolver, KeyResolver  # noqa: E402
 from tenuo.temporal._observability import TemporalAuditEvent  # noqa: E402
-from tenuo.temporal._interceptors import TenuoPlugin  # noqa: E402
+from tenuo.temporal._interceptors import TenuoWorkerInterceptor  # noqa: E402
 from tenuo.temporal._config import TenuoPluginConfig  # noqa: E402
 from tenuo.temporal._pop import _compute_pop_challenge  # noqa: E402
 from tenuo.temporal._headers import _extract_key_id_from_headers, tenuo_headers  # noqa: E402
@@ -744,13 +744,13 @@ class TestExceptions:
 
 
 class TestTenuoPlugin:
-    """Tests for TenuoPlugin."""
+    """Tests for TenuoWorkerInterceptor."""
 
     def test_creates_activity_interceptor(self):
         """Creates activity inbound interceptor."""
         resolver = MagicMock(spec=KeyResolver)
         config = TenuoPluginConfig(key_resolver=resolver, trusted_roots=_TEMPORAL_TRUST_ROOTS)
-        interceptor = TenuoPlugin(config)
+        interceptor = TenuoWorkerInterceptor(config)
 
         next_interceptor = MagicMock()
         activity_interceptor = interceptor.intercept_activity(next_interceptor)
@@ -1599,7 +1599,7 @@ class TestPopDedupStoreHook:
             trusted_roots=[control_key.public_key],
             pop_dedup_store=dedup,
         )
-        ti = TenuoPlugin(cfg)
+        ti = TenuoWorkerInterceptor(cfg)
         nxt = MagicMock()
         nxt.execute_activity = AsyncMock(return_value="ok")
         nxt.init = MagicMock()
@@ -1759,7 +1759,7 @@ def test_otel_span_emitted_on_allow():
     from tenuo import SigningKey, Warrant
     from tenuo_core import Subpath
     from tenuo.temporal._constants import TENUO_POP_HEADER
-    from tenuo.temporal._interceptors import TenuoPlugin
+    from tenuo.temporal._interceptors import TenuoWorkerInterceptor
     from tenuo.temporal._config import TenuoPluginConfig
     from tenuo.temporal._resolvers import EnvKeyResolver
     from tenuo.temporal._headers import tenuo_headers
@@ -1794,7 +1794,7 @@ def test_otel_span_emitted_on_allow():
         key_resolver=EnvKeyResolver(),
         trusted_roots=[control_key.public_key],
     )
-    ti = TenuoPlugin(cfg)
+    ti = TenuoWorkerInterceptor(cfg)
     nxt = MagicMock()
     nxt.execute_activity = AsyncMock(return_value="ok")
     nxt.init = MagicMock()
@@ -2180,7 +2180,7 @@ class TestConstraintTypesThroughInterceptor:
         import time as _time
 
         from tenuo.temporal._constants import TENUO_POP_HEADER, TENUO_ARG_KEYS_HEADER
-        from tenuo.temporal._interceptors import TenuoPlugin
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
         from tenuo.temporal._config import TenuoPluginConfig
         from tenuo.temporal._resolvers import EnvKeyResolver
         from tenuo.temporal._headers import tenuo_headers
@@ -2191,7 +2191,7 @@ class TestConstraintTypesThroughInterceptor:
             key_resolver=EnvKeyResolver(),
             trusted_roots=[control_key.public_key],
         )
-        plugin = TenuoPlugin(cfg)
+        plugin = TenuoWorkerInterceptor(cfg)
         nxt = MagicMock()
         nxt.execute_activity = AsyncMock(return_value="ok")
         nxt.init = MagicMock()
@@ -2438,7 +2438,7 @@ class TestMetricsWiring:
         from tenuo import SigningKey, Warrant
         from tenuo_core import Wildcard
         from tenuo.temporal._constants import TENUO_ARG_KEYS_HEADER, TENUO_POP_HEADER
-        from tenuo.temporal._interceptors import TenuoPlugin
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
         from tenuo.temporal._config import TenuoPluginConfig
         from tenuo.temporal._resolvers import EnvKeyResolver
         from tenuo.temporal._headers import tenuo_headers
@@ -2461,7 +2461,7 @@ class TestMetricsWiring:
             trusted_roots=[control_key.public_key],
             metrics=metrics,
         )
-        plugin = TenuoPlugin(cfg)
+        plugin = TenuoWorkerInterceptor(cfg)
         nxt = MagicMock()
         nxt.execute_activity = AsyncMock(return_value="ok")
         nxt.init = MagicMock()
@@ -2513,7 +2513,7 @@ class TestMetricsWiring:
         from tenuo import SigningKey, Warrant
         from tenuo_core import Subpath
         from tenuo.temporal._constants import TENUO_ARG_KEYS_HEADER, TENUO_POP_HEADER
-        from tenuo.temporal._interceptors import TenuoPlugin
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
         from tenuo.temporal._config import TenuoPluginConfig
         from tenuo.temporal._resolvers import EnvKeyResolver
         from tenuo.temporal._headers import tenuo_headers
@@ -2536,7 +2536,7 @@ class TestMetricsWiring:
             trusted_roots=[control_key.public_key],
             metrics=metrics,
         )
-        plugin = TenuoPlugin(cfg)
+        plugin = TenuoWorkerInterceptor(cfg)
         nxt = MagicMock()
         nxt.execute_activity = AsyncMock(return_value="ok")
         nxt.init = MagicMock()

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -21,7 +21,7 @@ from tenuo.temporal._resolvers import EnvKeyResolver  # noqa: E402
 from tenuo.temporal_plugin import (  # noqa: E402
     TENUO_TEMPORAL_SIMPLE_PLUGIN_NAME,
     TenuoTemporalPlugin,
-    _simple_plugin_interceptor_kwargs,
+    _simple_plugin_kwargs,
     ensure_tenuo_workflow_runner,
 )
 
@@ -47,11 +47,11 @@ def test_client_interceptor_exposed_and_shared() -> None:
     assert isinstance(p2.client_interceptor, TenuoClientInterceptor)
 
 
-def test_simple_plugin_interceptor_kwargs_match_sdk_signature() -> None:
+def test_simple_plugin_kwargs_match_sdk_signature() -> None:
     """Every key we pass to ``SimplePlugin.__init__`` must exist on the installed SDK."""
     ci = TenuoClientInterceptor()
     wi = TenuoPlugin(_minimal_config())
-    kw = _simple_plugin_interceptor_kwargs(ci, wi)
+    kw = _simple_plugin_kwargs(ci, wi)
     params = inspect.signature(SimplePlugin.__init__).parameters
     for name in kw:
         assert name in params, f"SimplePlugin.__init__ has no {name!r} (got {sorted(kw)})"
@@ -94,12 +94,32 @@ def test_ensure_tenuo_workflow_runner_preserves_custom_restrictions() -> None:
     assert wr is not base
 
 
-def test_ensure_tenuo_workflow_runner_non_sandbox_unchanged() -> None:
+def test_ensure_tenuo_workflow_runner_non_sandbox_unchanged(caplog) -> None:
+    """Unknown custom runners are returned unchanged with a warning."""
+
     class _NotSandboxed:
-        """Stand-in for an unsandboxed :class:`WorkflowRunner`."""
+        """Stand-in for an unknown custom :class:`WorkflowRunner`."""
 
     existing = _NotSandboxed()
-    assert ensure_tenuo_workflow_runner(existing) is existing
+    with caplog.at_level("WARNING", logger="tenuo.temporal"):
+        assert ensure_tenuo_workflow_runner(existing) is existing
+    assert any(
+        "passthrough for" in rec.getMessage()
+        for rec in caplog.records
+    ), "Custom runners should log a passthrough warning."
+
+
+def test_ensure_tenuo_workflow_runner_rejects_unsandboxed() -> None:
+    """UnsandboxedWorkflowRunner is rejected outright (PyO3 passthrough impossible)."""
+    from tenuo.exceptions import ConfigurationError
+
+    try:
+        from temporalio.worker import UnsandboxedWorkflowRunner
+    except ImportError:
+        pytest.skip("temporalio version does not expose UnsandboxedWorkflowRunner")
+
+    with pytest.raises(ConfigurationError, match="UnsandboxedWorkflowRunner"):
+        ensure_tenuo_workflow_runner(UnsandboxedWorkflowRunner())
 
 
 def test_lazy_export_from_tenuo_temporal() -> None:
@@ -130,7 +150,7 @@ def test_internal_mint_activity_registered():
 def test_activity_fns_auto_discovered() -> None:
     """TenuoTemporalPlugin auto-populates activity_fns from worker activities."""
     config = _minimal_config()
-    assert not config.activity_fns  # starts empty
+    assert not config.activity_fns
 
     plugin = TenuoTemporalPlugin(config)
 
@@ -140,18 +160,24 @@ def test_activity_fns_auto_discovered() -> None:
     def mock_activity_b() -> None:
         pass
 
-    # Simulate what SimplePlugin.configure_worker does: call the activities callable
-    # with the existing activities list, then check config.activity_fns is populated.
     result = plugin.activities([mock_activity_a, mock_activity_b])  # type: ignore[operator]
-    assert len(config.activity_fns) == 2  # noqa: PLR2004
-    assert mock_activity_a in config.activity_fns
-    assert mock_activity_b in config.activity_fns
+
+    # The plugin works on a copy; the user's config must never be mutated.
+    assert not config.activity_fns, (
+        "TenuoTemporalPlugin must not mutate the user's config.activity_fns; "
+        "auto-discovery should populate the plugin's private copy instead."
+    )
+    # Auto-discovery is visible on the plugin's private config copy.
+    discovered = plugin._tenuo_config.activity_fns or []
+    assert len(discovered) == 2  # noqa: PLR2004
+    assert mock_activity_a in discovered
+    assert mock_activity_b in discovered
     # The internal mint activity should also be appended to the return value
     assert len(result) >= 2  # noqa: PLR2004
 
 
 def test_activity_fns_not_overwritten_if_already_set() -> None:
-    """If activity_fns is already set, auto-discovery should not overwrite it."""
+    """If activity_fns is already set, auto-discovery does not overwrite it."""
 
     def explicit_fn() -> None:
         pass
@@ -165,8 +191,36 @@ def test_activity_fns_not_overwritten_if_already_set() -> None:
         pass
 
     plugin.activities([other_fn])  # type: ignore[operator]
-    # Should still have only explicit_fn (not replaced by other_fn)
+    # User's config is untouched (we work on a copy).
     assert config.activity_fns == [explicit_fn]
+    # Plugin's private copy also retains the explicit list (no overwrite).
+    assert plugin._tenuo_config.activity_fns == [explicit_fn]
+
+
+def test_config_is_not_mutated_between_plugin_instances() -> None:
+    """Sharing a single TenuoPluginConfig between two plugins stays clean."""
+    config = _minimal_config()
+    assert not config.activity_fns
+
+    plugin_a = TenuoTemporalPlugin(config)
+    plugin_b = TenuoTemporalPlugin(config)
+
+    def fn_a() -> None:
+        pass
+
+    def fn_b() -> None:
+        pass
+
+    plugin_a.activities([fn_a])  # type: ignore[operator]
+    plugin_b.activities([fn_b])  # type: ignore[operator]
+
+    # Each plugin auto-discovered its own activities, without contaminating
+    # the other plugin or the user's shared config.
+    assert not config.activity_fns
+    assert fn_a in (plugin_a._tenuo_config.activity_fns or [])
+    assert fn_b not in (plugin_a._tenuo_config.activity_fns or [])
+    assert fn_b in (plugin_b._tenuo_config.activity_fns or [])
+    assert fn_a not in (plugin_b._tenuo_config.activity_fns or [])
 
 
 # ---------------------------------------------------------------------------
@@ -182,8 +236,12 @@ def test_duplicate_plugin_registration_raises() -> None:
     # First call succeeds
     plugin.activities([])  # type: ignore[operator]
 
-    # Second call on the same instance should raise
-    with pytest.raises(TenuoConfigError, match="duplicate Tenuo plugin registered"):
+    # Second call on the same instance should raise with guidance pointing to
+    # the client-inheritance pattern.
+    with pytest.raises(
+        TenuoConfigError,
+        match=r"Duplicate Tenuo plugin registration.*Client\.connect",
+    ):
         plugin.activities([])  # type: ignore[operator]
 
 
@@ -224,6 +282,81 @@ def test_preload_all_not_called_if_unsupported() -> None:
     plugin = TenuoTemporalPlugin(config)
     # Should not raise even though NoPreloadResolver has no preload_keys()
     plugin.activities([])  # type: ignore[operator]
+
+
+def test_preload_failure_for_custom_resolver_logs_error(caplog) -> None:
+    """Custom resolvers that fail preload log at ERROR, not WARNING."""
+
+    class ExplodingResolver:
+        def resolve_sync(self, key_id: str) -> None:
+            return None
+
+        def preload_all(self) -> int:
+            raise RuntimeError("secrets store offline")
+
+    config = _minimal_config()
+    config.key_resolver = ExplodingResolver()  # type: ignore[assignment]
+    plugin = TenuoTemporalPlugin(config)
+
+    with caplog.at_level("ERROR", logger="tenuo.temporal"):
+        plugin.activities([])  # type: ignore[operator]
+
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert error_records, "Preload failure for a custom resolver must log ERROR."
+    assert any(
+        "ExplodingResolver" in r.getMessage() for r in error_records
+    ), "Error message should name the failing resolver class."
+
+
+def test_preload_failure_for_env_resolver_raises(monkeypatch) -> None:
+    """EnvKeyResolver preload failure is fatal: resolve_sync can't fall back inside the sandbox."""
+    from tenuo.exceptions import ConfigurationError
+
+    config = _minimal_config()
+
+    def _boom(self: EnvKeyResolver) -> int:
+        raise RuntimeError("env scanned badly")
+
+    monkeypatch.setattr(EnvKeyResolver, "preload_all", _boom)
+
+    plugin = TenuoTemporalPlugin(config)
+    with pytest.raises(ConfigurationError, match="EnvKeyResolver.preload_all"):
+        plugin.activities([])  # type: ignore[operator]
+
+
+def test_workflow_failure_exception_types_registered() -> None:
+    """Tenuo domain exceptions are registered as workflow_failure_exception_types."""
+    sdk_params = inspect.signature(SimplePlugin.__init__).parameters
+    if "workflow_failure_exception_types" not in sdk_params:
+        pytest.skip("Installed temporalio does not support workflow_failure_exception_types.")
+
+    from tenuo.temporal.exceptions import (
+        ChainValidationError,
+        KeyResolutionError,
+        LocalActivityError,
+        PopVerificationError,
+        TemporalConstraintViolation,
+        TenuoContextError,
+        WarrantExpired,
+    )
+
+    plugin = TenuoTemporalPlugin(_minimal_config())
+    registered = list(getattr(plugin, "workflow_failure_exception_types", []) or [])
+    # Tenuo must register at minimum the domain-level workflow failure types.
+    expected = {
+        TenuoContextError,
+        PopVerificationError,
+        TemporalConstraintViolation,
+        WarrantExpired,
+        ChainValidationError,
+        KeyResolutionError,
+        LocalActivityError,
+    }
+    missing = expected - set(registered)
+    assert not missing, (
+        f"TenuoTemporalPlugin should register these exceptions as workflow "
+        f"failure types, but they are missing: {sorted(cls.__name__ for cls in missing)}."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -16,7 +16,7 @@ from temporalio.worker.workflow_sandbox import (  # noqa: E402
 from tenuo import SigningKey  # noqa: E402
 from tenuo.temporal._client import TenuoClientInterceptor  # noqa: E402
 from tenuo.temporal._config import TenuoPluginConfig  # noqa: E402
-from tenuo.temporal._interceptors import TenuoPlugin  # noqa: E402
+from tenuo.temporal._interceptors import TenuoWorkerInterceptor  # noqa: E402
 from tenuo.temporal._resolvers import EnvKeyResolver  # noqa: E402
 from tenuo.temporal_plugin import (  # noqa: E402
     TENUO_TEMPORAL_SIMPLE_PLUGIN_NAME,
@@ -50,7 +50,7 @@ def test_client_interceptor_exposed_and_shared() -> None:
 def test_simple_plugin_kwargs_match_sdk_signature() -> None:
     """Every key we pass to ``SimplePlugin.__init__`` must exist on the installed SDK."""
     ci = TenuoClientInterceptor()
-    wi = TenuoPlugin(_minimal_config())
+    wi = TenuoWorkerInterceptor(_minimal_config())
     kw = _simple_plugin_kwargs(ci, wi)
     params = inspect.signature(SimplePlugin.__init__).parameters
     for name in kw:
@@ -69,7 +69,7 @@ def test_configure_worker_merges_interceptor_and_runner() -> None:
     out = p.configure_worker(cfg)
     inters = out.get("interceptors") or []
     assert len(inters) == 1
-    assert isinstance(inters[0], TenuoPlugin)
+    assert isinstance(inters[0], TenuoWorkerInterceptor)
     wr = out.get("workflow_runner")
     assert isinstance(wr, SandboxedWorkflowRunner)
 
@@ -502,3 +502,31 @@ def test_revocation_list_provider_none_by_default() -> None:
     sk = SigningKey.generate()
     config = TenuoPluginConfig(signing_key=sk, trusted_roots=[sk.public_key])
     assert config.revocation_list_provider is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Deprecated alias: ``tenuo.temporal.TenuoPlugin`` → ``TenuoWorkerInterceptor``
+#
+# The old name ``TenuoPlugin`` was confusing because the class is a Temporal
+# SDK WorkerInterceptor, not a Temporal SDK Plugin. It was also too similar
+# to ``tenuo.temporal_plugin.TenuoTemporalPlugin``. The alias stays importable
+# for one beta cycle and emits a ``DeprecationWarning``.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_deprecated_tenuo_plugin_alias_warns_and_points_to_worker_interceptor() -> None:
+    """``from tenuo.temporal import TenuoPlugin`` must warn and resolve to the new class."""
+    import warnings
+
+    import tenuo.temporal as tt
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        alias = tt.TenuoPlugin
+
+    assert alias is TenuoWorkerInterceptor
+    dep_warns = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert dep_warns, "expected DeprecationWarning for tenuo.temporal.TenuoPlugin"
+    msg = str(dep_warns[-1].message)
+    assert "TenuoPlugin" in msg and "TenuoWorkerInterceptor" in msg
+    assert "deprecated" in msg.lower()

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -109,17 +109,36 @@ def test_ensure_tenuo_workflow_runner_non_sandbox_unchanged(caplog) -> None:
     ), "Custom runners should log a passthrough warning."
 
 
-def test_ensure_tenuo_workflow_runner_rejects_unsandboxed() -> None:
-    """UnsandboxedWorkflowRunner is rejected outright (PyO3 passthrough impossible)."""
-    from tenuo.exceptions import ConfigurationError
+def test_ensure_tenuo_workflow_runner_warns_on_unsandboxed(caplog) -> None:
+    """UnsandboxedWorkflowRunner is allowed but warns loudly (both warnings + logging)."""
+    import warnings
 
     try:
         from temporalio.worker import UnsandboxedWorkflowRunner
     except ImportError:
         pytest.skip("temporalio version does not expose UnsandboxedWorkflowRunner")
 
-    with pytest.raises(ConfigurationError, match="UnsandboxedWorkflowRunner"):
-        ensure_tenuo_workflow_runner(UnsandboxedWorkflowRunner())
+    existing = UnsandboxedWorkflowRunner()
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        with caplog.at_level("WARNING", logger="tenuo.temporal"):
+            result = ensure_tenuo_workflow_runner(existing)
+
+    assert result is existing, (
+        "ensure_tenuo_workflow_runner must not replace a user-supplied "
+        "UnsandboxedWorkflowRunner — it should return it unchanged and warn."
+    )
+
+    user_warnings = [
+        w for w in captured_warnings if issubclass(w.category, UserWarning)
+    ]
+    assert user_warnings, "UserWarning must be emitted for UnsandboxedWorkflowRunner."
+    assert "UnsandboxedWorkflowRunner" in str(user_warnings[0].message)
+
+    assert any(
+        "UnsandboxedWorkflowRunner" in rec.getMessage()
+        for rec in caplog.records
+    ), "A tenuo.temporal logger warning must also be emitted."
 
 
 def test_lazy_export_from_tenuo_temporal() -> None:

--- a/tenuo-python/tests/adapters/test_transparent_interceptor.py
+++ b/tenuo-python/tests/adapters/test_transparent_interceptor.py
@@ -1,7 +1,7 @@
 """
 Test transparent PoP computation in the outbound workflow interceptor.
 
-This test suite verifies that the TenuoPlugin correctly computes PoP
+This test suite verifies that the TenuoWorkerInterceptor correctly computes PoP
 inline during start_activity() calls, eliminating the need for queue machinery.
 
 Key aspects tested:
@@ -12,7 +12,7 @@ Key aspects tested:
 5. Fail-closed behavior when PoP computation fails
 
 Design Decision: timestamp parameter is OPTIONAL
-  - For Temporal: TenuoPlugin always provides it (workflow.now())
+  - For Temporal: TenuoWorkerInterceptor always provides it (workflow.now())
   - For non-Temporal: None → wall-clock time (correct behavior)
   - Users should NEVER call warrant.sign() directly in Temporal workflows
   - The transparent interceptor architecture ensures correct usage
@@ -47,7 +47,7 @@ from tenuo import SigningKey, Warrant
 from tenuo.temporal._client import TenuoClientInterceptor
 from tenuo.temporal._config import TenuoPluginConfig
 from tenuo.temporal._headers import tenuo_headers
-from tenuo.temporal._interceptors import TenuoPlugin
+from tenuo.temporal._interceptors import TenuoWorkerInterceptor
 from tenuo.temporal._resolvers import EnvKeyResolver
 
 
@@ -260,7 +260,7 @@ if TEMPORAL_AVAILABLE:
                 activities = [read_file, write_file, list_files]
                 resolver = EnvKeyResolver()
                 resolver.preload_keys(["agent1"])
-                worker_interceptor = TenuoPlugin(
+                worker_interceptor = TenuoWorkerInterceptor(
                     TenuoPluginConfig(
                         key_resolver=resolver,
                         on_denial="raise",
@@ -347,7 +347,7 @@ if TEMPORAL_AVAILABLE:
                 parallel_activities = [read_file]
                 resolver = EnvKeyResolver()
                 resolver.preload_keys(["agent1"])
-                worker_interceptor = TenuoPlugin(
+                worker_interceptor = TenuoWorkerInterceptor(
                     TenuoPluginConfig(
                         key_resolver=resolver,
                         on_denial="raise",

--- a/tenuo-python/tests/e2e/test_temporal_e2e.py
+++ b/tenuo-python/tests/e2e/test_temporal_e2e.py
@@ -34,7 +34,7 @@ from tenuo import SigningKey, Warrant  # noqa: E402
 from tenuo.temporal import (  # noqa: E402
     EnvKeyResolver,
     TenuoClientInterceptor,
-    TenuoPlugin,
+    TenuoWorkerInterceptor,
     TenuoPluginConfig,
     tenuo_headers,
 )
@@ -318,7 +318,7 @@ class TestActivityInterceptorAuthorizer:
             trusted_roots=[ck.public_key],
             audit_callback=events.append if events is not None else None,
         )
-        return TenuoPlugin(cfg)
+        return TenuoWorkerInterceptor(cfg)
 
     def test_allows_authorized_activity(self, warrant, agent_key, control_key, headers_dict):
         events = []
@@ -467,7 +467,7 @@ class TestAuditEvents:
             trusted_roots=[control_key.public_key],
             audit_callback=events.append, redact_args_in_logs=False,
         )
-        ti = TenuoPlugin(cfg)
+        ti = TenuoWorkerInterceptor(cfg)
         wf = "wf-ae"
         act_headers = _make_activity_headers(
             headers_dict, warrant, agent_key, "read_file", {"path": "/tmp/demo/a.txt"})
@@ -495,7 +495,7 @@ class TestAuditEvents:
             trusted_roots=[control_key.public_key],
             audit_callback=events.append,
         )
-        ti = TenuoPlugin(cfg)
+        ti = TenuoWorkerInterceptor(cfg)
         wf = "wf-de"
         act_headers = _make_activity_headers(
             headers_dict, warrant, agent_key, "read_file", {"path": "/etc/shadow"})
@@ -530,7 +530,7 @@ class TestDryRunMode:
             trusted_roots=[control_key.public_key],
             audit_callback=events.append,
         )
-        ti = TenuoPlugin(cfg)
+        ti = TenuoWorkerInterceptor(cfg)
         wf = "wf-dry-deny"
         act_headers = _make_activity_headers(
             headers_dict, warrant, agent_key, "read_file", {"path": "/etc/shadow"}
@@ -559,7 +559,7 @@ class TestDryRunMode:
             dry_run=True,
             require_warrant=True,
         )
-        ti = TenuoPlugin(cfg)
+        ti = TenuoWorkerInterceptor(cfg)
         nxt = MagicMock()
         nxt.execute_activity = AsyncMock(return_value="executed")
         nxt.init = MagicMock()
@@ -584,7 +584,7 @@ class TestParallelActivities:
             key_resolver=EnvKeyResolver(), on_denial="raise",
             trusted_roots=[ck.public_key],
         )
-        return TenuoPlugin(cfg)
+        return TenuoWorkerInterceptor(cfg)
 
     def test_two_different_activities_both_authorized(
         self, warrant, agent_key, control_key, headers_dict
@@ -704,7 +704,7 @@ class TestActivityRetries:
             key_resolver=EnvKeyResolver(), on_denial="raise",
             trusted_roots=[ck.public_key],
         )
-        return TenuoPlugin(cfg)
+        return TenuoWorkerInterceptor(cfg)
 
     def test_retry_with_fresh_pop(
         self, warrant, agent_key, control_key, headers_dict
@@ -757,7 +757,7 @@ class TestConcurrentWorkflows:
             key_resolver=EnvKeyResolver(), on_denial="raise",
             trusted_roots=[control_key.public_key],
         )
-        ti = TenuoPlugin(ti_cfg)
+        ti = TenuoWorkerInterceptor(ti_cfg)
 
         nxt = MagicMock()
         nxt.execute_activity = AsyncMock(return_value="data")
@@ -804,7 +804,7 @@ class TestWarrantExpiration:
             key_resolver=EnvKeyResolver(), on_denial="raise",
             trusted_roots=[control_key.public_key],
         )
-        ti = TenuoPlugin(cfg)
+        ti = TenuoWorkerInterceptor(cfg)
         wf = "wf-exp-auth"
 
         act_headers = _make_activity_headers(
@@ -832,7 +832,7 @@ class TestPopValidation:
     """PoP signature must match exactly — wrong key, wrong args, missing PoP."""
 
     def _make(self, ck):
-        return TenuoPlugin(TenuoPluginConfig(
+        return TenuoWorkerInterceptor(TenuoPluginConfig(
             key_resolver=EnvKeyResolver(), on_denial="raise",
             trusted_roots=[ck.public_key],
         ))
@@ -946,7 +946,7 @@ class TestConcurrentWorkflowsFullRoundTrip:
             key_resolver=EnvKeyResolver(), on_denial="raise",
             trusted_roots=[control_key.public_key],
         )
-        ti = TenuoPlugin(cfg)
+        ti = TenuoWorkerInterceptor(cfg)
 
         h1 = tenuo_headers(warrant1, "a1")
         h2 = tenuo_headers(warrant2, "a2")
@@ -996,7 +996,7 @@ class TestConcurrentWorkflowsFullRoundTrip:
             key_resolver=EnvKeyResolver(), on_denial="raise",
             trusted_roots=[control_key.public_key],
         )
-        ti = TenuoPlugin(cfg)
+        ti = TenuoWorkerInterceptor(cfg)
 
         h1 = tenuo_headers(warrant1, "a1")
         # PoP for an out-of-scope path
@@ -1106,7 +1106,7 @@ class TestDistributedHeaderPropagation:
             key_resolver=EnvKeyResolver(), on_denial="raise",
             trusted_roots=[control_key.public_key],
         )
-        ti = TenuoPlugin(cfg)
+        ti = TenuoWorkerInterceptor(cfg)
 
         nxt = MagicMock()
         nxt.execute_activity = AsyncMock(return_value="content")
@@ -1347,7 +1347,7 @@ class TestOutboundInterceptorHeaderInjection:
             key_resolver=EnvKeyResolver(), on_denial="raise",
             trusted_roots=[control_key.public_key],
         )
-        ti = TenuoPlugin(cfg)
+        ti = TenuoWorkerInterceptor(cfg)
 
         nxt = MagicMock()
         nxt.execute_activity = AsyncMock(return_value="remote-result")

--- a/tenuo-python/tests/e2e/test_temporal_live.py
+++ b/tenuo-python/tests/e2e/test_temporal_live.py
@@ -43,7 +43,7 @@ from tenuo.temporal import (  # noqa: E402
     KeyResolver,
     TemporalAuditEvent,
     TenuoClientInterceptor,
-    TenuoPlugin,
+    TenuoWorkerInterceptor,
     TenuoPluginConfig,
     tenuo_execute_activity,
     tenuo_execute_child_workflow,
@@ -319,7 +319,7 @@ async def _run_workflow(
     if plugin_config:
         cfg_kwargs.update(plugin_config)
     cfg = TenuoPluginConfig(**cfg_kwargs)
-    interceptor = TenuoPlugin(cfg)
+    interceptor = TenuoWorkerInterceptor(cfg)
     _set_worker_config(cfg)
 
     sandbox_runner = SandboxedWorkflowRunner(

--- a/tenuo-python/tests/e2e/test_temporal_replay.py
+++ b/tenuo-python/tests/e2e/test_temporal_replay.py
@@ -5,7 +5,7 @@ try:
     from temporalio import workflow, activity
     from temporalio.worker import Replayer, Worker
     from temporalio.testing import WorkflowEnvironment
-    from temporalio.client import Client, WorkflowHistory
+    from temporalio.client import Client
     from temporalio.worker.workflow_sandbox import (
         SandboxedWorkflowRunner,
         SandboxRestrictions,
@@ -21,7 +21,6 @@ from tenuo.temporal import (
     TenuoPluginConfig,
     tenuo_headers,
 )
-from tenuo.temporal._constants import TENUO_POP_HEADER
 from tenuo.temporal.exceptions import KeyResolutionError
 from tenuo import Warrant
 from tenuo_core import SigningKey
@@ -73,15 +72,18 @@ def _tenuo_sandbox_runner() -> SandboxedWorkflowRunner:
     )
 
 
-# ---------------------------------------------------------------------------
-# Helpers for the tampering / rotated-root tests
-# ---------------------------------------------------------------------------
+@pytest.mark.temporal_live
+@pytest.mark.asyncio
+async def test_tenuo_plugin_replay_safety():
+    """TenuoPlugin + AuthorizedWorkflow stay deterministic under Temporal Replayer."""
+    signing_key = SigningKey.generate()
+    config = TenuoPluginConfig(
+        key_resolver=DictKeyResolver({KEY_ID: signing_key}),
+        dry_run=False,
+        trusted_roots=[signing_key.public_key],
+        activity_fns=[write_db_activity],
+    )
 
-
-async def _record_successful_run(
-    signing_key: SigningKey, config: TenuoPluginConfig
-) -> WorkflowHistory:
-    """Run the workflow end-to-end and return the recorded history."""
     warrant = (
         Warrant.mint_builder()
         .holder(signing_key.public_key)
@@ -92,6 +94,7 @@ async def _record_successful_run(
 
     async with await WorkflowEnvironment.start_local() as env:
         client = env.client
+
         client_interceptor = TenuoClientInterceptor()
         client_with_interceptor = Client(
             client.service_client,
@@ -99,6 +102,7 @@ async def _record_successful_run(
             data_converter=client.data_converter,
             interceptors=[client_interceptor],
         )
+
         async with Worker(
             client_with_interceptor,
             task_queue="replay-task-queue",
@@ -118,59 +122,9 @@ async def _record_successful_run(
                 task_queue="replay-task-queue",
             )
             assert result == "Wrote: test-data-123"
-            return await client_with_interceptor.get_workflow_handle(
-                "replay-wf-1"
-            ).fetch_history()
 
-
-def _flip_pop_byte_in_history(history: WorkflowHistory) -> WorkflowHistory:
-    """Return a new history where the PoP payload on the first activity-schedule
-    event has one byte flipped. Raises if no PoP header is found (keeps the test
-    honest — if the recording didn't carry a PoP, the scenario is meaningless).
-    """
-    tampered_any = False
-    for event in history.events:
-        attrs = event.activity_task_scheduled_event_attributes
-        if attrs is None or not attrs.ByteSize():
-            continue
-        header = attrs.header
-        if header is None:
-            continue
-        field = header.fields.get(TENUO_POP_HEADER)
-        if field is None or not field.data:
-            continue
-        mutated = bytearray(field.data)
-        mutated[0] ^= 0x01
-        field.data = bytes(mutated)
-        tampered_any = True
-        break
-
-    if not tampered_any:
-        raise AssertionError(
-            "No activity-task-scheduled event with a PoP header found in the "
-            "captured history; cannot tamper a non-existent field."
-        )
-    return history
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.temporal_live
-@pytest.mark.asyncio
-async def test_tenuo_plugin_replay_safety():
-    """TenuoPlugin + AuthorizedWorkflow stay deterministic under Temporal Replayer."""
-    signing_key = SigningKey.generate()
-    config = TenuoPluginConfig(
-        key_resolver=DictKeyResolver({KEY_ID: signing_key}),
-        dry_run=False,
-        trusted_roots=[signing_key.public_key],
-        activity_fns=[write_db_activity],
-    )
-
-    history = await _record_successful_run(signing_key, config)
+            wf_handle = client_with_interceptor.get_workflow_handle("replay-wf-1")
+            history = await wf_handle.fetch_history()
 
     replayer = Replayer(
         workflows=[ReplayTestWorkflow],
@@ -184,88 +138,4 @@ async def test_tenuo_plugin_replay_safety():
 
     assert replay_results.replay_failure is None, (
         f"Workflow replay failed: {replay_results.replay_failure}"
-    )
-
-
-@pytest.mark.temporal_live
-@pytest.mark.asyncio
-async def test_replay_fails_on_tampered_pop_header():
-    """Proves the verification path runs during replay.
-
-    Record a successful run, flip a byte in the PoP header embedded in the
-    recorded history, then replay. The plugin re-verifies each activity's PoP
-    on replay, so a single mutated byte must turn into a replay failure. If
-    this test ever passes through with ``replay_failure is None``, the plugin
-    is no longer verifying during replay.
-    """
-    signing_key = SigningKey.generate()
-    config = TenuoPluginConfig(
-        key_resolver=DictKeyResolver({KEY_ID: signing_key}),
-        dry_run=False,
-        trusted_roots=[signing_key.public_key],
-        activity_fns=[write_db_activity],
-    )
-
-    history = await _record_successful_run(signing_key, config)
-    tampered_history = _flip_pop_byte_in_history(history)
-
-    replayer = Replayer(
-        workflows=[ReplayTestWorkflow],
-        interceptors=[TenuoPlugin(config)],
-        workflow_runner=_tenuo_sandbox_runner(),
-    )
-    replay_results = await replayer.replay_workflow(
-        tampered_history,
-        raise_on_replay_failure=False,
-    )
-
-    assert replay_results.replay_failure is not None, (
-        "Replay succeeded despite a tampered PoP payload — the plugin is not "
-        "verifying activity PoP signatures during replay."
-    )
-
-
-@pytest.mark.temporal_live
-@pytest.mark.asyncio
-async def test_replay_fails_when_trusted_root_removed():
-    """Replay must fail when the recorded warrant's issuer is no longer trusted.
-
-    Records a run signed by ``original_key`` and trusted by ``[original_key]``,
-    then replays with a config trusting only a different key. The plugin must
-    reject the history during replay rather than silently accepting stored
-    state.
-    """
-    original_key = SigningKey.generate()
-    recording_config = TenuoPluginConfig(
-        key_resolver=DictKeyResolver({KEY_ID: original_key}),
-        dry_run=False,
-        trusted_roots=[original_key.public_key],
-        activity_fns=[write_db_activity],
-    )
-
-    history = await _record_successful_run(original_key, recording_config)
-
-    rotated_key = SigningKey.generate()
-    replay_config = TenuoPluginConfig(
-        key_resolver=DictKeyResolver({KEY_ID: original_key}),
-        dry_run=False,
-        # Only the rotated root is trusted; the recorded warrant's issuer is not.
-        trusted_roots=[rotated_key.public_key],
-        activity_fns=[write_db_activity],
-    )
-
-    replayer = Replayer(
-        workflows=[ReplayTestWorkflow],
-        interceptors=[TenuoPlugin(replay_config)],
-        workflow_runner=_tenuo_sandbox_runner(),
-    )
-    replay_results = await replayer.replay_workflow(
-        history,
-        raise_on_replay_failure=False,
-    )
-
-    assert replay_results.replay_failure is not None, (
-        "Replay succeeded even though the recorded warrant's issuer was "
-        "removed from the trusted root set — the plugin is not re-checking "
-        "trust during replay."
     )

--- a/tenuo-python/tests/e2e/test_temporal_replay.py
+++ b/tenuo-python/tests/e2e/test_temporal_replay.py
@@ -5,7 +5,7 @@ try:
     from temporalio import workflow, activity
     from temporalio.worker import Replayer, Worker
     from temporalio.testing import WorkflowEnvironment
-    from temporalio.client import Client
+    from temporalio.client import Client, WorkflowHistory
     from temporalio.worker.workflow_sandbox import (
         SandboxedWorkflowRunner,
         SandboxRestrictions,
@@ -21,6 +21,8 @@ from tenuo.temporal import (
     TenuoPluginConfig,
     tenuo_headers,
 )
+from tenuo.temporal._constants import TENUO_POP_HEADER
+from tenuo.temporal.exceptions import KeyResolutionError
 from tenuo import Warrant
 from tenuo_core import SigningKey
 
@@ -40,7 +42,7 @@ class DictKeyResolver(KeyResolver):
 
     def resolve_sync(self, key_id: str):
         if key_id not in self.keys:
-            raise ValueError(f"Key {key_id} not found")
+            raise KeyResolutionError(key_id=key_id)
         return self.keys[key_id]
 
 
@@ -71,13 +73,15 @@ def _tenuo_sandbox_runner() -> SandboxedWorkflowRunner:
     )
 
 
-@pytest.mark.temporal_live
-@pytest.mark.asyncio
-async def test_tenuo_plugin_replay_safety():
-    """TenuoPlugin + AuthorizedWorkflow stay deterministic under Temporal Replayer."""
-    signing_key = SigningKey.generate()
-    key_dict = {KEY_ID: signing_key}
+# ---------------------------------------------------------------------------
+# Helpers for the tampering / rotated-root tests
+# ---------------------------------------------------------------------------
 
+
+async def _record_successful_run(
+    signing_key: SigningKey, config: TenuoPluginConfig
+) -> WorkflowHistory:
+    """Run the workflow end-to-end and return the recorded history."""
     warrant = (
         Warrant.mint_builder()
         .holder(signing_key.public_key)
@@ -86,40 +90,27 @@ async def test_tenuo_plugin_replay_safety():
         .mint(signing_key)
     )
 
-    config = TenuoPluginConfig(
-        key_resolver=DictKeyResolver(key_dict),
-        dry_run=False,
-        trusted_roots=[signing_key.public_key],
-        activity_fns=[write_db_activity],
-    )
-
     async with await WorkflowEnvironment.start_local() as env:
         client = env.client
-
         client_interceptor = TenuoClientInterceptor()
-
         client_with_interceptor = Client(
             client.service_client,
             namespace=client.namespace,
             data_converter=client.data_converter,
             interceptors=[client_interceptor],
         )
-
-        sandbox_runner = _tenuo_sandbox_runner()
-
         async with Worker(
             client_with_interceptor,
             task_queue="replay-task-queue",
             workflows=[ReplayTestWorkflow],
             activities=[write_db_activity],
             interceptors=[TenuoPlugin(config)],
-            workflow_runner=sandbox_runner,
+            workflow_runner=_tenuo_sandbox_runner(),
         ):
             client_interceptor.set_headers_for_workflow(
                 "replay-wf-1",
                 tenuo_headers(warrant, KEY_ID),
             )
-
             result = await client_with_interceptor.execute_workflow(
                 ReplayTestWorkflow.run,
                 "test-data-123",
@@ -127,16 +118,65 @@ async def test_tenuo_plugin_replay_safety():
                 task_queue="replay-task-queue",
             )
             assert result == "Wrote: test-data-123"
+            return await client_with_interceptor.get_workflow_handle(
+                "replay-wf-1"
+            ).fetch_history()
 
-            wf_handle = client_with_interceptor.get_workflow_handle("replay-wf-1")
-            history = await wf_handle.fetch_history()
+
+def _flip_pop_byte_in_history(history: WorkflowHistory) -> WorkflowHistory:
+    """Return a new history where the PoP payload on the first activity-schedule
+    event has one byte flipped. Raises if no PoP header is found (keeps the test
+    honest — if the recording didn't carry a PoP, the scenario is meaningless).
+    """
+    tampered_any = False
+    for event in history.events:
+        attrs = event.activity_task_scheduled_event_attributes
+        if attrs is None or not attrs.ByteSize():
+            continue
+        header = attrs.header
+        if header is None:
+            continue
+        field = header.fields.get(TENUO_POP_HEADER)
+        if field is None or not field.data:
+            continue
+        mutated = bytearray(field.data)
+        mutated[0] ^= 0x01
+        field.data = bytes(mutated)
+        tampered_any = True
+        break
+
+    if not tampered_any:
+        raise AssertionError(
+            "No activity-task-scheduled event with a PoP header found in the "
+            "captured history; cannot tamper a non-existent field."
+        )
+    return history
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.temporal_live
+@pytest.mark.asyncio
+async def test_tenuo_plugin_replay_safety():
+    """TenuoPlugin + AuthorizedWorkflow stay deterministic under Temporal Replayer."""
+    signing_key = SigningKey.generate()
+    config = TenuoPluginConfig(
+        key_resolver=DictKeyResolver({KEY_ID: signing_key}),
+        dry_run=False,
+        trusted_roots=[signing_key.public_key],
+        activity_fns=[write_db_activity],
+    )
+
+    history = await _record_successful_run(signing_key, config)
 
     replayer = Replayer(
         workflows=[ReplayTestWorkflow],
         interceptors=[TenuoPlugin(config)],
         workflow_runner=_tenuo_sandbox_runner(),
     )
-
     replay_results = await replayer.replay_workflow(
         history,
         raise_on_replay_failure=False,
@@ -144,4 +184,88 @@ async def test_tenuo_plugin_replay_safety():
 
     assert replay_results.replay_failure is None, (
         f"Workflow replay failed: {replay_results.replay_failure}"
+    )
+
+
+@pytest.mark.temporal_live
+@pytest.mark.asyncio
+async def test_replay_fails_on_tampered_pop_header():
+    """Proves the verification path runs during replay.
+
+    Record a successful run, flip a byte in the PoP header embedded in the
+    recorded history, then replay. The plugin re-verifies each activity's PoP
+    on replay, so a single mutated byte must turn into a replay failure. If
+    this test ever passes through with ``replay_failure is None``, the plugin
+    is no longer verifying during replay.
+    """
+    signing_key = SigningKey.generate()
+    config = TenuoPluginConfig(
+        key_resolver=DictKeyResolver({KEY_ID: signing_key}),
+        dry_run=False,
+        trusted_roots=[signing_key.public_key],
+        activity_fns=[write_db_activity],
+    )
+
+    history = await _record_successful_run(signing_key, config)
+    tampered_history = _flip_pop_byte_in_history(history)
+
+    replayer = Replayer(
+        workflows=[ReplayTestWorkflow],
+        interceptors=[TenuoPlugin(config)],
+        workflow_runner=_tenuo_sandbox_runner(),
+    )
+    replay_results = await replayer.replay_workflow(
+        tampered_history,
+        raise_on_replay_failure=False,
+    )
+
+    assert replay_results.replay_failure is not None, (
+        "Replay succeeded despite a tampered PoP payload — the plugin is not "
+        "verifying activity PoP signatures during replay."
+    )
+
+
+@pytest.mark.temporal_live
+@pytest.mark.asyncio
+async def test_replay_fails_when_trusted_root_removed():
+    """Replay must fail when the recorded warrant's issuer is no longer trusted.
+
+    Records a run signed by ``original_key`` and trusted by ``[original_key]``,
+    then replays with a config trusting only a different key. The plugin must
+    reject the history during replay rather than silently accepting stored
+    state.
+    """
+    original_key = SigningKey.generate()
+    recording_config = TenuoPluginConfig(
+        key_resolver=DictKeyResolver({KEY_ID: original_key}),
+        dry_run=False,
+        trusted_roots=[original_key.public_key],
+        activity_fns=[write_db_activity],
+    )
+
+    history = await _record_successful_run(original_key, recording_config)
+
+    rotated_key = SigningKey.generate()
+    replay_config = TenuoPluginConfig(
+        key_resolver=DictKeyResolver({KEY_ID: original_key}),
+        dry_run=False,
+        # Only the rotated root is trusted; the recorded warrant's issuer is not.
+        trusted_roots=[rotated_key.public_key],
+        activity_fns=[write_db_activity],
+    )
+
+    replayer = Replayer(
+        workflows=[ReplayTestWorkflow],
+        interceptors=[TenuoPlugin(replay_config)],
+        workflow_runner=_tenuo_sandbox_runner(),
+    )
+    replay_results = await replayer.replay_workflow(
+        history,
+        raise_on_replay_failure=False,
+    )
+
+    assert replay_results.replay_failure is not None, (
+        "Replay succeeded even though the recorded warrant's issuer was "
+        "removed from the trusted root set — the plugin is not re-checking "
+        "trust during replay."
     )

--- a/tenuo-python/tests/e2e/test_temporal_replay.py
+++ b/tenuo-python/tests/e2e/test_temporal_replay.py
@@ -17,7 +17,7 @@ from tenuo.temporal import (
     AuthorizedWorkflow,
     KeyResolver,
     TenuoClientInterceptor,
-    TenuoPlugin,
+    TenuoWorkerInterceptor,
     TenuoPluginConfig,
     tenuo_headers,
 )
@@ -75,7 +75,7 @@ def _tenuo_sandbox_runner() -> SandboxedWorkflowRunner:
 @pytest.mark.temporal_live
 @pytest.mark.asyncio
 async def test_tenuo_plugin_replay_safety():
-    """TenuoPlugin + AuthorizedWorkflow stay deterministic under Temporal Replayer."""
+    """TenuoWorkerInterceptor + AuthorizedWorkflow stay deterministic under Temporal Replayer."""
     signing_key = SigningKey.generate()
     config = TenuoPluginConfig(
         key_resolver=DictKeyResolver({KEY_ID: signing_key}),
@@ -108,7 +108,7 @@ async def test_tenuo_plugin_replay_safety():
             task_queue="replay-task-queue",
             workflows=[ReplayTestWorkflow],
             activities=[write_db_activity],
-            interceptors=[TenuoPlugin(config)],
+            interceptors=[TenuoWorkerInterceptor(config)],
             workflow_runner=_tenuo_sandbox_runner(),
         ):
             client_interceptor.set_headers_for_workflow(
@@ -128,7 +128,7 @@ async def test_tenuo_plugin_replay_safety():
 
     replayer = Replayer(
         workflows=[ReplayTestWorkflow],
-        interceptors=[TenuoPlugin(config)],
+        interceptors=[TenuoWorkerInterceptor(config)],
         workflow_runner=_tenuo_sandbox_runner(),
     )
     replay_results = await replayer.replay_workflow(

--- a/tenuo-python/tests/security/test_integration_invariants.py
+++ b/tenuo-python/tests/security/test_integration_invariants.py
@@ -1291,7 +1291,7 @@ class _TemporalAdapter(_Adapter):
         pytest.importorskip("temporalio")
         from tenuo.temporal._config import TenuoPluginConfig
         from tenuo.temporal._constants import TENUO_WARRANT_HEADER
-        from tenuo.temporal._interceptors import TenuoPlugin
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
         from tenuo.temporal._resolvers import KeyResolver
 
         self._root = SigningKey.generate()
@@ -1309,7 +1309,7 @@ class _TemporalAdapter(_Adapter):
             require_warrant=True,
             on_denial="raise",
         )
-        self._interceptor = TenuoPlugin(cfg)
+        self._interceptor = TenuoWorkerInterceptor(cfg)
         self._warrant = Warrant.issue(
             self._root, capabilities={"test_activity": {}}, ttl_seconds=3600,
             holder=self._root.public_key,
@@ -2049,7 +2049,7 @@ class TestMCPInvariants:
 @pytest.mark.security
 class TestTemporalInvariants:
     """
-    Security invariants for the Temporal TenuoPlugin integration.
+    Security invariants for the Temporal TenuoWorkerInterceptor integration.
 
     The interceptor validates warrants arriving in Temporal activity headers.
     These tests exercise execute_activity() with synthetic headers so no
@@ -2059,7 +2059,7 @@ class TestTemporalInvariants:
     def _make_interceptor(self, trusted_key: SigningKey):
         pytest.importorskip("temporalio")
         from tenuo.temporal._config import TenuoPluginConfig
-        from tenuo.temporal._interceptors import TenuoPlugin
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
         from tenuo.temporal._resolvers import KeyResolver
 
         class _StaticResolver(KeyResolver):
@@ -2075,7 +2075,7 @@ class TestTemporalInvariants:
             require_warrant=True,
             on_denial="raise",
         )
-        return TenuoPlugin(cfg)
+        return TenuoWorkerInterceptor(cfg)
 
     def _make_activity_input(self, headers: Dict[str, Any]):
         """Build a fake Temporal ExecuteActivityInput from a headers dict."""
@@ -2279,7 +2279,7 @@ class TestTemporalInvariantsExtended:
     def _make_interceptor(self, trusted_key: SigningKey):
         pytest.importorskip("temporalio")
         from tenuo.temporal._config import TenuoPluginConfig
-        from tenuo.temporal._interceptors import TenuoPlugin
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
         from tenuo.temporal._resolvers import KeyResolver
 
         class _R(KeyResolver):
@@ -2293,7 +2293,7 @@ class TestTemporalInvariantsExtended:
             trusted_roots=[trusted_key.public_key],
             require_warrant=True, on_denial="raise",
         )
-        return TenuoPlugin(cfg)
+        return TenuoWorkerInterceptor(cfg)
 
     def _make_input(self, warrant: Warrant, activity_name: str = "test_activity"):
         from unittest.mock import MagicMock

--- a/tenuo-python/tests/security/test_security_contracts.py
+++ b/tenuo-python/tests/security/test_security_contracts.py
@@ -243,7 +243,7 @@ class TestOnDenialBehaviouralContracts:
         pytest.importorskip("temporalio")
         from tenuo.temporal._config import TenuoPluginConfig
         from tenuo.temporal._constants import TENUO_WARRANT_HEADER
-        from tenuo.temporal._interceptors import TenuoPlugin
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
         from tenuo.temporal._resolvers import KeyResolver
 
         trusted_key = SigningKey.generate()
@@ -261,7 +261,7 @@ class TestOnDenialBehaviouralContracts:
             require_warrant=True,
             on_denial="log",
         )
-        interceptor = TenuoPlugin(cfg)
+        interceptor = TenuoWorkerInterceptor(cfg)
 
         inp = MagicMock()
         inp.headers = {TENUO_WARRANT_HEADER: bytes(w.to_bytes())}
@@ -532,7 +532,7 @@ class TestDryRunIsOptIn:
 
         pytest.importorskip("temporalio")
         from tenuo.temporal._config import TenuoPluginConfig
-        from tenuo.temporal._interceptors import TenuoPlugin
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
         from tenuo.temporal._resolvers import KeyResolver
 
         root = SigningKey.generate()
@@ -547,7 +547,7 @@ class TestDryRunIsOptIn:
             require_warrant=True,
             dry_run=True,
         )
-        interceptor = TenuoPlugin(cfg)
+        interceptor = TenuoWorkerInterceptor(cfg)
 
         inp = MagicMock()
         inp.headers = {}  # no warrant
@@ -594,7 +594,7 @@ class TestDryRunIsOptIn:
 
         pytest.importorskip("temporalio")
         from tenuo.temporal._config import TenuoPluginConfig
-        from tenuo.temporal._interceptors import TenuoPlugin
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
         from tenuo.temporal._resolvers import KeyResolver
 
         root = SigningKey.generate()
@@ -610,7 +610,7 @@ class TestDryRunIsOptIn:
             dry_run=False,
             on_denial="raise",
         )
-        interceptor = TenuoPlugin(cfg)
+        interceptor = TenuoWorkerInterceptor(cfg)
 
         inp = MagicMock()
         inp.headers = {}  # no warrant


### PR DESCRIPTION
## Summary

Addresses worker-side feedback from the Temporal team (DABH) on
[temporalio/sdk-python#1447](https://github.com/temporalio/sdk-python/pull/1447).

**Plugin (`tenuo-python/tenuo/temporal_plugin.py`)**
- No longer mutates the user's `TenuoPluginConfig`; works on a shallow copy so two workers sharing a config stay isolated.
- Registers Tenuo's domain exceptions (`TenuoContextError`, `PopVerificationError`, `TemporalConstraintViolation`, `WarrantExpired`, `ChainValidationError`, `KeyResolutionError`, `LocalActivityError`) as `workflow_failure_exception_types` on SDKs that support it.
- Preload failures log at `ERROR` with the resolver class name; `EnvKeyResolver` preload failure raises `ConfigurationError` (no safe `os.environ` fallback in the sandbox).
- `ensure_tenuo_workflow_runner` emits a `UserWarning` plus a logger warning when given `UnsandboxedWorkflowRunner` (Tenuo still works — the user is just opting out of Temporal's own determinism guardrails, which is a legitimate choice for debugging), and warns for unknown custom runners.
- Duplicate-registration error now points at `Client.connect(plugins=[plugin])` inheritance instead of advising one-plugin-per-worker.

**Plugin-confusion rename (`tenuo.temporal.TenuoPlugin` → `TenuoWorkerInterceptor`)**
- The old name was a Temporal SDK `WorkerInterceptor`, not a Temporal SDK `Plugin`, and its resemblance to `tenuo.temporal_plugin.TenuoTemporalPlugin` caused real misconfigurations (e.g. `Worker(plugins=[TenuoPlugin(...)])` silently accepting an unusable argument).
- New canonical name: `tenuo.temporal.TenuoWorkerInterceptor`.
- Backward compat: `tenuo.temporal.TenuoPlugin` is still importable as a deprecated alias and emits a `DeprecationWarning` on first resolution; scheduled for removal in a future beta. Most users register `TenuoTemporalPlugin` via `Client.connect(plugins=[plugin])` and are unaffected.
- Updated all internal usages, tests, examples (5 files), and docs. Added an "About the names" callout table in `docs/temporal.md` and a "renamed from" breadcrumb in `docs/temporal-reference.md`.
- New unit test asserts the alias warns and resolves to the new class.

**Tests**
- `DictKeyResolver` raises `KeyResolutionError` instead of `ValueError`.
- 7 new unit tests in `tests/adapters/test_temporal_plugin.py` cover every plugin-side change above, plus the deprecation-alias test.

**Deferred to follow-ups**
- Making `ensure_tenuo_workflow_runner` private — useful public escape hatch for advanced users; keep public.
- Replay-time negative tests (tampered history, rotated trusted roots, clock-boundary). Initial attempts revealed that the current plugin architecture does not re-verify activity PoP during replay — activities don't re-execute, and the workflow inbound interceptor only stashes headers without re-checking. Designing meaningful replay-safety tests requires plumbing changes and should be scoped as its own task.

## Test plan
- [x] `uv run pytest tests/adapters/test_temporal_plugin.py` — 33 passed (incl. new deprecation test).
- [x] `uv run pytest tests/adapters/test_temporal.py tests/adapters/test_transparent_interceptor.py tests/adapters/test_temporal_integration.py tests/e2e/test_temporal_replay.py` — 166 passed.
- [x] `uv run pytest tests/e2e/test_temporal_e2e.py tests/e2e/test_temporal_replay.py` — 61 passed.
- [x] `uv run pytest tests/security/test_security_contracts.py tests/security/test_integration_invariants.py` — 117 passed, 22 skipped.
- [x] `uvx ruff check` clean on modified files.
- [x] `mypy tenuo/temporal/__init__.py tenuo/temporal/_interceptors.py tenuo/temporal_plugin.py` — no errors.
- [x] All 5 Temporal examples byte-compile.