### PR TITLE
temporal: privatize ensure_tenuo_workflow_runner + attenuated_headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   order now checks `bool` first, so booleans stay booleans on both sides.
   This is a signed-bytes-format change that affects any tool-call
   argument dict containing Python `True` / `False`.
+- **`ensure_tenuo_workflow_runner` and `attenuated_headers` are now
+  internal.** Renamed to `_ensure_tenuo_workflow_runner` in
+  `tenuo.temporal_plugin` and `_attenuated_headers` in
+  `tenuo.temporal._workflow`; removed from `tenuo.temporal.__all__`
+  and `tenuo.temporal_plugin.__all__`. Users wiring a worker manually
+  should rely on the plugin (`TenuoTemporalPlugin`) or
+  `TenuoWorkerInterceptor(..., task_queue=...)` / `register_worker_config`;
+  child-workflow delegation should go through
+  `tenuo_execute_child_workflow(...)`.
 - **Worker-config registration is strict-match by `task_queue`.** The
   internal worker-config registry no longer has a "last registered"
   fallback slot or a "if only one is registered, use it" convenience

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -68,7 +68,7 @@ All documented symbols can be imported from the top-level package (`from tenuo.t
 | `tenuo.temporal._observability` | `TemporalAuditEvent`, `TenuoMetrics` |
 | `tenuo.temporal._constants` | `TENUO_WARRANT_HEADER`, `TENUO_KEY_ID_HEADER`, `TENUO_POP_HEADER`, `TENUO_COMPRESSED_HEADER` |
 | `tenuo.temporal.exceptions` | `TenuoContextError`, `PopVerificationError`, `TemporalConstraintViolation`, `WarrantExpired`, `ChainValidationError`, `LocalActivityError`, `KeyResolutionError` |
-| `tenuo.temporal_plugin` | `TenuoTemporalPlugin`, `ensure_tenuo_workflow_runner` |
+| `tenuo.temporal_plugin` | `TenuoTemporalPlugin` |
 
 ---
 

--- a/tenuo-python/tenuo/temporal/__init__.py
+++ b/tenuo-python/tenuo/temporal/__init__.py
@@ -41,7 +41,7 @@ For direct imports (preferred in library / internal code)::
     tenuo.temporal._observability TemporalAuditEvent, TenuoMetrics
     tenuo.temporal._constants     TENUO_WARRANT_HEADER, TENUO_KEY_ID_HEADER, …
     tenuo.temporal.exceptions     TenuoContextError, PopVerificationError, …
-    tenuo.temporal_plugin         TenuoTemporalPlugin, ensure_tenuo_workflow_runner
+    tenuo.temporal_plugin         TenuoTemporalPlugin
 """
 
 from __future__ import annotations
@@ -64,7 +64,6 @@ from tenuo.temporal.exceptions import TenuoContextError  # noqa: F401
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     # temporal_plugin (heavy: pulls in temporalio.plugin)
     "TenuoTemporalPlugin": ("tenuo.temporal_plugin", "TenuoTemporalPlugin"),
-    "ensure_tenuo_workflow_runner": ("tenuo.temporal_plugin", "ensure_tenuo_workflow_runner"),
     # _workflow — user-facing helpers
     "execute_workflow_authorized": ("tenuo.temporal._workflow", "execute_workflow_authorized"),
     "start_workflow_authorized": ("tenuo.temporal._workflow", "start_workflow_authorized"),
@@ -76,7 +75,6 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "workflow_grant": ("tenuo.temporal._workflow", "workflow_grant"),
     "workflow_issue_execution": ("tenuo.temporal._workflow", "workflow_issue_execution"),
     "set_activity_approvals": ("tenuo.temporal._workflow", "set_activity_approvals"),
-    "attenuated_headers": ("tenuo.temporal._workflow", "attenuated_headers"),
     "tenuo_continue_as_new": ("tenuo.temporal._workflow", "tenuo_continue_as_new"),
     # _state — public escape hatch for manual worker setup
     "register_worker_config": ("tenuo.temporal._state", "register_worker_config"),

--- a/tenuo-python/tenuo/temporal/_workflow.py
+++ b/tenuo-python/tenuo/temporal/_workflow.py
@@ -348,7 +348,7 @@ async def _dispatch_mint_activity(
 
     Centralises the boilerplate (RetryPolicy, timeout, non-retryable error types)
     shared by ``workflow_grant``, ``workflow_issue_execution``, and
-    ``attenuated_headers``. Returns the raw child warrant bytes.
+    ``_attenuated_headers``. Returns the raw child warrant bytes.
 
     Capabilities are stashed in a process-local dict rather than inlined in
     ``_MintRequest``, because PyO3 constraint types cannot survive Temporal's
@@ -715,7 +715,7 @@ async def start_workflow_authorized(
     )
 
 
-async def attenuated_headers(
+async def _attenuated_headers(
     *,
     tools: Optional[List[str]] = None,
     constraints: Optional[Dict[str, Any]] = None,
@@ -723,9 +723,11 @@ async def attenuated_headers(
     child_key_id: Optional[str] = None,
     compress: bool = True,
 ) -> Dict[str, bytes]:
-    """Create headers for a child workflow with attenuated scope.
+    """Internal: build child-workflow headers with an attenuated warrant.
 
-    Must be called from within a workflow context.
+    Called from :func:`tenuo_execute_child_workflow`. Must run inside a
+    workflow context. Not part of the public API; users delegate via
+    ``tenuo_execute_child_workflow(..., tools=..., constraints=...)``.
     """
     try:
         from temporalio import workflow  # type: ignore[import-not-found]  # noqa: F401
@@ -838,7 +840,7 @@ async def tenuo_execute_child_workflow(
     except ImportError:
         raise TenuoContextError("temporalio not available. Install with: pip install temporalio")
 
-    hdrs = await attenuated_headers(
+    hdrs = await _attenuated_headers(
         tools=tools,
         constraints=constraints,
         ttl_seconds=ttl_seconds,

--- a/tenuo-python/tenuo/temporal_plugin.py
+++ b/tenuo-python/tenuo/temporal_plugin.py
@@ -154,7 +154,7 @@ def _simple_plugin_kwargs(
     return kwargs
 
 
-def ensure_tenuo_workflow_runner(
+def _ensure_tenuo_workflow_runner(
     existing: Optional["WorkflowRunner"],
 ) -> "WorkflowRunner":
     """Return a workflow runner with ``tenuo`` and ``tenuo_core`` sandbox passthrough.
@@ -353,7 +353,7 @@ class TenuoTemporalPlugin(SimplePlugin):
 
         super().__init__(
             TENUO_TEMPORAL_SIMPLE_PLUGIN_NAME,
-            workflow_runner=ensure_tenuo_workflow_runner,
+            workflow_runner=_ensure_tenuo_workflow_runner,
             activities=_add_activities,
             **_simple_plugin_kwargs(self.client_interceptor, worker_interceptor),
         )
@@ -419,5 +419,4 @@ class TenuoTemporalPlugin(SimplePlugin):
 __all__ = [
     "TENUO_TEMPORAL_SIMPLE_PLUGIN_NAME",
     "TenuoTemporalPlugin",
-    "ensure_tenuo_workflow_runner",
 ]

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -22,7 +22,7 @@ from tenuo.temporal_plugin import (  # noqa: E402
     TENUO_TEMPORAL_SIMPLE_PLUGIN_NAME,
     TenuoTemporalPlugin,
     _simple_plugin_kwargs,
-    ensure_tenuo_workflow_runner,
+    _ensure_tenuo_workflow_runner,
 )
 
 
@@ -81,28 +81,26 @@ def test_configure_client_merges_client_interceptors() -> None:
 
 
 def test_ensure_tenuo_workflow_runner_none() -> None:
-    wr = ensure_tenuo_workflow_runner(None)
+    wr = _ensure_tenuo_workflow_runner(None)
     assert isinstance(wr, SandboxedWorkflowRunner)
 
 
 def test_ensure_tenuo_workflow_runner_preserves_custom_restrictions() -> None:
     base = SandboxedWorkflowRunner(
-        restrictions=SandboxRestrictions.default.with_passthrough_modules("json")
+        restrictions=SandboxRestrictions.default.with_passthrough_modules("foo")
     )
-    wr = ensure_tenuo_workflow_runner(base)
+    wr = _ensure_tenuo_workflow_runner(base)
     assert isinstance(wr, SandboxedWorkflowRunner)
     assert wr is not base
 
 
 def test_ensure_tenuo_workflow_runner_non_sandbox_unchanged(caplog) -> None:
-    """Unknown custom runners are returned unchanged with a warning."""
-
     class _NotSandboxed:
         """Stand-in for an unknown custom :class:`WorkflowRunner`."""
 
     existing = _NotSandboxed()
     with caplog.at_level("WARNING", logger="tenuo.temporal"):
-        assert ensure_tenuo_workflow_runner(existing) is existing
+        assert _ensure_tenuo_workflow_runner(existing) is existing
     assert any(
         "passthrough for" in rec.getMessage()
         for rec in caplog.records
@@ -110,22 +108,21 @@ def test_ensure_tenuo_workflow_runner_non_sandbox_unchanged(caplog) -> None:
 
 
 def test_ensure_tenuo_workflow_runner_warns_on_unsandboxed(caplog) -> None:
-    """UnsandboxedWorkflowRunner is allowed but warns loudly (both warnings + logging)."""
+    """UnsandboxedWorkflowRunner is allowed and warns."""
     import warnings
-
     try:
-        from temporalio.worker import UnsandboxedWorkflowRunner
+        from temporalio.worker.workflow_sandbox import UnsandboxedWorkflowRunner
     except ImportError:
-        pytest.skip("temporalio version does not expose UnsandboxedWorkflowRunner")
+        pytest.skip("UnsandboxedWorkflowRunner not available")
 
     existing = UnsandboxedWorkflowRunner()
-    with warnings.catch_warnings(record=True) as captured_warnings:
-        warnings.simplefilter("always")
-        with caplog.at_level("WARNING", logger="tenuo.temporal"):
-            result = ensure_tenuo_workflow_runner(existing)
+    with caplog.at_level("WARNING", logger="tenuo.temporal"):
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
+            result = _ensure_tenuo_workflow_runner(existing)
 
     assert result is existing, (
-        "ensure_tenuo_workflow_runner must not replace a user-supplied "
+        "_ensure_tenuo_workflow_runner must not replace a user-supplied "
         "UnsandboxedWorkflowRunner — it should return it unchanged and warn."
     )
 
@@ -146,7 +143,6 @@ def test_lazy_export_from_tenuo_temporal() -> None:
 
     cls = tt.TenuoTemporalPlugin
     assert cls is TenuoTemporalPlugin
-    assert tt.ensure_tenuo_workflow_runner is ensure_tenuo_workflow_runner
 
 
 def test_internal_mint_activity_registered():

--- a/tenuo-python/tests/adapters/test_temporal_replay_safety.py
+++ b/tenuo-python/tests/adapters/test_temporal_replay_safety.py
@@ -215,48 +215,48 @@ class TestWorkflowGrantAsync:
 
 
 class TestPassthroughModules:
-    """ensure_tenuo_workflow_runner provides tenuo + tenuo_core passthrough."""
+    """_ensure_tenuo_workflow_runner provides tenuo + tenuo_core passthrough."""
 
     def test_ensure_tenuo_workflow_runner_creates_sandboxed_runner(self):
-        """ensure_tenuo_workflow_runner(None) returns a SandboxedWorkflowRunner."""
+        """_ensure_tenuo_workflow_runner(None) returns a SandboxedWorkflowRunner."""
         from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
 
-        from tenuo.temporal_plugin import ensure_tenuo_workflow_runner
+        from tenuo.temporal_plugin import _ensure_tenuo_workflow_runner
 
-        runner = ensure_tenuo_workflow_runner(None)
+        runner = _ensure_tenuo_workflow_runner(None)
         assert isinstance(runner, SandboxedWorkflowRunner)
 
     def test_ensure_tenuo_workflow_runner_adds_passthrough_to_existing_runner(self):
-        """ensure_tenuo_workflow_runner wraps an existing SandboxedWorkflowRunner."""
+        """_ensure_tenuo_workflow_runner wraps an existing SandboxedWorkflowRunner."""
         from temporalio.worker.workflow_sandbox import (
-            SandboxRestrictions,
             SandboxedWorkflowRunner,
+            SandboxRestrictions,
         )
 
-        from tenuo.temporal_plugin import ensure_tenuo_workflow_runner
+        from tenuo.temporal_plugin import _ensure_tenuo_workflow_runner
 
         existing = SandboxedWorkflowRunner(restrictions=SandboxRestrictions.default)
-        runner = ensure_tenuo_workflow_runner(existing)
+        runner = _ensure_tenuo_workflow_runner(existing)
         assert isinstance(runner, SandboxedWorkflowRunner)
 
 
 # =============================================================================
-# Test 7 — attenuated_headers is async (0.1c)
+# Test 7 — _attenuated_headers is async (0.1c)
 # =============================================================================
 
 
 class TestAttenuatedHeadersAsync:
-    """attenuated_headers must be async so execute_local_activity can be awaited."""
+    """_attenuated_headers must be async so execute_local_activity can be awaited."""
 
     def test_attenuated_headers_is_async(self):
-        """attenuated_headers must be declared 'async def' so callers can await
-        workflow.execute_local_activity inside it, making warrant bytes
-        deterministic on Temporal replay.
+        """``_attenuated_headers`` must be declared ``async def`` so callers
+        can await ``workflow.execute_local_activity`` inside it, making
+        warrant bytes deterministic on Temporal replay.
         """
-        from tenuo.temporal._workflow import attenuated_headers
+        from tenuo.temporal._workflow import _attenuated_headers
 
-        assert inspect.iscoroutinefunction(attenuated_headers), (
-            "attenuated_headers must be declared 'async def' so callers can await "
+        assert inspect.iscoroutinefunction(_attenuated_headers), (
+            "_attenuated_headers must be declared 'async def' so callers can await "
             "workflow.execute_local_activity inside it. This ensures warrant bytes "
             "are deterministic on Temporal workflow replay."
         )


### PR DESCRIPTION
## Summary

Small follow-up to #396 

- `ensure_tenuo_workflow_runner` → `_ensure_tenuo_workflow_runner`. Sandbox-passthrough construction is an internal detail of `TenuoTemporalPlugin.__init__`. Users wiring a worker manually already have `TenuoTemporalPlugin`, `TenuoWorkerInterceptor(..., task_queue=...)`, and `register_worker_config(...)` for the part they actually need.
- `attenuated_headers` → `_attenuated_headers`. Only caller is `tenuo_execute_child_workflow`, which is the documented delegation path; the helper was never advertised in docs or examples.

Removed from `__all__` / `_LAZY_IMPORTS` on both `tenuo.temporal_plugin` and `tenuo.temporal`; updated `docs/temporal-reference.md` public-imports table; updated the two tests that imported the old names. One concise Breaking entry in the `Unreleased` CHANGELOG covers both.

## Test plan

- [x] `uv run pytest tests/adapters/ -q` — 1544 passed, 15 skipped
- [x] `uv run mypy tenuo/temporal/ tenuo/temporal_plugin.py` — clean
- [x] `uv run ruff check tenuo/ tests/` — clean