### PR TITLE
temporal: tighten test coverage — dedup, depth bomb, interceptor composition

### DIFF
--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -37,7 +37,7 @@ from tenuo.temporal._observability import TemporalAuditEvent  # noqa: E402
 from tenuo.temporal._interceptors import TenuoWorkerInterceptor  # noqa: E402
 from tenuo.temporal._config import TenuoPluginConfig  # noqa: E402
 from tenuo.temporal._headers import _extract_key_id_from_headers, tenuo_headers  # noqa: E402
-from tenuo.temporal._decorators import get_tool_name, is_unprotected, tool, unprotected  # noqa: E402
+from tenuo.temporal._decorators import unprotected  # noqa: E402
 
 from tenuo import SigningKey as _TenCfgSigningKey  # noqa: E402
 
@@ -1081,53 +1081,10 @@ class TestTenuoPlugin:
 
 
 # =============================================================================
-# Phase 2: @unprotected Decorator Tests
-# =============================================================================
-
-
-class TestUnprotectedDecorator:
-    """Tests for @unprotected decorator."""
-
-    def test_marks_function_as_unprotected(self):
-        """@unprotected sets the marker attribute."""
-
-        @unprotected
-        def my_activity():
-            pass
-
-        assert hasattr(my_activity, "_tenuo_unprotected")
-        assert my_activity._tenuo_unprotected is True
-
-    def test_is_unprotected_returns_true_for_decorated(self):
-        """is_unprotected returns True for decorated functions."""
-
-        @unprotected
-        def my_activity():
-            pass
-
-        assert is_unprotected(my_activity) is True
-
-    def test_is_unprotected_returns_false_for_regular(self):
-        """is_unprotected returns False for regular functions."""
-
-        def my_activity():
-            pass
-
-        assert is_unprotected(my_activity) is False
-
-    def test_decorator_preserves_function(self):
-        """@unprotected doesn't modify function behavior."""
-
-        @unprotected
-        def add(a, b):
-            return a + b
-
-        assert add(2, 3) == 5
-
-
-# =============================================================================
 # Phase 2: Exception Tests
 # =============================================================================
+# ``TestUnprotectedDecorator`` lives in ``test_temporal_integration.py`` — the
+# decorator-contract tests are consolidated there to avoid duplication.
 
 
 class TestPhase2Exceptions:
@@ -1187,65 +1144,10 @@ class TestPhase2Config:
 
 
 # =============================================================================
-# Phase 3: @tool() Decorator Tests
-# =============================================================================
-
-
-class TestToolDecorator:
-    """Tests for @tool() decorator."""
-
-    def test_marks_function_with_tool_name(self):
-        """@tool() sets the tool name attribute."""
-
-        @tool("read_file")
-        def fetch_document():
-            pass
-
-        assert hasattr(fetch_document, "_tenuo_tool_name")
-        assert fetch_document._tenuo_tool_name == "read_file"
-
-    def test_get_tool_name_returns_decorated_name(self):
-        """get_tool_name returns the @tool() name."""
-
-        @tool("write_file")
-        def save_document():
-            pass
-
-        assert get_tool_name(save_document, "save_document") == "write_file"
-
-    def test_get_tool_name_returns_default_for_undecorated(self):
-        """get_tool_name returns default for undecorated functions."""
-
-        def my_activity():
-            pass
-
-        assert get_tool_name(my_activity, "my_activity") == "my_activity"
-
-    def test_decorator_preserves_function(self):
-        """@tool() doesn't modify function behavior."""
-
-        @tool("calculator")
-        def multiply(a, b):
-            return a * b
-
-        assert multiply(3, 4) == 12
-
-    def test_decorator_can_stack_with_unprotected(self):
-        """@tool() and @unprotected can be stacked."""
-
-        @unprotected
-        @tool("internal_lookup")
-        def lookup_config(key):
-            return f"value_{key}"
-
-        assert get_tool_name(lookup_config, "default") == "internal_lookup"
-        assert is_unprotected(lookup_config) is True
-        assert lookup_config("foo") == "value_foo"
-
-
-# =============================================================================
 # Phase 4: Enterprise Key Resolvers & Metrics Tests
 # =============================================================================
+# ``TestToolDecorator`` lives in ``test_temporal_integration.py`` — see that
+# file for the full @tool()/@unprotected decorator contract coverage.
 
 
 class TestCompositeKeyResolver:

--- a/tenuo-python/tests/adapters/test_temporal_integration.py
+++ b/tenuo-python/tests/adapters/test_temporal_integration.py
@@ -170,6 +170,18 @@ class TestToolDecorator:
 
         assert get_tool_name(my_activity, "my_activity") == "my_activity"
 
+    def test_decorator_can_stack_with_unprotected(self):
+        """@tool() and @unprotected compose: both markers survive stacking."""
+
+        @unprotected
+        @tool("internal_lookup")
+        def lookup_config(key):
+            return f"value_{key}"
+
+        assert get_tool_name(lookup_config, "default") == "internal_lookup"
+        assert is_unprotected(lookup_config) is True
+        assert lookup_config("foo") == "value_foo"
+
 
 # =============================================================================
 # Test: Unprotected Decorator

--- a/tenuo-python/tests/e2e/test_temporal_e2e.py
+++ b/tenuo-python/tests/e2e/test_temporal_e2e.py
@@ -2113,5 +2113,97 @@ class TestMintActivityDispatchErrorRewrap:
         assert "TENUO_TEMPORAL_ACTIVITIES" not in str(excinfo.value)
 
 
+class TestChainDepthEnforcement:
+    """``max_chain_depth`` must reject warrants whose ``depth`` exceeds the
+    configured limit, raising ``ChainValidationError`` wrapped non-retryable.
+
+    Regression guard for delegation bombs: if depth enforcement silently
+    bypasses in a refactor, an attacker with a root warrant can build an
+    arbitrarily deep chain and bypass depth-based revocation windows.
+    """
+
+    def test_deep_chain_rejected_with_chain_invalid_error_code(
+        self, agent_key, control_key
+    ):
+        sub_agent_key = SigningKey.generate()
+
+        root = (
+            Warrant.mint_builder()
+            .capability("read_file", path=Subpath("/tmp/demo"))
+            .holder(agent_key.public_key)
+            .ttl(3600)
+            .mint(control_key)
+        )
+        # Depth 1: root -> agent delegates to sub_agent
+        child = (
+            root.grant_builder()
+            .capability("read_file", path=Subpath("/tmp/demo"))
+            .holder(sub_agent_key.public_key)
+            .ttl(1800)
+            .grant(agent_key)
+        )
+        # Depth 2: sub_agent delegates downward
+        grandchild = (
+            child.grant_builder()
+            .capability("read_file", path=Subpath("/tmp/demo"))
+            .holder(SigningKey.generate().public_key)
+            .ttl(900)
+            .grant(sub_agent_key)
+        )
+
+        assert grandchild.depth >= 2, (
+            "Test precondition: real chain construction must produce depth>=2"
+        )
+
+        events: list = []
+        cfg = TenuoPluginConfig(
+            key_resolver=EnvKeyResolver(),
+            on_denial="raise",
+            trusted_roots=[control_key.public_key],
+            audit_callback=events.append,
+            max_chain_depth=1,
+        )
+        ti = TenuoWorkerInterceptor(cfg)
+
+        leaf_headers = tenuo_headers(grandchild, "agent1")
+        act_headers = _make_activity_headers(
+            leaf_headers, grandchild, sub_agent_key,
+            "read_file", {"path": "/tmp/demo/f.txt"},
+        )
+        nxt = MagicMock()
+        nxt.execute_activity = AsyncMock()
+        nxt.init = MagicMock()
+        ai = ti.intercept_activity(nxt)
+        info = FakeActivityInfo(activity_type="read_file", workflow_id="wf-deep")
+        inp = FakeExecuteActivityInput(
+            fn=lambda path: path,
+            args=("/tmp/demo/f.txt",),
+            headers=act_headers,
+        )
+
+        with patch("temporalio.activity.info") as mock_info:
+            mock_info.return_value = info
+            with pytest.raises(ApplicationError) as exc_info:
+                _run(ai.execute_activity(inp))
+
+        _assert_non_retryable(exc_info)
+        # Wire-type must reach downstream consumers as the stable CHAIN_INVALID
+        # code, not a generic ApplicationError.
+        assert exc_info.value.type == "CHAIN_INVALID", (
+            f"Expected non_retryable type=CHAIN_INVALID, got {exc_info.value.type!r}"
+        )
+
+        deny_events = [e for e in events if e.decision == "DENY"]
+        assert deny_events, "Depth violation must emit a DENY audit event"
+        assert any(
+            e.constraint_violated == "max_chain_depth_exceeded" for e in deny_events
+        ), (
+            "Audit event must name the specific constraint so operators can "
+            f"triage depth-bomb attempts; got constraints: "
+            f"{[e.constraint_violated for e in deny_events]}"
+        )
+        nxt.execute_activity.assert_not_called()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tenuo-python/tests/e2e/test_temporal_live.py
+++ b/tenuo-python/tests/e2e/test_temporal_live.py
@@ -32,7 +32,11 @@ from temporalio import activity, workflow  # noqa: E402
 from temporalio.client import Client, WorkflowFailureError  # noqa: E402
 from temporalio.common import RetryPolicy  # noqa: E402
 from temporalio.testing import WorkflowEnvironment  # noqa: E402
-from temporalio.worker import Worker  # noqa: E402
+from temporalio.worker import (  # noqa: E402
+    ActivityInboundInterceptor,
+    Interceptor,
+    Worker,
+)
 from temporalio.worker.workflow_sandbox import (  # noqa: E402
     SandboxedWorkflowRunner,
     SandboxRestrictions,
@@ -498,3 +502,139 @@ class TestLiveDelegationAndContinuation:
         assert result == "echo:hello:1"
         allow_events = [e for e in events if e.decision == "ALLOW"]
         assert len(allow_events) >= 2
+
+
+# ---------------------------------------------------------------------------
+# User interceptor composition
+# ---------------------------------------------------------------------------
+# Users commonly stack their own observability / instrumentation interceptors
+# alongside Tenuo (OTel, Braintrust, Datadog). The ``Worker(interceptors=[...])``
+# contract is that Temporal composes the chain in declaration order, and each
+# interceptor's ``intercept_activity`` hook receives the next link. These tests
+# verify Tenuo plays that contract cleanly regardless of ordering — neither
+# starving the user interceptor nor being starved by it.
+
+
+class _CountingActivityInbound(ActivityInboundInterceptor):
+    """Minimal user interceptor: records every activity dispatch it sees."""
+
+    def __init__(self, nxt: ActivityInboundInterceptor, seen: list[str]) -> None:
+        super().__init__(nxt)
+        self._seen = seen
+
+    async def execute_activity(self, input):  # type: ignore[override]
+        self._seen.append(input.fn.__name__)
+        return await self.next.execute_activity(input)
+
+
+class _CountingWorkerInterceptor(Interceptor):
+    """Wraps ``_CountingActivityInbound`` as a Temporal ``Interceptor``."""
+
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    def intercept_activity(
+        self, next_interceptor: ActivityInboundInterceptor
+    ) -> ActivityInboundInterceptor:
+        return _CountingActivityInbound(next_interceptor, self.seen)
+
+
+async def _run_with_composed_interceptors(
+    env: WorkflowEnvironment,
+    keys,
+    warrant,
+    *,
+    user_first: bool,
+):
+    """Drive the authorized happy path with a user interceptor composed beside Tenuo."""
+    control, agent = keys
+    task_queue = f"compose-{uuid.uuid4().hex[:8]}"
+
+    client_interceptor = TenuoClientInterceptor()
+    workflow_id = f"compose-{uuid.uuid4().hex[:8]}"
+    client_interceptor.set_headers_for_workflow(
+        workflow_id, tenuo_headers(warrant, "agent1"),
+    )
+
+    events: list[TemporalAuditEvent] = []
+    cfg = TenuoPluginConfig(
+        key_resolver=DictKeyResolver({"agent1": agent}),
+        on_denial="raise",
+        trusted_roots=[control.public_key],
+        audit_callback=events.append,
+    )
+    tenuo_interceptor = TenuoWorkerInterceptor(cfg, task_queue=task_queue)
+    counting = _CountingWorkerInterceptor()
+    chain = (
+        [counting, tenuo_interceptor] if user_first else [tenuo_interceptor, counting]
+    )
+
+    raw_client = await Client.connect(
+        env.client.service_client.config.target_host,
+        interceptors=[client_interceptor],  # type: ignore[list-item]
+    )
+
+    sandbox_runner = SandboxedWorkflowRunner(
+        restrictions=SandboxRestrictions.default.with_passthrough_modules(
+            "tenuo", "tenuo_core",
+        )
+    )
+
+    worker = Worker(
+        raw_client,
+        task_queue=task_queue,
+        workflows=[AuthorizedFileWorkflow],
+        activities=[echo],
+        interceptors=chain,  # type: ignore[arg-type]
+        workflow_runner=sandbox_runner,
+    )
+
+    async with worker:
+        result = await raw_client.execute_workflow(
+            AuthorizedFileWorkflow.run,
+            "hello",
+            id=workflow_id,
+            task_queue=task_queue,
+            execution_timeout=timedelta(seconds=120),
+        )
+
+    return result, events, counting.seen
+
+
+@pytest.mark.temporal_live
+class TestLiveUserInterceptorComposition:
+    """Tenuo must coexist with user-supplied ``WorkerInterceptor``s in either order.
+
+    Each test asserts the authorized path succeeds end-to-end AND both
+    interceptors observed the activity — regression guard against ordering
+    assumptions that would silently break OTel/Braintrust-style stacks.
+    """
+
+    @pytest.mark.asyncio
+    async def test_user_interceptor_before_tenuo(self, keys, warrant, demo_dir):
+        async with await WorkflowEnvironment.start_local() as env:
+            result, events, seen = await _run_with_composed_interceptors(
+                env, keys, warrant, user_first=True,
+            )
+        assert result == "echo:hello"
+        assert "echo" in seen, (
+            "User interceptor declared first must see the activity dispatch"
+        )
+        assert any(e.decision == "ALLOW" for e in events), (
+            "Tenuo authorization must still fire when a user interceptor "
+            "is declared before TenuoWorkerInterceptor"
+        )
+
+    @pytest.mark.asyncio
+    async def test_user_interceptor_after_tenuo(self, keys, warrant, demo_dir):
+        async with await WorkflowEnvironment.start_local() as env:
+            result, events, seen = await _run_with_composed_interceptors(
+                env, keys, warrant, user_first=False,
+            )
+        assert result == "echo:hello"
+        assert "echo" in seen, (
+            "User interceptor declared after Tenuo must still see allowed "
+            "activity dispatches (Tenuo must not short-circuit the chain "
+            "on the allow path)"
+        )
+        assert any(e.decision == "ALLOW" for e in events)

--- a/tenuo-python/tests/e2e/test_temporal_replay.py
+++ b/tenuo-python/tests/e2e/test_temporal_replay.py
@@ -1,11 +1,37 @@
-import pytest
+"""Record-and-replay tests for the Tenuo Temporal integration.
+
+These tests exercise the full live worker -> history -> Replayer cycle and
+assert that workflow decisions (success AND failure) reproduce deterministically
+on replay, across realistic configuration drift (trusted-root rotation, clock
+boundary crossings).
+
+Each test records a history against a real in-process Temporal server, then
+replays that history in a separate ``Replayer`` instance. ``replay_failure``
+being ``None`` is the load-bearing assertion: Temporal flags any non-determinism
+(command sequence drift, new activity dispatches, timestamp misuse) as a replay
+failure, so this is the workflow-level determinism guarantee.
+
+Activity bodies are **not** re-executed on replay — their recorded results are
+fed back to the workflow. That means these tests prove workflow-side
+determinism (outbound interceptor PoP computation, command sequencing,
+`workflow.now()` discipline) but do NOT exercise the activity-inbound
+authorization path during replay. Activity-inbound verification happens once,
+at record time; see ``test_temporal_live.py`` for that coverage.
+"""
+
+from __future__ import annotations
+
+import uuid
 from datetime import timedelta
 
+import pytest
+
 try:
-    from temporalio import workflow, activity
-    from temporalio.worker import Replayer, Worker
+    from temporalio import activity, workflow
+    from temporalio.client import Client, WorkflowFailureError
+    from temporalio.common import RetryPolicy
     from temporalio.testing import WorkflowEnvironment
-    from temporalio.client import Client
+    from temporalio.worker import Replayer, Worker
     from temporalio.worker.workflow_sandbox import (
         SandboxedWorkflowRunner,
         SandboxRestrictions,
@@ -13,25 +39,29 @@ try:
 except ImportError:
     pytest.skip("temporalio not installed", allow_module_level=True)
 
+from tenuo import Subpath, Warrant
 from tenuo.temporal import (
     AuthorizedWorkflow,
     KeyResolver,
     TenuoClientInterceptor,
-    TenuoWorkerInterceptor,
     TenuoPluginConfig,
+    TenuoWorkerInterceptor,
     tenuo_headers,
 )
 from tenuo.temporal.exceptions import KeyResolutionError
-from tenuo import Warrant
 from tenuo_core import SigningKey
 
 KEY_ID = "replay-test-key"
-# Temporal activity type defaults to the Python function name.
 TOOL = "write_db_activity"
 
 
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
 class DictKeyResolver(KeyResolver):
-    """Pre-loaded keys (same pattern as test_temporal_live — no os.environ in sandbox)."""
+    """Pre-loaded keys: avoids os.environ access inside the workflow sandbox."""
 
     def __init__(self, keys: dict):
         self.keys = keys
@@ -45,25 +75,7 @@ class DictKeyResolver(KeyResolver):
         return self.keys[key_id]
 
 
-@activity.defn
-async def write_db_activity(data: str) -> str:
-    return f"Wrote: {data}"
-
-
-@workflow.defn
-class ReplayTestWorkflow(AuthorizedWorkflow):
-    @workflow.run
-    async def run(self, data: str) -> str:
-        # On replay, this should NOT execute the activity again — history supplies the result.
-        return await self.execute_authorized_activity(
-            write_db_activity,
-            args=[data],
-            start_to_close_timeout=timedelta(minutes=1),
-        )
-
-
 def _tenuo_sandbox_runner() -> SandboxedWorkflowRunner:
-    """Same sandbox + passthrough as production examples and test_temporal_live."""
     return SandboxedWorkflowRunner(
         restrictions=SandboxRestrictions.default.with_passthrough_modules(
             "tenuo",
@@ -72,18 +84,167 @@ def _tenuo_sandbox_runner() -> SandboxedWorkflowRunner:
     )
 
 
+def _build_config(
+    signing_key: SigningKey,
+    *,
+    trusted_roots: list,
+    activity_fns: list,
+) -> TenuoPluginConfig:
+    return TenuoPluginConfig(
+        key_resolver=DictKeyResolver({KEY_ID: signing_key}),
+        dry_run=False,
+        trusted_roots=trusted_roots,
+        activity_fns=activity_fns,
+    )
+
+
+async def _record_and_fetch_history(
+    *,
+    env: WorkflowEnvironment,
+    config: TenuoPluginConfig,
+    workflow_cls,
+    activities: list,
+    task_queue: str,
+    workflow_id: str,
+    warrant: Warrant,
+    arg,
+    expect_failure: bool = False,
+):
+    """Run a workflow end-to-end and return its recorded history.
+
+    Returns the ``WorkflowHistory`` suitable for replay. If
+    ``expect_failure`` is True, the workflow is expected to raise
+    ``WorkflowFailureError`` during ``execute_workflow``; this is caught so the
+    test can still fetch the recorded (failed) history.
+    """
+    client = env.client
+    client_interceptor = TenuoClientInterceptor()
+    client_with_interceptor = Client(
+        client.service_client,
+        namespace=client.namespace,
+        data_converter=client.data_converter,
+        interceptors=[client_interceptor],
+    )
+
+    async with Worker(
+        client_with_interceptor,
+        task_queue=task_queue,
+        workflows=[workflow_cls],
+        activities=activities,
+        interceptors=[TenuoWorkerInterceptor(config)],
+        workflow_runner=_tenuo_sandbox_runner(),
+    ):
+        client_interceptor.set_headers_for_workflow(
+            workflow_id,
+            tenuo_headers(warrant, KEY_ID),
+        )
+        try:
+            await client_with_interceptor.execute_workflow(
+                workflow_cls.run,
+                arg,
+                id=workflow_id,
+                task_queue=task_queue,
+            )
+        except WorkflowFailureError:
+            if not expect_failure:
+                raise
+
+        handle = client_with_interceptor.get_workflow_handle(workflow_id)
+        return await handle.fetch_history()
+
+
+# ---------------------------------------------------------------------------
+# Activities
+# ---------------------------------------------------------------------------
+
+
+@activity.defn
+async def write_db_activity(data: str) -> str:
+    return f"Wrote: {data}"
+
+
+@activity.defn
+async def list_directory(path: str) -> list[str]:
+    # Stub: tests exercise the authorization path, not filesystem access.
+    return [f"{path}/stub.txt"]
+
+
+# ---------------------------------------------------------------------------
+# Workflows
+# ---------------------------------------------------------------------------
+
+
+@workflow.defn
+class ReplayTestWorkflow(AuthorizedWorkflow):
+    @workflow.run
+    async def run(self, data: str) -> str:
+        return await self.execute_authorized_activity(
+            write_db_activity,
+            args=[data],
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+
+
+@workflow.defn
+class DeniedReplayWorkflow(AuthorizedWorkflow):
+    """Attempts an activity whose arguments violate the warrant's Subpath constraint."""
+
+    @workflow.run
+    async def run(self, path: str) -> list[str]:
+        return await self.execute_authorized_activity(
+            list_directory,
+            args=[path],
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+
+
+@workflow.defn
+class ClockBoundaryWorkflow(AuthorizedWorkflow):
+    """Two activity dispatches separated by a sleep that crosses the PoP window.
+
+    PoP windows are 30-second buckets ``(unix_now // 30) * 30``. A sleep longer
+    than 30s guarantees the two dispatches land in different buckets, so the
+    replayed outbound interceptor has to reproduce distinct bucket timestamps
+    from ``workflow.now()`` — not from wall-clock ``time.time()``.
+    """
+
+    @workflow.run
+    async def run(self, data: str) -> str:
+        r1 = await self.execute_authorized_activity(
+            write_db_activity,
+            args=[f"{data}-1"],
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+        # 35s > 30s PoP bucket width, so the next activity dispatch
+        # falls in a later bucket.
+        await workflow.sleep(timedelta(seconds=35))
+        r2 = await self.execute_authorized_activity(
+            write_db_activity,
+            args=[f"{data}-2"],
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+        return f"{r1}|{r2}"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.temporal_live
 @pytest.mark.asyncio
 async def test_tenuo_plugin_replay_safety():
-    """TenuoWorkerInterceptor + AuthorizedWorkflow stay deterministic under Temporal Replayer."""
+    """Happy-path replay: an authorized workflow replays without replay_failure."""
     signing_key = SigningKey.generate()
-    config = TenuoPluginConfig(
-        key_resolver=DictKeyResolver({KEY_ID: signing_key}),
-        dry_run=False,
+    config = _build_config(
+        signing_key,
         trusted_roots=[signing_key.public_key],
         activity_fns=[write_db_activity],
     )
-
     warrant = (
         Warrant.mint_builder()
         .holder(signing_key.public_key)
@@ -93,38 +254,16 @@ async def test_tenuo_plugin_replay_safety():
     )
 
     async with await WorkflowEnvironment.start_local() as env:
-        client = env.client
-
-        client_interceptor = TenuoClientInterceptor()
-        client_with_interceptor = Client(
-            client.service_client,
-            namespace=client.namespace,
-            data_converter=client.data_converter,
-            interceptors=[client_interceptor],
-        )
-
-        async with Worker(
-            client_with_interceptor,
-            task_queue="replay-task-queue",
-            workflows=[ReplayTestWorkflow],
+        history = await _record_and_fetch_history(
+            env=env,
+            config=config,
+            workflow_cls=ReplayTestWorkflow,
             activities=[write_db_activity],
-            interceptors=[TenuoWorkerInterceptor(config)],
-            workflow_runner=_tenuo_sandbox_runner(),
-        ):
-            client_interceptor.set_headers_for_workflow(
-                "replay-wf-1",
-                tenuo_headers(warrant, KEY_ID),
-            )
-            result = await client_with_interceptor.execute_workflow(
-                ReplayTestWorkflow.run,
-                "test-data-123",
-                id="replay-wf-1",
-                task_queue="replay-task-queue",
-            )
-            assert result == "Wrote: test-data-123"
-
-            wf_handle = client_with_interceptor.get_workflow_handle("replay-wf-1")
-            history = await wf_handle.fetch_history()
+            task_queue=f"replay-happy-{uuid.uuid4().hex[:8]}",
+            workflow_id=f"replay-happy-{uuid.uuid4().hex[:8]}",
+            warrant=warrant,
+            arg="test-data-123",
+        )
 
     replayer = Replayer(
         workflows=[ReplayTestWorkflow],
@@ -138,4 +277,174 @@ async def test_tenuo_plugin_replay_safety():
 
     assert replay_results.replay_failure is None, (
         f"Workflow replay failed: {replay_results.replay_failure}"
+    )
+
+
+@pytest.mark.temporal_live
+@pytest.mark.asyncio
+async def test_tenuo_plugin_replay_denied_workflow():
+    """Denied-workflow replay: a workflow that failed authorization at record
+    time must reach the *same* failure deterministically on replay.
+
+    Regression guard: if denial branches ever read wall-clock state or
+    non-deterministic context, the original execution would complete but
+    replay would crash with a mismatched command sequence.
+    """
+    signing_key = SigningKey.generate()
+    config = _build_config(
+        signing_key,
+        trusted_roots=[signing_key.public_key],
+        activity_fns=[list_directory],
+    )
+    # Warrant permits list_directory only under /allowed; we'll dispatch against /forbidden.
+    warrant = (
+        Warrant.mint_builder()
+        .holder(signing_key.public_key)
+        .capability("list_directory", path=Subpath("/allowed"))
+        .ttl(3600)
+        .mint(signing_key)
+    )
+
+    async with await WorkflowEnvironment.start_local() as env:
+        history = await _record_and_fetch_history(
+            env=env,
+            config=config,
+            workflow_cls=DeniedReplayWorkflow,
+            activities=[list_directory],
+            task_queue=f"replay-denied-{uuid.uuid4().hex[:8]}",
+            workflow_id=f"replay-denied-{uuid.uuid4().hex[:8]}",
+            warrant=warrant,
+            arg="/forbidden",
+            expect_failure=True,
+        )
+
+    replayer = Replayer(
+        workflows=[DeniedReplayWorkflow],
+        interceptors=[TenuoWorkerInterceptor(config)],
+        workflow_runner=_tenuo_sandbox_runner(),
+    )
+    replay_results = await replayer.replay_workflow(
+        history,
+        raise_on_replay_failure=False,
+    )
+
+    assert replay_results.replay_failure is None, (
+        f"Denied workflow did not replay deterministically: "
+        f"{replay_results.replay_failure}"
+    )
+
+
+@pytest.mark.temporal_live
+@pytest.mark.asyncio
+async def test_tenuo_plugin_replay_trusted_root_rotation():
+    """Rotation replay: replay with an extended trusted-root set (overlap
+    with the recording root) must still complete cleanly.
+
+    Simulates the operational scenario where a new trusted root is provisioned
+    between workflow record and replay (e.g. worker redeploys with a rotated
+    provider). The original root remains in the set, so previously-issued
+    warrants remain verifiable; the new root is additive.
+    """
+    original_key = SigningKey.generate()
+    rotated_key = SigningKey.generate()
+
+    record_config = _build_config(
+        original_key,
+        trusted_roots=[original_key.public_key],
+        activity_fns=[write_db_activity],
+    )
+    # Rotated config: both roots are trusted (overlap).
+    replay_config = _build_config(
+        original_key,
+        trusted_roots=[original_key.public_key, rotated_key.public_key],
+        activity_fns=[write_db_activity],
+    )
+
+    warrant = (
+        Warrant.mint_builder()
+        .holder(original_key.public_key)
+        .capability(TOOL)
+        .ttl(3600)
+        .mint(original_key)
+    )
+
+    async with await WorkflowEnvironment.start_local() as env:
+        history = await _record_and_fetch_history(
+            env=env,
+            config=record_config,
+            workflow_cls=ReplayTestWorkflow,
+            activities=[write_db_activity],
+            task_queue=f"replay-rot-{uuid.uuid4().hex[:8]}",
+            workflow_id=f"replay-rot-{uuid.uuid4().hex[:8]}",
+            warrant=warrant,
+            arg="rotation-data",
+        )
+
+    replayer = Replayer(
+        workflows=[ReplayTestWorkflow],
+        interceptors=[TenuoWorkerInterceptor(replay_config)],
+        workflow_runner=_tenuo_sandbox_runner(),
+    )
+    replay_results = await replayer.replay_workflow(
+        history,
+        raise_on_replay_failure=False,
+    )
+
+    assert replay_results.replay_failure is None, (
+        f"Replay under rotated trusted-root set failed: "
+        f"{replay_results.replay_failure}"
+    )
+
+
+@pytest.mark.temporal_live
+@pytest.mark.asyncio
+async def test_tenuo_plugin_replay_clock_boundary_crossing():
+    """Clock-boundary replay: a workflow whose activity dispatches straddle a
+    30-second PoP window boundary must replay deterministically.
+
+    Uses a time-skipping test server so the in-workflow ``workflow.sleep(35s)``
+    advances virtual time without burning real seconds. ``workflow.now()`` is
+    replay-deterministic, so both dispatches land in the same PoP buckets on
+    replay as on record — regression guard against any accidental
+    ``time.time()``/``datetime.now()`` leak into the PoP path.
+    """
+    signing_key = SigningKey.generate()
+    config = _build_config(
+        signing_key,
+        trusted_roots=[signing_key.public_key],
+        activity_fns=[write_db_activity],
+    )
+    warrant = (
+        Warrant.mint_builder()
+        .holder(signing_key.public_key)
+        .capability(TOOL)
+        .ttl(3600)
+        .mint(signing_key)
+    )
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        history = await _record_and_fetch_history(
+            env=env,
+            config=config,
+            workflow_cls=ClockBoundaryWorkflow,
+            activities=[write_db_activity],
+            task_queue=f"replay-clock-{uuid.uuid4().hex[:8]}",
+            workflow_id=f"replay-clock-{uuid.uuid4().hex[:8]}",
+            warrant=warrant,
+            arg="clock-data",
+        )
+
+    replayer = Replayer(
+        workflows=[ClockBoundaryWorkflow],
+        interceptors=[TenuoWorkerInterceptor(config)],
+        workflow_runner=_tenuo_sandbox_runner(),
+    )
+    replay_results = await replayer.replay_workflow(
+        history,
+        raise_on_replay_failure=False,
+    )
+
+    assert replay_results.replay_failure is None, (
+        f"Clock-boundary workflow did not replay deterministically: "
+        f"{replay_results.replay_failure}"
     )


### PR DESCRIPTION
Delete 2 duplicate decorator test classes, add adversarial `max_chain_depth` denial test, user-interceptor composition tests (both orderings), and replay-determinism tests for denial, trusted-root rotation, and PoP clock-boundary.

All checks pass (`scripts/check.sh`): 3027 Python tests, 160 explorer tests, mypy + ruff clean.