### PR TITLE
temporal: non-retryable CHAIN_INVALID for malformed warrant headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Malformed warrant bytes at activity ingress now surface as a
+  non-retryable `CHAIN_INVALID` denial** with a DENY audit event
+  (`constraint_violated="malformed_warrant_header"`). Previously,
+  CBOR-semantic errors from `Warrant.from_bytes` leaked out of
+  `_extract_warrant_from_headers` as an uncaught
+  `DeserializationError`, which could be treated as retryable by
+  Temporal and was invisible to audit sinks.
+
 ### Changed
 
 - **`TenuoPluginConfig.retry_pop_max_windows` default raised from `5` to

--- a/tenuo-python/tenuo/temporal/_headers.py
+++ b/tenuo-python/tenuo/temporal/_headers.py
@@ -16,6 +16,7 @@ from tenuo.temporal._constants import (
     _WARRANT_DECOMPRESS_MAX_BYTES,
     _gzip_decompress_limited,
 )
+from tenuo.exceptions import SerializationError as _TenuoCoreSerializationError
 from tenuo.temporal.exceptions import ChainValidationError, TenuoContextError
 
 logger = logging.getLogger("tenuo.temporal")
@@ -121,7 +122,21 @@ def _extract_warrant_from_headers(headers: Dict[str, bytes]) -> Any:
                 )
         return Warrant.from_bytes(cbor_bytes)
 
-    except (ValueError, EOFError, gzip.BadGzipFile, UnicodeDecodeError, binascii.Error) as e:
+    except (
+        ValueError,
+        EOFError,
+        gzip.BadGzipFile,
+        UnicodeDecodeError,
+        binascii.Error,
+        # ``Warrant.from_bytes`` raises ``DeserializationError`` (a subclass of
+        # ``tenuo.exceptions.SerializationError``) when the bytes are valid
+        # CBOR but semantically wrong for a warrant (e.g. wrong type, missing
+        # fields). Without catching it here, malformed warrants at ingress
+        # leak out of the interceptor as an uncaught exception instead of a
+        # non-retryable ``CHAIN_INVALID`` denial — turning an authorization
+        # failure into a retryable worker error.
+        _TenuoCoreSerializationError,
+    ) as e:
         raise ChainValidationError(
             reason=f"Failed to deserialize warrant: {e}",
             depth=0,

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -825,6 +825,16 @@ class TenuoActivityInboundInterceptor:
         try:
             warrant = _extract_warrant_from_headers(headers)
         except ChainValidationError as chain_exc:
+            # Emit a DENY audit event before raising: operators routing
+            # audit events to OTel/Datadog/Braintrust would otherwise be
+            # blind to malformed-header ingress attempts (the Temporal
+            # ApplicationError reaches the workflow caller, but doesn't
+            # flow through the authorization audit pipeline).
+            self._emit_malformed_warrant_denial_event(
+                info=info,
+                reason=str(chain_exc),
+                start_ns=start_ns,
+            )
             raise self._wrap_as_non_retryable(chain_exc) from chain_exc
 
         # -- 4. Unauthenticated Execution Handling --
@@ -1261,6 +1271,61 @@ class TenuoActivityInboundInterceptor:
             logger.error(
                 "Audit callback failed for ALLOW event (tool=%s): %s",
                 tool, e, exc_info=True,
+            )
+
+    def _emit_malformed_warrant_denial_event(
+        self,
+        info: Any,
+        reason: str,
+        start_ns: Optional[int] = None,
+    ) -> None:
+        """Emit a DENY audit event for an activity that was rejected before
+        warrant extraction succeeded (e.g. non-CBOR bytes, wrong compressed
+        flag, truncated payload). The warrant object is unavailable, so
+        warrant-derived fields carry explicit ``"<malformed>"`` / ``None``
+        placeholders so operators can filter on this denial class in their
+        audit pipeline.
+        """
+        import time
+        latency_s = (time.perf_counter_ns() - start_ns) / 1e9 if start_ns else 0.0
+
+        if self._config.metrics is not None:
+            wf_type = getattr(info, "workflow_type", "")
+            self._config.metrics.record_denied(
+                tool=info.activity_type,
+                reason=reason,
+                workflow_type=wf_type,
+                latency_seconds=latency_s,
+            )
+
+        if not self._config.audit_deny or not self._config.audit_callback:
+            return
+
+        event = TemporalAuditEvent(
+            workflow_id=info.workflow_id,
+            workflow_type=info.workflow_type,
+            workflow_run_id=info.workflow_run_id,
+            activity_name=info.activity_type,
+            activity_id=info.activity_id,
+            task_queue=info.task_queue,
+            decision="DENY",
+            tool=info.activity_type,
+            arguments={},
+            warrant_id="<malformed>",
+            warrant_expires_at=None,
+            warrant_capabilities=[],
+            denial_reason=reason,
+            constraint_violated="malformed_warrant_header",
+            tenuo_version=self._version,
+        )
+
+        try:
+            self._config.audit_callback(event)
+        except Exception as e:
+            logger.error(
+                "Audit callback failed for malformed-warrant DENY event "
+                "(activity=%s, reason=%s): %s",
+                info.activity_type, reason, e, exc_info=True,
             )
 
     def _emit_denial_event(

--- a/tenuo-python/tests/e2e/test_temporal_e2e.py
+++ b/tenuo-python/tests/e2e/test_temporal_e2e.py
@@ -2113,6 +2113,139 @@ class TestMintActivityDispatchErrorRewrap:
         assert "TENUO_TEMPORAL_ACTIVITIES" not in str(excinfo.value)
 
 
+class TestMalformedWarrantHeadersAtIngress:
+    """Defense-in-depth at the activity-inbound boundary: malformed
+    ``x-tenuo-warrant`` bytes must deterministically surface as a
+    non-retryable ``ApplicationError(type="CHAIN_INVALID")`` — never as a
+    transient retryable error, never as allow-on-fail.
+
+    This is *not* a history-tampering test (that is Temporal's concern,
+    not Tenuo's). It models buggy or malicious clients that put garbage
+    in Tenuo headers: truncated CBOR, non-CBOR payloads, compressed flag
+    pointing at non-gzip bytes. A silent regression here would let
+    arbitrary byte streams bypass warrant validation.
+    """
+
+    def _make_interceptor(self, control_key, events=None):
+        cfg = TenuoPluginConfig(
+            key_resolver=EnvKeyResolver(),
+            on_denial="raise",
+            trusted_roots=[control_key.public_key],
+            audit_callback=events.append if events is not None else None,
+        )
+        return TenuoWorkerInterceptor(cfg)
+
+    def _invoke_with_headers(self, ti, raw_headers, events=None):
+        headers = {k: FakePayload(data=v) for k, v in raw_headers.items()}
+        nxt = MagicMock()
+        nxt.execute_activity = AsyncMock()
+        nxt.init = MagicMock()
+        ai = ti.intercept_activity(nxt)
+        info = FakeActivityInfo(
+            activity_type="read_file", workflow_id="wf-malformed"
+        )
+        inp = FakeExecuteActivityInput(
+            fn=lambda path: path,
+            args=("/tmp/demo/f.txt",),
+            headers=headers,
+        )
+        with patch("temporalio.activity.info") as mock_info:
+            mock_info.return_value = info
+            with pytest.raises(ApplicationError) as exc_info:
+                _run(ai.execute_activity(inp))
+        nxt.execute_activity.assert_not_called()
+        return exc_info
+
+    def test_random_bytes_in_warrant_header_uncompressed(
+        self, warrant, agent_key, control_key
+    ):
+        """Non-CBOR bytes with ``compressed=0`` must raise CHAIN_INVALID."""
+        events: list = []
+        ti = self._make_interceptor(control_key, events)
+
+        pop = warrant.sign(
+            agent_key, "read_file", {"path": "/tmp/demo/f.txt"}, int(time.time())
+        )
+        raw_headers = {
+            TENUO_WARRANT_HEADER: b"\x00\x01\x02garbage-not-cbor\xff\xfe",
+            TENUO_COMPRESSED_HEADER: b"0",
+            TENUO_KEY_ID_HEADER: b"agent1",
+            TENUO_POP_HEADER: base64.b64encode(bytes(pop)),
+        }
+
+        exc_info = self._invoke_with_headers(ti, raw_headers, events)
+        _assert_non_retryable(exc_info)
+        assert exc_info.value.type == "CHAIN_INVALID", (
+            f"Malformed warrant must surface as CHAIN_INVALID non-retryable; "
+            f"got type={exc_info.value.type!r}"
+        )
+        deny_events = [e for e in events if e.decision == "DENY"]
+        assert deny_events, (
+            "Malformed-header denial must emit a DENY audit event for triage"
+        )
+        assert any(
+            e.constraint_violated == "malformed_warrant_header" for e in deny_events
+        ), (
+            "Malformed-warrant denials must be labelled so operators can "
+            f"filter them in audit sinks; got: "
+            f"{[e.constraint_violated for e in deny_events]}"
+        )
+        assert any(e.warrant_id == "<malformed>" for e in deny_events), (
+            "Placeholder warrant_id must signal absent warrant context"
+        )
+
+    def test_random_bytes_with_compressed_flag_set(
+        self, warrant, agent_key, control_key
+    ):
+        """Non-gzip bytes with ``compressed=1`` must also raise CHAIN_INVALID —
+        proves the decompression path cannot leak a raw parse fallback."""
+        ti = self._make_interceptor(control_key)
+
+        pop = warrant.sign(
+            agent_key, "read_file", {"path": "/tmp/demo/f.txt"}, int(time.time())
+        )
+        raw_headers = {
+            TENUO_WARRANT_HEADER: b"not-gzip-bytes-at-all",
+            TENUO_COMPRESSED_HEADER: b"1",
+            TENUO_KEY_ID_HEADER: b"agent1",
+            TENUO_POP_HEADER: base64.b64encode(bytes(pop)),
+        }
+
+        exc_info = self._invoke_with_headers(ti, raw_headers)
+        _assert_non_retryable(exc_info)
+        assert exc_info.value.type == "CHAIN_INVALID", (
+            f"Bad compressed payload must surface as CHAIN_INVALID; "
+            f"got type={exc_info.value.type!r}"
+        )
+
+    def test_truncated_warrant_cbor(self, warrant, agent_key, control_key):
+        """Partial CBOR bytes (valid prefix, cut short) must raise CHAIN_INVALID
+        — a regression guard that partial-parse paths cannot admit an
+        under-specified warrant."""
+        ti = self._make_interceptor(control_key)
+
+        valid_bytes = bytes(warrant)
+        assert len(valid_bytes) > 8, (
+            "Test precondition: serialized warrant must be substantial "
+            "enough that a 4-byte prefix is obviously truncated"
+        )
+        truncated = valid_bytes[:4]
+
+        pop = warrant.sign(
+            agent_key, "read_file", {"path": "/tmp/demo/f.txt"}, int(time.time())
+        )
+        raw_headers = {
+            TENUO_WARRANT_HEADER: truncated,
+            TENUO_COMPRESSED_HEADER: b"0",
+            TENUO_KEY_ID_HEADER: b"agent1",
+            TENUO_POP_HEADER: base64.b64encode(bytes(pop)),
+        }
+
+        exc_info = self._invoke_with_headers(ti, raw_headers)
+        _assert_non_retryable(exc_info)
+        assert exc_info.value.type == "CHAIN_INVALID"
+
+
 class TestChainDepthEnforcement:
     """``max_chain_depth`` must reject warrants whose ``depth`` exceeds the
     configured limit, raising ``ChainValidationError`` wrapped non-retryable.


### PR DESCRIPTION
Malformed warrant bytes at activity ingress now surface as non-retryable `CHAIN_INVALID` with a DENY audit event (`constraint_violated="malformed_warrant_header"`), instead of leaking as an uncaught `DeserializationError` invisible to audit sinks.

Found by the new `TestMalformedWarrantHeadersAtIngress` tests.