### PR TITLE
temporal: drop TenuoPlugin deprecated alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,10 +173,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     with `_worker_configs: Dict[task_queue, TenuoPluginConfig]`; the
     mint activity resolves its config through `activity.info().task_queue`.
     Regression coverage in `tests/adapters/test_tenant_isolation.py`.
-- **`tenuo.temporal.TenuoPlugin` renamed to `TenuoWorkerInterceptor`**
-  — the old name collided with `TenuoTemporalPlugin` and
+- **`tenuo.temporal.TenuoPlugin` → `TenuoWorkerInterceptor`, no alias.**
+  The old name collided with `TenuoTemporalPlugin` and
   `Worker(plugins=[TenuoPlugin(...)])` silently accepted an unusable
-  argument.
+  argument. Import `TenuoWorkerInterceptor` directly.
 - **Temporal auth errors now reach the wire with stable codes and
   non-retryable semantics** in both activity and workflow contexts.
   `ApplicationError.type` is the Tenuo `error_code`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,7 +176,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`tenuo.temporal.TenuoPlugin` renamed to `TenuoWorkerInterceptor`**
   — the old name collided with `TenuoTemporalPlugin` and
   `Worker(plugins=[TenuoPlugin(...)])` silently accepted an unusable
-  argument. The old name remains importable as a deprecated alias.
+  argument.
 - **Temporal auth errors now reach the wire with stable codes and
   non-retryable semantics** in both activity and workflow contexts.
   `ApplicationError.type` is the Tenuo `error_code`

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -74,8 +74,6 @@ All documented symbols can be imported from the top-level package (`from tenuo.t
 
 ## `TenuoWorkerInterceptor` (manual setup)
 
-> Renamed from `TenuoPlugin` to `TenuoWorkerInterceptor`. The old name is still importable from `tenuo.temporal` but emits a `DeprecationWarning` — it was a Temporal SDK `WorkerInterceptor`, not a Temporal SDK `Plugin`, and the resemblance to `TenuoTemporalPlugin` (the recommended entry point; see [docs/temporal.md](./temporal.md)) caused real misconfiguration.
-
 For cases where you need manual control over interceptors and the sandbox runner (instead of `TenuoTemporalPlugin`):
 
 ```python

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -80,8 +80,6 @@ export TENUO_KEY_agent1=$(python -c "from tenuo import SigningKey; import base64
 > |---|---|---|
 > | `tenuo.temporal_plugin.TenuoTemporalPlugin` | Temporal SDK **`SimplePlugin`** | **Default.** Pass to `Client.connect(plugins=[...])`. Wires the client interceptor, worker interceptor, and sandboxed workflow runner in one step. |
 > | `tenuo.temporal.TenuoWorkerInterceptor` | Temporal SDK **`WorkerInterceptor`** | Advanced only. Use when you are hand-composing your own `Plugin` / `SimplePlugin` and just want Tenuo's authorization interceptor. |
->
-> `TenuoWorkerInterceptor` was previously named `TenuoPlugin`. That old name is still importable from `tenuo.temporal` but now emits a `DeprecationWarning` because it is a worker interceptor, not a plugin, and the resemblance to `TenuoTemporalPlugin` caused real misconfiguration (`Worker(plugins=[TenuoPlugin(...)])` — which silently does nothing). Update imports to `TenuoWorkerInterceptor`.
 
 ## Start an authorized workflow
 

--- a/tenuo-python/tenuo/temporal/__init__.py
+++ b/tenuo-python/tenuo/temporal/__init__.py
@@ -30,8 +30,7 @@ For direct imports (preferred in library / internal code)::
                                   set_activity_approvals, tenuo_continue_as_new, …
     tenuo.temporal._client        TenuoClientInterceptor, TenuoWarrantContextPropagator,
                                   tenuo_warrant_context
-    tenuo.temporal._interceptors  TenuoWorkerInterceptor (alias ``TenuoPlugin`` is
-                                  deprecated). The interceptor constructs a
+    tenuo.temporal._interceptors  TenuoWorkerInterceptor. Constructs a
                                   tenuo_core ``Authorizer(trusted_roots=...)``
                                   and calls ``authorize_one(...)`` /
                                   ``check_chain(...)`` on every activity
@@ -112,40 +111,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
 }
 
 
-# Deprecated aliases: name -> (new_name, replacement_object_location)
-# Resolved via ``__getattr__`` so that importing the old name emits a
-# DeprecationWarning exactly once per site of use.
-_DEPRECATED_ALIASES: dict[str, tuple[str, str]] = {
-    # ``TenuoPlugin`` was an awkward name because the class is a Temporal SDK
-    # *WorkerInterceptor*, not a Temporal SDK *Plugin*. The similarity to
-    # ``TenuoTemporalPlugin`` (which actually is a ``SimplePlugin``) caused
-    # confusion (e.g. passed to ``Worker(plugins=...)``).
-    "TenuoPlugin": ("TenuoWorkerInterceptor", "tenuo.temporal._interceptors"),
-}
-
-
 def __getattr__(name: str) -> Any:
-    deprecated = _DEPRECATED_ALIASES.get(name)
-    if deprecated is not None:
-        new_name, module_path = deprecated
-        import importlib
-        import warnings
-
-        warnings.warn(
-            (
-                f"`tenuo.temporal.{name}` is deprecated and will be removed "
-                f"in a future beta release; import "
-                f"`tenuo.temporal.{new_name}` instead. "
-                f"(The class is a Temporal SDK worker interceptor, not a "
-                f"Temporal SDK plugin — the new name makes that explicit "
-                f"and disambiguates from `tenuo.temporal_plugin.TenuoTemporalPlugin`.)"
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        mod = importlib.import_module(module_path)
-        return getattr(mod, new_name)
-
     entry = _LAZY_IMPORTS.get(name)
     if entry is not None:
         module_path, attr = entry
@@ -157,7 +123,7 @@ def __getattr__(name: str) -> Any:
 
 def __dir__() -> list[str]:
     eager = list(globals())
-    return sorted(set(eager) | set(_LAZY_IMPORTS) | set(_DEPRECATED_ALIASES))
+    return sorted(set(eager) | set(_LAZY_IMPORTS))
 
 
 __all__ = [
@@ -171,6 +137,4 @@ __all__ = [
     "TenuoContextError",
     # Lazy-loaded (documented public API)
     *_LAZY_IMPORTS,
-    # Deprecated aliases (still importable; emit DeprecationWarning)
-    *_DEPRECATED_ALIASES,
 ]

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -453,14 +453,6 @@ class TenuoWorkerInterceptor(_TemporalWorkerInterceptor):
     Stable identifier: :data:`TENUO_TEMPORAL_PLUGIN_ID` (``tenuo.TenuoTemporalPlugin``)
     for worker logs and Temporal Web activity summaries.
 
-    .. note::
-
-        This class was previously named ``TenuoPlugin``. The old name is still
-        importable from :mod:`tenuo.temporal` as a deprecated alias and will
-        be removed in a future beta. Imports should be updated to
-        ``TenuoWorkerInterceptor`` — the new name correctly reflects that this
-        is a Temporal SDK **interceptor**, not a Temporal SDK **plugin**.
-
     Parameters
     ----------
     config:

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -498,31 +498,3 @@ def test_revocation_list_provider_none_by_default() -> None:
     sk = SigningKey.generate()
     config = TenuoPluginConfig(signing_key=sk, trusted_roots=[sk.public_key])
     assert config.revocation_list_provider is None
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Deprecated alias: ``tenuo.temporal.TenuoPlugin`` → ``TenuoWorkerInterceptor``
-#
-# The old name ``TenuoPlugin`` was confusing because the class is a Temporal
-# SDK WorkerInterceptor, not a Temporal SDK Plugin. It was also too similar
-# to ``tenuo.temporal_plugin.TenuoTemporalPlugin``. The alias stays importable
-# for one beta cycle and emits a ``DeprecationWarning``.
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-def test_deprecated_tenuo_plugin_alias_warns_and_points_to_worker_interceptor() -> None:
-    """``from tenuo.temporal import TenuoPlugin`` must warn and resolve to the new class."""
-    import warnings
-
-    import tenuo.temporal as tt
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        alias = tt.TenuoPlugin
-
-    assert alias is TenuoWorkerInterceptor
-    dep_warns = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-    assert dep_warns, "expected DeprecationWarning for tenuo.temporal.TenuoPlugin"
-    msg = str(dep_warns[-1].message)
-    assert "TenuoPlugin" in msg and "TenuoWorkerInterceptor" in msg
-    assert "deprecated" in msg.lower()


### PR DESCRIPTION
The `TenuoPlugin` → `TenuoWorkerInterceptor` rename landed after `v0.1.0-beta.22`, so the alias and its `DeprecationWarning` plumbing never had an external user base. Removing the shim (`_DEPRECATED_ALIASES` + `__getattr__` branch + docstring/docs callouts + alias test) trims reviewer-surface noise before engaging Temporal.