### PR TITLE
Release 0.1.0-beta.23

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,7 +8,7 @@ assignees: ''
 
 ## Environment
 
-- **Tenuo version**: <!-- e.g. 0.1.0-beta.22 -->
+- **Tenuo version**: <!-- e.g. 0.1.0-beta.23 -->
 - **Python version**: <!-- e.g. 3.11.5 -->
 - **OS**: <!-- e.g. macOS 15.2, Ubuntu 24.04 -->
 - **Install method**: <!-- e.g. pip, uv, from source -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-beta.23] - 2026-04-24
+
 ### Fixed
 
 - **Malformed warrant bytes at activity ingress now surface as a

--- a/README.md
+++ b/README.md
@@ -330,8 +330,8 @@ This runs the [orchestrator -> worker -> authorizer demo](https://tenuo.ai/demo.
 **Official Images** on [Docker Hub](https://hub.docker.com/u/tenuo):
 
 ```bash
-docker pull tenuo/authorizer:0.1.0-beta.22  # Sidecar for warrant verification
-docker pull tenuo/control:0.1.0-beta.22     # Control plane (demo/reference)
+docker pull tenuo/authorizer:0.1.0-beta.23  # Sidecar for warrant verification
+docker pull tenuo/control:0.1.0-beta.23     # Control plane (demo/reference)
 ```
 
 **Helm Chart**:
@@ -377,7 +377,7 @@ What you get in Rust:
 
 ```toml
 [dependencies]
-tenuo = "0.1.0-beta.22"
+tenuo = "0.1.0-beta.23"
 ```
 
 Use the Rust API when you need a language-native enforcement boundary

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "axum",
  "base64",

--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Agent Capability Flow Control - Rust core library"

--- a/tenuo-python/Cargo.lock
+++ b/tenuo-python/Cargo.lock
@@ -2235,7 +2235,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "axum",
  "base64",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-python"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "pyo3",
  "tenuo",

--- a/tenuo-python/Cargo.toml
+++ b/tenuo-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-python"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Capability tokens for AI agents - Python SDK"

--- a/tenuo-python/pyproject.toml
+++ b/tenuo-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tenuo"
-version = "0.1.0b22"
+version = "0.1.0b23"
 description = "Capability tokens for AI agents - Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tenuo-python/tenuo/__init__.py
+++ b/tenuo-python/tenuo/__init__.py
@@ -370,4 +370,4 @@ __all__ = [
     "get_default_nonce_store",
 ]
 
-__version__ = "0.1.0b22"
+__version__ = "0.1.0b23"

--- a/tenuo-wasm/Cargo.lock
+++ b/tenuo-wasm/Cargo.lock
@@ -1452,7 +1452,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "base64",
  "cel-interpreter",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-wasm"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "base64",
  "chrono",

--- a/tenuo-wasm/Cargo.toml
+++ b/tenuo-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-wasm"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "WASM bindings for Tenuo"


### PR DESCRIPTION
## Highlights

**Temporal**
- Multi-tenant isolation: workflow-internal stores keyed by `run_id` (was `workflow_id`), worker-config registry strict-match by `task_queue` (no last-write-wins fallback). Closes a cross-tenant key/header leak in multi-namespace processes.
- Malformed warrant bytes at activity ingress now surface as non-retryable `CHAIN_INVALID` with a DENY audit event (previously leaked as `DeserializationError` and was invisible to audit sinks).
- `retry_pop_max_windows` default raised `5` → `40` so default Temporal retry policies don't flip transient failures into permanent ones.
- New `tenuo.temporal.TENUO_TEMPORAL_ACTIVITIES` for manual `Worker(...)` setups; missing registration produces `TenuoContextError` naming every registration path.
- New invariant test suite: boundary contract (every `error_code` → non-retryable `ApplicationError`), audit invariants (callback failures never re-raise, log with traceback), bounded collections (Hypothesis), and replay determinism (denied workflow, trusted-root rotation, 30s PoP clock-boundary).

**Breaking**
- **MCP PoP signs raw wire arguments** on both sides; constraint extraction is server-only. Removes silent denials when client/server configs drift, but changes signed bytes — clients and servers must upgrade together.
- **Python `bool` canonicalizes as CBOR `Boolean`** (was `Integer(1/0)` because `bool` inherits from `int`). Affects PoP digest for any tool-call args containing `True` / `False`.
- `TenuoPlugin` removed — import `TenuoWorkerInterceptor` directly. The old name collided with `TenuoTemporalPlugin` and was silently accepted by `Worker(plugins=[...])`.
- `ensure_tenuo_workflow_runner` and `attenuated_headers` are now internal (`_`-prefixed). Use `TenuoTemporalPlugin` or `TenuoWorkerInterceptor(..., task_queue=...)` / `register_worker_config(...)`.

Full notes: `CHANGELOG.md` (see the new `[0.1.0-beta.23]` block).

## Release checklist

- [x] Versions bumped in `pyproject.toml`, `tenuo-{python,core,wasm}/Cargo.toml`, all 3 `Cargo.lock` files, `tenuo/__init__.py:__version__`, `README.md` (Docker tags + Cargo example), `.github/ISSUE_TEMPLATE/bug-report.md`
- [x] `CHANGELOG.md` Unreleased stamped as `[0.1.0-beta.23] - 2026-04-24`
- [x] `./scripts/check.sh` clean (version sync, formatting, tests, vectors)
- [ ] Merge → tag `v0.1.0-beta.23` → publish GitHub release (triggers PyPI + crates.io + Docker Hub workflow)