### PR TITLE
Add e2e coverage for None-arg PoP canonicalization and FastMCP middleware ordering

### DIFF
--- a/tenuo-python/tests/adapters/test_mcp_fastmcp_e2e.py
+++ b/tenuo-python/tests/adapters/test_mcp_fastmcp_e2e.py
@@ -77,6 +77,56 @@ async def test_e2e_middleware_accepts_injected_warrant(e2e_server: Path) -> None
 
 
 @pytest.mark.asyncio
+async def test_e2e_none_arg_pop_canonicalization(e2e_server: Path) -> None:
+    """Regression: PoP succeeds when an optional arg is sent as None.
+
+    Reproduces the None-arg verifier rejection bug: client signs
+    strip_none_values(args), server verifies strip_none_values(args).
+    Both sides must produce byte-identical canonicalizations.
+
+    Covers two call shapes:
+    - explicit None value (client sends {"message": "hi", "max_len": null})
+    - absent key (client sends {"message": "hi"})
+    """
+    issuer = SigningKey.generate()
+    pub_hex = issuer.public_key.to_bytes().hex()
+    configure(issuer_key=issuer, dev_mode=True)
+    env = {
+        **os.environ,
+        "TENUO_MCP_E2E_ISSUER_PUB": pub_hex,
+        "PYTHONPATH": _repo_pythonpath(),
+    }
+
+    async with SecureMCPClient(
+        command=sys.executable,
+        args=[str(e2e_server)],
+        env=env,
+        inject_warrant=True,
+    ) as client:
+        async with mint(Capability("echo")):
+            # explicit None: would have crashed the Rust canonicalizer pre-fix
+            raw_explicit = await client.call_tool(
+                "echo",
+                {"message": "hello", "max_len": None},
+                warrant_context=False,
+                inject_warrant=True,
+            )
+            # absent key: FastMCP may expand to None inside the handler; PoP
+            # must still match because middleware sees the pre-handler args
+            raw_absent = await client.call_tool(
+                "echo",
+                {"message": "hello"},
+                warrant_context=False,
+                inject_warrant=True,
+            )
+
+    text_explicit = "".join(getattr(b, "text", str(b)) for b in raw_explicit)
+    text_absent = "".join(getattr(b, "text", str(b)) for b in raw_absent)
+    assert "echo:hello" in text_explicit
+    assert "echo:hello" in text_absent
+
+
+@pytest.mark.asyncio
 async def test_e2e_middleware_denies_without_warrant_structured(e2e_server: Path) -> None:
     """No _meta.tenuo → middleware denies; MCP client surfaces isError + structured tenuo."""
     issuer = SigningKey.generate()

--- a/tenuo-python/tests/fixtures/fastmcp_middleware_e2e_server.py
+++ b/tenuo-python/tests/fixtures/fastmcp_middleware_e2e_server.py
@@ -34,6 +34,12 @@ def main() -> None:
     async def ping() -> str:
         return "pong"
 
+    @mcp.tool()
+    async def echo(message: str, max_len: int | None = None) -> str:
+        """Echo message, optionally truncated. Tests None-arg PoP canonicalization."""
+        result = message if max_len is None else message[:max_len]
+        return f"echo:{result}"
+
     asyncio.run(mcp.run_stdio_async(show_banner=False, log_level="CRITICAL"))
 
 


### PR DESCRIPTION
## Summary

- Adds `echo` tool with optional `max_len: int | None = None` to the FastMCP e2e fixture server
- Adds `test_e2e_none_arg_pop_canonicalization` covering two call shapes through FastMCP's real dispatch:
  - Explicit null value (`{"message": "hello", "max_len": null}`)
  - Absent key (`{"message": "hello"}`)

## What this tests

**None-arg PoP canonicalization.** Both the client and `MCPVerifier.verify` call `strip_none_values` before signing/verifying. These tests confirm that holds end-to-end through FastMCP's actual dispatch pipeline, not just in unit tests with raw dicts.

**FastMCP middleware ordering.** The absent-key case confirms `TenuoMiddleware.on_call_tool` sees pre-handler arguments — FastMCP expands `None` for optional params inside the typed handler after `call_next`, not before calling middleware.