### PR TITLE
docs: Temporal improvements, In the Wild page, and homepage section

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -403,6 +403,7 @@
           <a href="{{ site.baseurl }}/quickstart">Quick Start</a> ·
           <a href="{{ site.baseurl }}/api-reference">API</a> ·
           <a href="{{ site.baseurl }}/security">Security</a> ·
+          <a href="{{ site.baseurl }}/in-the-wild">In the Wild</a> ·
           <a href="https://github.com/tenuo-ai/tenuo">GitHub</a>
         </p>
       </footer>

--- a/docs/in-the-wild.md
+++ b/docs/in-the-wild.md
@@ -1,0 +1,163 @@
+---
+title: Tenuo in the Wild
+description: External writing, talks, and coverage about Tenuo
+---
+
+<style>
+.wild-intro {
+  font-size: 1rem;
+  color: var(--text-muted);
+  margin: 0.25rem 0 2.5rem;
+  line-height: 1.6;
+}
+
+.wild-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  margin-top: 0.5rem;
+}
+
+.wild-card {
+  background: var(--surface);
+  padding: 1.5rem 1.75rem;
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  gap: 0.5rem;
+  transition: background 0.15s;
+}
+
+.wild-card:last-child {
+  border-bottom: none;
+}
+
+.wild-card:hover {
+  background: var(--surface-2);
+}
+
+.wild-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 8px;
+  border-radius: 3px;
+  width: fit-content;
+}
+
+.wild-badge--case-study {
+  background: rgba(0, 212, 255, 0.1);
+  color: var(--accent);
+  border: 1px solid rgba(0, 212, 255, 0.25);
+}
+
+.wild-badge--mention {
+  background: rgba(136, 136, 136, 0.1);
+  color: var(--text-muted);
+  border: 1px solid rgba(136, 136, 136, 0.25);
+}
+
+.wild-badge--standards {
+  background: rgba(59, 130, 246, 0.1);
+  color: #3b82f6;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+}
+
+.wild-badge--talk {
+  background: rgba(168, 85, 247, 0.1);
+  color: #a855f7;
+  border: 1px solid rgba(168, 85, 247, 0.25);
+}
+
+.wild-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.wild-title a {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.wild-title a:hover {
+  color: var(--accent);
+}
+
+.wild-attribution {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.wild-description {
+  font-size: 0.9rem;
+  color: var(--text);
+  opacity: 0.8;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.wild-link {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--accent);
+  text-decoration: none;
+  width: fit-content;
+}
+
+.wild-link:hover {
+  color: var(--accent-dim);
+  text-decoration: underline;
+}
+</style>
+
+# Tenuo in the Wild
+
+<p class="wild-intro">External mentions, write-ups, and recognition.</p>
+
+<div class="wild-list">
+
+  <div class="wild-card">
+    <span class="wild-badge wild-badge--case-study">Case study</span>
+    <div class="wild-title"><a href="https://brooksmcmillin.com/blog/wiring-capability-warrants-autonomous-agents/">Wiring capability warrants into autonomous agents</a></div>
+    <div class="wild-attribution">Brooks McMillin · Staff Engineer, Dropbox</div>
+    <p class="wild-description">Full production walkthrough: scope-gated rollout across 16 agents on Kubernetes, multi-hop delegation at depth 2 and 3, two integration bugs and their fixes, and a live prompt injection the warrant catches.</p>
+    <a class="wild-link" href="https://brooksmcmillin.com/blog/wiring-capability-warrants-autonomous-agents/">Read the post →</a>
+  </div>
+
+  <div class="wild-card">
+    <span class="wild-badge wild-badge--mention">Mention</span>
+    <div class="wild-title"><a href="#">OAuth multi-hop delegation for AI agents</a></div>
+    <div class="wild-attribution">WorkOS Engineering</div>
+    <p class="wild-description">Survey of emerging standards for multi-hop agent delegation. The AAT Internet-Draft is cited as a standards-track approach to offline-verifiable attenuation chains.</p>
+    <a class="wild-link" href="#">Read the post →</a>
+  </div>
+
+  <div class="wild-card">
+    <span class="wild-badge wild-badge--mention">Mention</span>
+    <div class="wild-title"><a href="#">AAC Construction Specification: Non-Human Identity Series</a></div>
+    <div class="wild-attribution">Mohamad Amin Hasbini · Independent researcher, Paris</div>
+    <p class="wild-description">Technical paper on privacy-preserving authorization for AI agents. The AAT Internet-Draft is surveyed as the primary prior art on delegation-chain attenuation, with an accurate technical comparison of the disclosure models.</p>
+    <a class="wild-link" href="#">Read the paper →</a>
+  </div>
+
+  <div class="wild-card">
+    <span class="wild-badge wild-badge--standards">Standards</span>
+    <div class="wild-title"><a href="https://datatracker.ietf.org/doc/draft-niyikiza-oauth-attenuating-agent-tokens/">draft-niyikiza-oauth-attenuating-agent-tokens-00</a></div>
+    <div class="wild-attribution">IETF OAuth Working Group</div>
+    <p class="wild-description">Individual Internet-Draft published in the IETF OAuth Working Group defining Attenuating Authorization Tokens for agentic delegation chains. Tenuo is the canonical reference implementation.</p>
+    <a class="wild-link" href="https://datatracker.ietf.org/doc/draft-niyikiza-oauth-attenuating-agent-tokens/">View on IETF Datatracker →</a>
+  </div>
+
+  <div class="wild-card">
+    <span class="wild-badge wild-badge--talk">Talk</span>
+    <div class="wild-title"><a href="https://greptalks.ai/c/unprompted-2026/D2-S2-03/">Capability-Based Authorization for AI Agents: Warrants That Survive Prompt Injection</a></div>
+    <div class="wild-attribution">GrepTalks · Unprompted 2026 editor's picks</div>
+    <p class="wild-description">Talk by Niki Aimable Niyikiza. Ranked #3 of 12 must-see talks at Unprompted 2026. Includes a live demo where a prompt injection is stopped at the execution layer without touching the model.</p>
+    <a class="wild-link" href="https://greptalks.ai/c/unprompted-2026/D2-S2-03/">View on GrepTalks →</a>
+  </div>
+
+</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -656,6 +656,84 @@
             text-decoration: underline;
         }
 
+        /* In the Wild */
+        .wild-cards {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 16px;
+            max-width: 900px;
+            margin: 0 auto;
+        }
+
+        .wild-card {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            background: var(--surface);
+            border: 1px solid rgba(56,189,248,0.1);
+            border-radius: 8px;
+            padding: 20px 22px;
+            text-decoration: none;
+            transition: border-color 0.2s, background 0.2s;
+        }
+
+        .wild-card:hover {
+            border-color: rgba(56,189,248,0.25);
+            background: var(--surface-2);
+        }
+
+        .wild-card-type {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.68rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--accent);
+            opacity: 0.7;
+        }
+
+        .wild-card-title {
+            font-size: 0.95rem;
+            font-weight: 600;
+            color: var(--text-bright);
+            line-height: 1.4;
+        }
+
+        .wild-card-source {
+            font-size: 0.8rem;
+            color: var(--muted-dim);
+        }
+
+        .wild-card-desc {
+            font-size: 0.82rem;
+            color: var(--muted);
+            line-height: 1.6;
+            flex: 1;
+        }
+
+        .wild-more {
+            text-align: center;
+            margin-top: 24px;
+        }
+
+        .wild-more a {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.8rem;
+            letter-spacing: 0.04em;
+            color: var(--muted);
+            text-decoration: none;
+            transition: color 0.2s;
+        }
+
+        .wild-more a:hover {
+            color: var(--accent);
+        }
+
+        @media (max-width: 768px) {
+            .wild-cards {
+                grid-template-columns: 1fr;
+            }
+        }
+
         /* Footer */
         footer {
             padding: 48px 0;
@@ -986,6 +1064,30 @@
             </div>
         </section>
 
+
+        <section class="section">
+            <div class="section-header">
+                <h2>Tenuo in the Wild</h2>
+                <p>External mentions, write-ups, and recognition.</p>
+            </div>
+            <div class="wild-cards">
+                <a class="wild-card" href="https://brooksmcmillin.com/blog/wiring-capability-warrants-autonomous-agents/">
+                    <div class="wild-card-type">Case study</div>
+                    <div class="wild-card-title">Wiring capability warrants into autonomous agents</div>
+                    <div class="wild-card-source">Brooks McMillin · Staff Engineer, Dropbox</div>
+                    <p class="wild-card-desc">Full production walkthrough: scope-gated rollout across 16 agents on Kubernetes, multi-hop delegation at depth 2 and 3, two integration bugs and their fixes, and a live prompt injection the warrant catches.</p>
+                </a>
+                <a class="wild-card" href="https://datatracker.ietf.org/doc/draft-niyikiza-oauth-attenuating-agent-tokens/">
+                    <div class="wild-card-type">Standards</div>
+                    <div class="wild-card-title">draft-niyikiza-oauth-attenuating-agent-tokens-00</div>
+                    <div class="wild-card-source">IETF OAuth Working Group</div>
+                    <p class="wild-card-desc">Individual Internet-Draft published in the IETF OAuth Working Group defining Attenuating Authorization Tokens for agentic delegation chains. Tenuo is the canonical reference implementation.</p>
+                </a>
+            </div>
+            <div class="wild-more">
+                <a href="in-the-wild">See all mentions →</a>
+            </div>
+        </section>
 
         <section class="production">
             <p>Rust core. Open source. Ready for your pipeline.<br>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tenuo — Warrant-based authorization for AI agents</title>
+    <title>Tenuo | Warrant-based authorization for AI agents</title>
 
     <!-- SEO -->
     <meta name="description"
@@ -16,7 +16,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://tenuo.ai/">
-    <meta property="og:title" content="Tenuo — Warrant-based authorization for AI agents">
+    <meta property="og:title" content="Tenuo | Warrant-based authorization for AI agents">
     <meta property="og:description"
         content="Task-scoped warrants that narrow as agents delegate. Every hop signed, every chain verifiable offline.">
     <meta property="og:image" content="https://tenuo.ai/images/og-preview.png">
@@ -24,7 +24,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://tenuo.ai/">
-    <meta name="twitter:title" content="Tenuo — Warrant-based authorization for AI agents">
+    <meta name="twitter:title" content="Tenuo | Warrant-based authorization for AI agents">
     <meta name="twitter:description"
         content="Task-scoped warrants that narrow as agents delegate. Every hop signed, every chain verifiable offline.">
     <meta name="twitter:image" content="https://tenuo.ai/images/og-preview.png">

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -7,15 +7,15 @@ description: Warrant-based authorization for Temporal AI agent workflows
 
 ## What is Temporal?
 
-[Temporal](https://temporal.io/) is a platform for **durable execution**: you implement **Workflows** (orchestration code whose progress is replayed from event history—surviving process restarts, retries, and long waits) and **Activities** (non-deterministic work such as tool calls, HTTP requests, or model inference). The service assigns tasks from **task queues** to **Workers**, persists workflow state, and gives you a standard way to build reliable, observable automation—including multi-step AI agents—without hand-rolling sagas or bespoke recovery logic.
+[Temporal](https://temporal.io/) is a platform for **durable execution**: you write **Workflows**, deterministic orchestration code whose progress is replayed from event history and survives process restarts, retries, and long waits, and **Activities**, the non-deterministic work such as tool calls, HTTP requests, or model inference. The service assigns tasks from **task queues** to **Workers**, persists workflow state, and gives you reliable, observable automation for multi-step AI agents without hand-rolling sagas or bespoke recovery logic.
 
 For a guided introduction, see [Understanding Temporal](https://learn.temporal.io/getting_started/).
 
 ## How Tenuo fits
 
-Tenuo provides cryptographic authorization for AI agent workflows on Temporal. Each Activity execution is verified against a signed **warrant** that specifies which tools the agent may call, with what arguments, and under whose delegation. Authorization is enforced transparently by the worker interceptor — activity definitions require no changes.
+Access control in Temporal typically relies on worker identity or task queue tokens, which grant the same permissions to every workflow running on that worker. As agents take on more consequential actions, you need finer control: which tools each agent may use for a given task, with what arguments, and on whose authority.
 
-If you're building agentic systems on Temporal, Tenuo lets you ship agents that are constrained by design: an agent can only do what its warrant allows, and every action is cryptographically attributable to the entity that authorized it. Verification and Proof-of-Possession signing run in-process with no external service dependency at runtime.
+Tenuo adds that task-scoped authorization layer. A signed warrant travels with each workflow and is verified by the worker interceptor before every Activity runs. Agents are **constrained by design**: an agent can only execute what its warrant permits, and every action is cryptographically attributable to the entity that authorized it. Activity definitions require no changes, and verification runs in-process with no external service dependency.
 
 ## Prerequisites
 
@@ -89,6 +89,42 @@ export TENUO_KEY_agent1=$(python -c "from tenuo import SigningKey; import base64
 > | `tenuo.temporal_plugin.TenuoTemporalPlugin` | Temporal SDK **`SimplePlugin`** | **Default.** Pass to `Client.connect(plugins=[...])`. Wires the client interceptor, worker interceptor, and sandboxed workflow runner in one step. |
 > | `tenuo.temporal.TenuoWorkerInterceptor` | Temporal SDK **`WorkerInterceptor`** | Advanced only. Use when you are hand-composing your own `Plugin` / `SimplePlugin` and just want Tenuo's authorization interceptor. |
 
+## Define activities and workflows
+
+Activity definitions stay unchanged — no Tenuo imports needed:
+
+```python
+from pathlib import Path
+from temporalio import activity, workflow
+from datetime import timedelta
+
+@activity.defn
+async def read_file(path: str) -> str:
+    return Path(path).read_text()
+
+@activity.defn
+async def write_file(path: str, content: str) -> str:
+    Path(path).write_text(content)
+    return f"Wrote {len(content)} bytes"
+```
+
+Use `AuthorizedWorkflow` to fail fast if warrant headers are missing, or use plain `workflow.execute_activity()` — the interceptor handles authorization either way:
+
+```python
+from tenuo.temporal import AuthorizedWorkflow
+
+@workflow.defn
+class MyWorkflow(AuthorizedWorkflow):
+    @workflow.run
+    async def run(self, input_path: str) -> str:
+        data = await self.execute_authorized_activity(
+            read_file,
+            args=[input_path],
+            start_to_close_timeout=timedelta(seconds=30),
+        )
+        return data.upper()
+```
+
 ## Start an authorized workflow
 
 Pass a warrant and key ID when starting a workflow. The warrant defines what the agent is allowed to do — your control plane or policy layer mints it.
@@ -125,42 +161,6 @@ handle = await start_workflow_authorized(
 # Signal, query, or await later
 await handle.signal(ApprovalWorkflow.approve, decision)
 result = await handle.result()
-```
-
-## Define activities and workflows
-
-Activity definitions stay unchanged — no Tenuo imports needed:
-
-```python
-from pathlib import Path
-from temporalio import activity, workflow
-from datetime import timedelta
-
-@activity.defn
-async def read_file(path: str) -> str:
-    return Path(path).read_text()
-
-@activity.defn
-async def write_file(path: str, content: str) -> str:
-    Path(path).write_text(content)
-    return f"Wrote {len(content)} bytes"
-```
-
-Use `AuthorizedWorkflow` to fail fast if warrant headers are missing, or use plain `workflow.execute_activity()` — the interceptor handles authorization either way:
-
-```python
-from tenuo.temporal import AuthorizedWorkflow
-
-@workflow.defn
-class MyWorkflow(AuthorizedWorkflow):
-    @workflow.run
-    async def run(self, input_path: str) -> str:
-        data = await self.execute_authorized_activity(
-            read_file,
-            args=[input_path],
-            start_to_close_timeout=timedelta(seconds=30),
-        )
-        return data.upper()
 ```
 
 ## Capability constraints


### PR DESCRIPTION
## Summary

- Adds **Tenuo in the Wild** page (`/in-the-wild`) — a curated list of external case studies, mentions, standards references, and talks, with badge-styled cards
- Adds **In the Wild section on the homepage** featuring two highlights (Brooks McMillin/Dropbox case study + IETF draft) with a link to the full page
- Improves `temporal.md` intro and section ordering
- Adds e2e test coverage for `None`-arg PoP canonicalization and FastMCP middleware ordering

## Test plan

- [ ] Preview `/in-the-wild` renders cards correctly with badge colors and hover states
- [ ] Homepage "Tenuo in the Wild" section shows two cards and "See all mentions →" link
- [ ] All existing CI checks pass