### PR TITLE
Fix approval gate monotonicity for subagents without gated tools

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,7 +8,7 @@ assignees: ''
 
 ## Environment
 
-- **Tenuo version**: <!-- e.g. 0.1.0-beta.23 -->
+- **Tenuo version**: <!-- e.g. 0.1.0-beta.24 -->
 - **Python version**: <!-- e.g. 3.11.5 -->
 - **OS**: <!-- e.g. macOS 15.2, Ubuntu 24.04 -->
 - **Install method**: <!-- e.g. pip, uv, from source -->

--- a/.github/workflows/docker-authorizer.yml
+++ b/.github/workflows/docker-authorizer.yml
@@ -13,6 +13,9 @@ on:
     branches: [main]
     paths:
       - 'tenuo-core/src/bin/authorizer.rs'
+      - 'tenuo-core/src/approval_gate.rs'
+      - 'tenuo-core/src/planes.rs'
+      - 'tenuo-core/src/warrant.rs'
       - 'tenuo-core/src/heartbeat.rs'
       - 'tenuo-core/deploy/docker/Dockerfile.authorizer'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Approval gate monotonicity when attenuating to subagents without gated tools.**
+  A child warrant that drops a parent's gated capability (e.g. session has
+  `web_fetch` + approval gate, researcher subagent has only `read_file`) may now
+  drop the gate extension too. Previously this was rejected as
+  `GatesStripped` even though the bypass was impossible.
+
 ## [0.1.0-beta.23] - 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-beta.24] - 2026-06-11
+
 ### Fixed
 
 - **Approval gate monotonicity when attenuating to subagents without gated tools.**

--- a/README.md
+++ b/README.md
@@ -330,8 +330,8 @@ This runs the [orchestrator -> worker -> authorizer demo](https://tenuo.ai/demo.
 **Official Images** on [Docker Hub](https://hub.docker.com/u/tenuo):
 
 ```bash
-docker pull tenuo/authorizer:0.1.0-beta.23  # Sidecar for warrant verification
-docker pull tenuo/control:0.1.0-beta.23     # Control plane (demo/reference)
+docker pull tenuo/authorizer:0.1.0-beta.24  # Sidecar for warrant verification
+docker pull tenuo/control:0.1.0-beta.24     # Control plane (demo/reference)
 ```
 
 **Helm Chart**:
@@ -377,7 +377,7 @@ What you get in Rust:
 
 ```toml
 [dependencies]
-tenuo = "0.1.0-beta.23"
+tenuo = "0.1.0-beta.24"
 ```
 
 Use the Rust API when you need a language-native enforcement boundary

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -2476,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "axum",
  "base64",

--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Agent Capability Flow Control - Rust core library"

--- a/tenuo-core/src/approval_gate.rs
+++ b/tenuo-core/src/approval_gate.rs
@@ -487,7 +487,7 @@ fn take_stricter_approval_gate(a: &ToolApprovalGate, b: &ToolApprovalGate) -> To
 /// Errors specific to approval gate monotonicity violations.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ApprovalGateError {
-    /// Parent had approval gates but child stripped them entirely.
+    /// Parent had approval gates but child stripped them while still holding a gated tool.
     GatesStripped,
     /// A specific tool's gate was removed in the child.
     ToolApprovalGateRemoved(String),
@@ -558,7 +558,17 @@ pub(crate) fn verify_approval_gate_monotonicity(
     };
 
     let child_gates = match child_gates {
-        None => return Err(ApprovalGateError::GatesStripped),
+        None => {
+            // Dropping the extension is safe when the child no longer holds any of
+            // the parent's gated tools (capability + gate removed together).
+            if parent_gates
+                .iter()
+                .any(|(tool, _)| child_tools.contains_key(tool))
+            {
+                return Err(ApprovalGateError::GatesStripped);
+            }
+            return Ok(());
+        }
         Some(g) => g,
     };
 
@@ -924,6 +934,21 @@ mod tests {
         assert_eq!(
             verify_approval_gate_monotonicity(Some(&parent), None, &child_tools),
             Err(ApprovalGateError::GatesStripped)
+        );
+    }
+
+    #[test]
+    fn test_monotonicity_gates_dropped_when_gated_tools_removed_ok() {
+        let mut parent = ApprovalGateMap::new();
+        parent.insert("web_fetch".into(), ToolApprovalGate::whole_tool());
+
+        let mut child_tools = BTreeMap::new();
+        child_tools.insert("read_file".into(), crate::constraints::ConstraintSet::new());
+        child_tools.insert("grep".into(), crate::constraints::ConstraintSet::new());
+
+        assert!(
+            verify_approval_gate_monotonicity(Some(&parent), None, &child_tools).is_ok(),
+            "subagent without web_fetch may drop the parent's web_fetch gate"
         );
     }
 

--- a/tenuo-core/src/bin/authorizer.rs
+++ b/tenuo-core/src/bin/authorizer.rs
@@ -75,7 +75,7 @@ use tenuo::{
 /// Authorizer-specific build number for independent release cycles.
 /// Increment this when shipping authorizer-only changes without bumping tenuo crate version.
 /// Full version string: `{CARGO_PKG_VERSION}+authz.{AUTHORIZER_BUILD}`
-pub const AUTHORIZER_BUILD: u32 = 1;
+pub const AUTHORIZER_BUILD: u32 = 2;
 
 /// Get the full authorizer version string with build metadata.
 pub fn authorizer_version() -> String {

--- a/tenuo-core/src/bin/authorizer.rs
+++ b/tenuo-core/src/bin/authorizer.rs
@@ -75,7 +75,7 @@ use tenuo::{
 /// Authorizer-specific build number for independent release cycles.
 /// Increment this when shipping authorizer-only changes without bumping tenuo crate version.
 /// Full version string: `{CARGO_PKG_VERSION}+authz.{AUTHORIZER_BUILD}`
-pub const AUTHORIZER_BUILD: u32 = 2;
+pub const AUTHORIZER_BUILD: u32 = 1;
 
 /// Get the full authorizer version string with build metadata.
 pub fn authorizer_version() -> String {

--- a/tenuo-core/tests/approval_gate_merge.rs
+++ b/tenuo-core/tests/approval_gate_merge.rs
@@ -1,9 +1,7 @@
 //! Integration tests for approval gate merge semantics.
 //!
-//! Approval gates are strictly monotonic: children can only add gates, never remove them.
-//! When a child sets approval gates during attenuation or issuance, the result is the union
-//! of inherited parent gates and the explicitly added gates, scoped to the child's
-//! tool set.
+//! Approval gates are monotonic for tools the child retains: inherited gates must
+//! not be weakened. When a child drops a gated tool entirely, the gate may drop too.
 
 use std::collections::{BTreeMap, HashMap};
 use std::time::Duration;
@@ -871,4 +869,51 @@ fn test_exempt_gate_inherited_by_second_attenuation() {
         ),
         "Exempt gate must survive second attenuation hop"
     );
+}
+
+#[test]
+fn test_subagent_attenuation_drops_gated_tool_and_gate() {
+    // Session has web_fetch + approval gate; researcher subagent keeps read/search only.
+    use tenuo::planes::Authorizer;
+    use tenuo::APPROVAL_GATE_EXTENSION_KEY;
+
+    let root_kp = SigningKey::generate();
+    let holder_kp = SigningKey::generate();
+
+    let mut parent_gates = ApprovalGateMap::new();
+    parent_gates.insert("web_fetch".into(), ToolApprovalGate::whole_tool());
+    let gate_bytes = encode_approval_gate_map(&parent_gates).unwrap();
+
+    let parent = Warrant::builder()
+        .capability("read_file", ConstraintSet::new())
+        .capability("grep", ConstraintSet::new())
+        .capability("glob", ConstraintSet::new())
+        .capability("web_fetch", ConstraintSet::new())
+        .ttl(Duration::from_secs(3600))
+        .holder(holder_kp.public_key())
+        .extension(APPROVAL_GATE_EXTENSION_KEY, gate_bytes)
+        .build(&root_kp)
+        .unwrap();
+
+    let mut attn = OwnedAttenuationBuilder::new(parent.clone());
+    attn.inherit_all();
+    attn.retain_capabilities(&[
+        "read_file".to_string(),
+        "grep".to_string(),
+        "glob".to_string(),
+    ]);
+    attn.set_holder(holder_kp.public_key());
+    let child = attn.build(&holder_kp).expect("researcher subwarrant should build");
+
+    assert!(
+        parse_approval_gate_map(child.extension(APPROVAL_GATE_EXTENSION_KEY))
+            .unwrap()
+            .is_none(),
+        "child without web_fetch should carry no approval gate extension"
+    );
+
+    let authorizer = Authorizer::new().with_trusted_root(root_kp.public_key());
+    authorizer
+        .verify_chain(&[parent, child])
+        .expect("parent->researcher chain should verify");
 }

--- a/tenuo-python/Cargo.lock
+++ b/tenuo-python/Cargo.lock
@@ -2241,7 +2241,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "axum",
  "base64",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-python"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "pyo3",
  "tenuo",

--- a/tenuo-python/Cargo.toml
+++ b/tenuo-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-python"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Capability tokens for AI agents - Python SDK"

--- a/tenuo-python/pyproject.toml
+++ b/tenuo-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tenuo"
-version = "0.1.0b23"
+version = "0.1.0b24"
 description = "Capability tokens for AI agents - Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tenuo-python/tenuo/__init__.py
+++ b/tenuo-python/tenuo/__init__.py
@@ -370,4 +370,4 @@ __all__ = [
     "get_default_nonce_store",
 ]
 
-__version__ = "0.1.0b23"
+__version__ = "0.1.0b24"

--- a/tenuo-wasm/Cargo.lock
+++ b/tenuo-wasm/Cargo.lock
@@ -916,9 +916,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchit"
-version = "0.8.6"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
+checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
 
 [[package]]
 name = "memchr"
@@ -1452,7 +1452,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tenuo"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "base64",
  "cel-interpreter",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-wasm"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "base64",
  "chrono",

--- a/tenuo-wasm/Cargo.toml
+++ b/tenuo-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-wasm"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "WASM bindings for Tenuo"


### PR DESCRIPTION
## Summary

- Allow child warrants to drop approval gate extensions when they no longer hold any of the parent's gated tools (e.g. session has `web_fetch` + approval gate, `researcher` subagent has only `read_file`/`grep`/`glob`).
- Add unit and integration tests covering the subagent attenuation + chain verification path.
- Bump `AUTHORIZER_BUILD` to 2 and publish `tenuo/authorizer:0.1.0-beta.23-authz.2` (claude-governance demo already pins this tag).

## Context

The old I5 check treated any child with no `tenuo.approval_gates` extension as `GatesStripped`, even when the child had dropped the gated capability entirely. That blocked combining WebFetch human approval with read-only subagents.

## Test plan

- [x] `cargo test approval_gate --lib`
- [x] `cargo test --test approval_gate_merge`
- [ ] CI green on this PR
- [ ] After merge: confirm `docker pull tenuo/authorizer:0.1.0-beta.23-authz.2` works
- [ ] Demo: `pip install -e tenuo-python` + `tenuo-claude up` with approval + subagents in yaml