### PR TITLE
Publish prebuilt tenuo-authorizer release binaries

### DIFF
--- a/.github/workflows/authorizer-binaries.yml
+++ b/.github/workflows/authorizer-binaries.yml
@@ -1,0 +1,186 @@
+name: Authorizer Binaries
+
+# Prebuilt ``tenuo-authorizer`` archives for ``tenuo-claude install-authorizer``.
+# Asset names: ``tenuo-authorizer-{tag}-{triple}.tar.gz`` (``.zip`` on Windows).
+#
+# Triggers:
+#   - release published → build at the release tag, upload binaries + SHA256SUMS
+#   - workflow_dispatch → smoke build; optional backfill via upload_release_tag
+#     (checks out that tag so binaries match the release commit)
+#   - push to main → smoke build (artifacts only)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      upload_release_tag:
+        description: "Upload to an existing release tag (e.g. v0.1.0-beta.24). Checks out that tag. Leave empty for artifacts only."
+        required: false
+        type: string
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.triple }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x64: pin 22.04 for an older glibc baseline (broader distro compatibility)
+          - runner: ubuntu-22.04
+            triple: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            triple: aarch64-unknown-linux-gnu
+          # Apple Silicon Mac (M1/M2/M3/M4 MacBook, Mac mini, iMac)
+          - runner: macos-latest
+            triple: aarch64-apple-darwin
+          # Intel Mac (last GitHub-hosted x86_64 macOS runner; EOL ~Aug 2027)
+          - runner: macos-15-intel
+            triple: x86_64-apple-darwin
+          - runner: windows-latest
+            triple: x86_64-pc-windows-msvc
+    steps:
+      - name: Resolve checkout ref
+        id: checkout
+        shell: bash
+        run: |
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            REF="${{ github.event.release.tag_name }}"
+          elif [ -n "${{ inputs.upload_release_tag }}" ]; then
+            REF="${{ inputs.upload_release_tag }}"
+          else
+            REF="${{ github.sha }}"
+          fi
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "Checkout ref: ${REF}"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.checkout.outputs.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache Rust
+        uses: swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        with:
+          workspaces: tenuo-core
+
+      - name: Install mold linker (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold clang
+
+      - name: Configure mold linker (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p ~/.cargo
+          cat >> ~/.cargo/config.toml << 'EOF'
+          [target.x86_64-unknown-linux-gnu]
+          linker = "clang"
+          rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+          [target.aarch64-unknown-linux-gnu]
+          linker = "clang"
+          rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+          EOF
+
+      - name: Resolve release tag (asset naming)
+        id: meta
+        shell: bash
+        run: |
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          elif [ -n "${{ inputs.upload_release_tag }}" ]; then
+            TAG="${{ inputs.upload_release_tag }}"
+          else
+            VERSION=$(grep '^version' tenuo-core/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+            TAG="v${VERSION}"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Asset tag: ${TAG}"
+
+      - name: Build tenuo-authorizer
+        working-directory: tenuo-core
+        run: cargo build --release --bin tenuo-authorizer --features data-plane,server --locked
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          ASSET="tenuo-authorizer-${{ steps.meta.outputs.tag }}-${{ matrix.triple }}.tar.gz"
+          mkdir -p dist
+          tar -czf "dist/${ASSET}" -C tenuo-core/target/release tenuo-authorizer
+          echo "ASSET_NAME=${ASSET}" >> "$GITHUB_ENV"
+          ls -la dist/
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $asset = "tenuo-authorizer-${{ steps.meta.outputs.tag }}-${{ matrix.triple }}.zip"
+          New-Item -ItemType Directory -Force dist | Out-Null
+          Compress-Archive -Path tenuo-core/target/release/tenuo-authorizer.exe -DestinationPath "dist/$asset" -Force
+          "ASSET_NAME=$asset" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Get-ChildItem dist
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4.6.2
+        with:
+          name: authorizer-${{ matrix.triple }}
+          path: dist/*
+          if-no-files-found: error
+
+  release-assets:
+    name: Publish release assets
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.upload_release_tag != '')
+    steps:
+      - name: Resolve release tag
+        id: meta
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.upload_release_tag }}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Publishing to release: ${TAG}"
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          pattern: authorizer-*
+          merge-multiple: true
+
+      - name: Generate SHA256SUMS
+        working-directory: dist
+        run: |
+          shopt -s nullglob
+          files=(tenuo-authorizer-*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No release binaries found in dist/"
+            ls -la
+            exit 1
+          fi
+          sha256sum "${files[@]}" | tee SHA256SUMS
+          echo "checksum_count=${#files[@]}" >> "$GITHUB_OUTPUT"
+        id: sums
+
+      - name: Upload binaries and checksums to GitHub release
+        shell: bash
+        run: |
+          gh release upload "${{ steps.meta.outputs.tag }}" dist/tenuo-authorizer-* dist/SHA256SUMS --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/authorizer-binaries.yml
+++ b/.github/workflows/authorizer-binaries.yml
@@ -77,6 +77,9 @@ jobs:
         uses: swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           workspaces: tenuo-core
+          # Isolate from main CI cache (different features/profile); shared linux x86_64
+          # cache otherwise restores incomplete artifacts and breaks release builds.
+          shared-key: authorizer-${{ matrix.triple }}
 
       - name: Install mold linker (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/authorizer-binaries.yml
+++ b/.github/workflows/authorizer-binaries.yml
@@ -175,8 +175,6 @@ jobs:
             exit 1
           fi
           sha256sum "${files[@]}" | tee SHA256SUMS
-          echo "checksum_count=${#files[@]}" >> "$GITHUB_OUTPUT"
-        id: sums
 
       - name: Upload binaries and checksums to GitHub release
         shell: bash

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -1695,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -1709,18 +1709,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1728,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1740,13 +1740,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -135,7 +135,7 @@ uuid = { version = "1.6", features = ["v4", "v7", "serde", "js"] }
 # Python bindings (optional)
 # Note: extension-module must NOT be here - it goes in the final cdylib (tenuo-python)
 # abi3-py38 allows building without linking Python at compile time
-pyo3 = { version = "=0.28.3", features = ["abi3-py39"], optional = true }
+pyo3 = { version = "=0.29.0", features = ["abi3-py39"], optional = true }
 
 # Server dependencies (optional)
 tokio = { version = "1.35", features = ["full"], optional = true }

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -2292,58 +2292,58 @@ fn constraint_to_py(py: Python<'_>, constraint: &Constraint) -> PyResult<Py<PyAn
 /// retrieved from dicts (e.g. approval gate `{"exempt": OneOf([...])}`) convert
 /// reliably under PyO3 0.24 with the abi3 extension module.
 fn py_to_constraint(obj: &Bound<'_, PyAny>) -> PyResult<Constraint> {
-    if let Ok(b) = obj.downcast::<PyPattern>() {
+    if let Ok(b) = obj.cast::<PyPattern>() {
         return Ok(Constraint::Pattern(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyExact>() {
+    if let Ok(b) = obj.cast::<PyExact>() {
         return Ok(Constraint::Exact(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyOneOf>() {
+    if let Ok(b) = obj.cast::<PyOneOf>() {
         return Ok(Constraint::OneOf(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyNotOneOf>() {
+    if let Ok(b) = obj.cast::<PyNotOneOf>() {
         return Ok(Constraint::NotOneOf(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyRange>() {
+    if let Ok(b) = obj.cast::<PyRange>() {
         return Ok(Constraint::Range(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyCidr>() {
+    if let Ok(b) = obj.cast::<PyCidr>() {
         return Ok(Constraint::Cidr(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyUrlPattern>() {
+    if let Ok(b) = obj.cast::<PyUrlPattern>() {
         return Ok(Constraint::UrlPattern(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyContains>() {
+    if let Ok(b) = obj.cast::<PyContains>() {
         return Ok(Constraint::Contains(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PySubset>() {
+    if let Ok(b) = obj.cast::<PySubset>() {
         return Ok(Constraint::Subset(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyAll>() {
+    if let Ok(b) = obj.cast::<PyAll>() {
         return Ok(Constraint::All(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyAnyOf>() {
+    if let Ok(b) = obj.cast::<PyAnyOf>() {
         return Ok(Constraint::Any(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyNot>() {
+    if let Ok(b) = obj.cast::<PyNot>() {
         return Ok(Constraint::Not(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyCel>() {
+    if let Ok(b) = obj.cast::<PyCel>() {
         return Ok(Constraint::Cel(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyRegex>() {
+    if let Ok(b) = obj.cast::<PyRegex>() {
         return Ok(Constraint::Regex(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyWildcard>() {
+    if let Ok(b) = obj.cast::<PyWildcard>() {
         return Ok(Constraint::Wildcard(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PySubpath>() {
+    if let Ok(b) = obj.cast::<PySubpath>() {
         return Ok(Constraint::Subpath(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyUrlSafe>() {
+    if let Ok(b) = obj.cast::<PyUrlSafe>() {
         return Ok(Constraint::UrlSafe(b.borrow().inner.clone()));
     }
-    if let Ok(b) = obj.downcast::<PyShlex>() {
+    if let Ok(b) = obj.cast::<PyShlex>() {
         return Ok(Constraint::Shlex(b.borrow().inner.clone()));
     }
     Err(py_validation_err(
@@ -2472,7 +2472,7 @@ fn py_to_arg_approval_gate(
     }
 
     // {"exempt": <constraint>} form — plain Python dict with a single "exempt" key.
-    if let Ok(d) = av.downcast::<PyDict>() {
+    if let Ok(d) = av.cast::<PyDict>() {
         if d.len() != 1 {
             return Err(py_validation_err(format!(
                 "arg gate '{}': approval gate dict must have exactly one key ('exempt')",
@@ -2526,7 +2526,7 @@ fn py_dict_to_approval_gate_map(
         let tool: String = key.extract()?;
         if value.is_none() {
             gm.insert(tool, ToolApprovalGate::whole_tool());
-        } else if let Ok(args_dict) = value.downcast::<PyDict>() {
+        } else if let Ok(args_dict) = value.cast::<PyDict>() {
             let mut args = std::collections::BTreeMap::new();
             for (ak, av) in args_dict.iter() {
                 let arg_name: String = ak.extract()?;
@@ -3528,7 +3528,7 @@ impl PyIssuanceBuilder {
 
     /// Set required approvers.
     fn with_required_approvers(&mut self, approvers: &Bound<'_, PyAny>) -> PyResult<()> {
-        let py_list = approvers.downcast::<pyo3::types::PyList>()?;
+        let py_list = approvers.cast::<pyo3::types::PyList>()?;
         let mut rust_approvers = Vec::new();
         for item in py_list.iter() {
             let pk: PyPublicKey = item.extract()?;
@@ -3692,7 +3692,7 @@ impl PyWarrant {
                 let tool_name: String = tool_key.extract()?;
 
                 let constraints_dict: &Bound<'_, PyDict> = constraints_val
-                    .downcast()
+                    .cast()
                     .map_err(|_| py_validation_err("capabilities values must be dicts"))?;
 
                 let constraint_set = py_dict_to_constraint_set(constraints_dict)?;
@@ -4028,7 +4028,7 @@ impl PyWarrant {
             let tool_name: String = tool_key.extract()?;
 
             let constraints_dict: &Bound<'_, PyDict> = constraints_val
-                .downcast()
+                .cast()
                 .map_err(|_| py_validation_err("capabilities values must be dicts"))?;
 
             let constraint_set = py_dict_to_constraint_set(constraints_dict)?;
@@ -5619,7 +5619,7 @@ impl PyAuthorizer {
         let mut warrants = Vec::with_capacity(len);
         for i in 0..len {
             let item = chain.get_item(i)?;
-            let warrant_bound = item.downcast::<PyWarrant>()?;
+            let warrant_bound = item.cast::<PyWarrant>()?;
             let warrant = warrant_bound.borrow();
             warrants.push(warrant.inner.clone());
         }
@@ -5659,7 +5659,7 @@ impl PyAuthorizer {
         let mut warrants = Vec::with_capacity(len);
         for i in 0..len {
             let item = chain.get_item(i)?;
-            let warrant_bound = item.downcast::<PyWarrant>()?;
+            let warrant_bound = item.cast::<PyWarrant>()?;
             let warrant = warrant_bound.borrow();
             warrants.push(warrant.inner.clone());
         }
@@ -5790,7 +5790,7 @@ impl PyAuthorizer {
         let mut warrants = Vec::with_capacity(len);
         for i in 0..len {
             let item = chain.get_item(i)?;
-            let warrant_bound = item.downcast::<PyWarrant>()?;
+            let warrant_bound = item.cast::<PyWarrant>()?;
             let warrant = warrant_bound.borrow();
             warrants.push(warrant.inner.clone());
         }

--- a/tenuo-core/tests/approval_gate_merge.rs
+++ b/tenuo-core/tests/approval_gate_merge.rs
@@ -903,7 +903,9 @@ fn test_subagent_attenuation_drops_gated_tool_and_gate() {
         "glob".to_string(),
     ]);
     attn.set_holder(holder_kp.public_key());
-    let child = attn.build(&holder_kp).expect("researcher subwarrant should build");
+    let child = attn
+        .build(&holder_kp)
+        .expect("researcher subwarrant should build");
 
     assert!(
         parse_approval_gate_map(child.extension(APPROVAL_GATE_EXTENSION_KEY))

--- a/tenuo-python/Cargo.lock
+++ b/tenuo-python/Cargo.lock
@@ -1533,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -1547,18 +1547,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1578,13 +1578,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/tenuo-python/Cargo.toml
+++ b/tenuo-python/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 [dependencies]
 tenuo = { path = "../tenuo-core", features = ["python-extension", "cel", "python-server"] }
 # pyo3 is re-exported from tenuo crate with python feature
-pyo3 = { version = "=0.28.3", features = ["abi3-py39", "extension-module"] }
+pyo3 = { version = "=0.29.0", features = ["abi3-py39", "extension-module"] }
 
 # Cargo only reads `[profile.*]` from the crate/workspace being built, never
 # from path dependencies, so `tenuo-core`'s custom release profile does NOT


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that builds native `tenuo-authorizer` archives for Linux (x64 on ubuntu-22.04, arm64), macOS (Apple Silicon + Intel), and Windows.
- Publish binaries and a `SHA256SUMS` manifest to GitHub releases; supports backfilling an existing tag via `workflow_dispatch` without a version bump.
- Backfill builds check out the release tag (not the workflow ref) so uploaded assets match the released commit.

## Test plan
- [x] `workflow_dispatch` smoke run on the feature branch (5 build jobs green)
- [ ] After merge: backfill `v0.1.0-beta.24` with `upload_release_tag=v0.1.0-beta.24`
- [ ] Verify `tenuo-claude install-authorizer` downloads the macOS arm64 asset on a clean machine
- [ ] Confirm `SHA256SUMS` matches published archives