### PR TITLE
fix: gate-aware approvals, overflow, min_approvals validation, hash hardening

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -889,8 +889,8 @@ AnyOf([
 > - `AnyOf([...])` - OR composite: at least one constraint must match
 > - `Any()` - Alias for `Wildcard()`: allows any value for a specific field in zero-trust mode
 
-> [!WARNING]
-> **Attenuation not supported.** `AnyOf -> AnyOf` attenuation is rejected because subset checking for disjunctions is not provably sound without full evaluation. `AnyOf` can only appear in root warrants or be attenuated from `Wildcard`. To narrow alternatives, restructure using `All` with typed constraints.
+> [!NOTE]
+> **Attenuation rule: every child branch must be covered by a parent branch.** `AnyOf -> AnyOf` attenuation is valid when the child's set of alternatives is a subset of the parent's: each child branch must be a valid attenuation of at least one parent branch. For example, `AnyOf([Subpath("/var"), Subpath("/srv")]) -> AnyOf([Subpath("/var/log")])` is valid; adding a new branch not in the parent is rejected.
 
 ---
 
@@ -905,8 +905,8 @@ from tenuo import Not, Exact
 Not(Exact("production"))
 ```
 
-> [!WARNING]
-> **Attenuation not supported.** `Not -> Not` attenuation is rejected because negation reverses the subset direction: `Not(B) ⊆ Not(A)` requires `A ⊆ B` (the inner must widen, not narrow), making safe attenuation infeasible. Use positive constraints (OneOf, Pattern) instead.
+> [!NOTE]
+> **Attenuation rule: the inner constraint direction is inverted.** `Not(child_inner)` is a valid attenuation of `Not(parent_inner)` when the **child inner is at least as permissive as the parent inner** (the opposite of the usual direction). Because `Not` flips accepted/rejected sets, a wider inner produces a narrower outer. For example, `Not(Exact("admin")) -> Not(OneOf(["admin","root"]))` is valid (child inner is wider, so the child `Not` accepts fewer values). Attempting to narrow the inner (`Not(OneOf([...])) -> Not(Exact(...))`) is rejected because it widens the outer accepted set.
 
 ---
 
@@ -1156,8 +1156,8 @@ When attenuating a warrant, child constraints must be **contained** within paren
 | `Contains()` | Contains (more required values) |
 | `Subset()` | Subset (fewer allowed values) |
 | `All()` | All (more constraints) |
-| `AnyOf()` | Not supported (use `All` or restructure) |
-| `Not()` | Not supported (use positive constraints) |
+| `AnyOf()` | AnyOf (child branches ⊆ parent branches) |
+| `Not()` | Not (child inner must be >= as permissive as parent inner; direction inverted) |
 | `CEL()` | CEL (parenthesized conjunction with parent) |
 | `Subpath()` | Subpath (narrower root), Exact (if path contained) |
 | `UrlSafe()` | UrlSafe (more restrictive), Exact (if URL is safe) |
@@ -1168,8 +1168,8 @@ When attenuating a warrant, child constraints must be **contained** within paren
 - **Exact**: Cannot change value at all
 - **Range**: If parent bound is exclusive, child cannot make it inclusive at the same value (would widen)
 - **No attenuation TO Wildcard** (from non-Wildcard parents): Would re-widen authority
-- **Not**: Attenuation not supported. Negation reverses the subset direction (`Not(B) ⊆ Not(A)` requires `A ⊆ B`, not `B ⊆ A`), making safe attenuation infeasible. Use positive constraints (OneOf, Pattern) instead.
-- **AnyOf (OR)**: Attenuation not supported. Subset checking for disjunctions requires full evaluation. Use `All` with structured constraints instead.
+- **Not**: Attenuation direction is inverted. `Not(parent_inner) -> Not(child_inner)` is valid only when the child inner is **at least as permissive** as the parent inner (i.e. `child_inner.validate_attenuation(parent_inner)` succeeds). Narrowing the inner widens the outer accepted set, which is rejected.
+- **AnyOf (OR)**: Every child branch must be covered by at least one parent branch. Adding a new branch not present in the parent is rejected as privilege escalation.
 - **CEL**: Child must be `(parent) && (extra)`. The extra predicate must be parenthesized to prevent `||` precedence bypass.
 
 ### Cross-Type Containment

--- a/docs/spec/wire-format-v1.md
+++ b/docs/spec/wire-format-v1.md
@@ -622,7 +622,7 @@ All constraints serialize as `[type_id, value]` tuples. The `value` is the serde
 - `Subset`: child’s allowed set must be ⊆ parent’s allowed set.
 - `All`: child may add more clauses; existing clauses must not be weakened.
 - `Any`: child may remove clauses; remaining clauses must not be weakened.
-- `Not`: negation of a stricter constraint remains stricter only if the inner constraint is stricter.
+- `Not`: direction is inverted. `Not(child_inner)` is stricter than `Not(parent_inner)` only when the child inner is **at least as permissive** as the parent inner (wider inner produces a narrower outer, because `Not` flips accepted/rejected sets).
 - `Cel`: child must conjoin with parent (logical AND); never replace/loosen parent expression.
 
 ### Constraint Attenuation Matrix (Normative)
@@ -670,8 +670,10 @@ All constraints serialize as `[type_id, value]` tuples. The `value` is the serde
 
 | Parent Pattern | Child Pattern | Valid | Rule |
 |----------------|---------------|-------|------|
-| `"*"` | `"*"` | YES | Single wildcard, equal |
-| `"*"` | Any other | IFF | Equal only (single wildcard is conservative) |
+| `"*"` | `"*"` | YES | Identity |
+| `"*"` | `"prefix-*"` | YES | Treated as `Prefix("")`; any non-empty prefix is a valid extension |
+| `"*"` | Exact `"v"` | YES | Any exact value satisfies an empty prefix |
+| `"*"` | `"*-suffix"` | NO | Cross-type (prefix to suffix) is not supported; use `"prefix-*"` narrowing instead |
 | `"prefix-*"` | `"prefix-more-*"` | YES | Child prefix extends parent |
 | `"prefix-*"` | `"prefix-exact"` | YES | Exact value starts with prefix |
 | `"*-suffix"` | `"*-more-suffix"` | YES | Child suffix extends parent |

--- a/ietf/draft-niyikiza-oauth-attenuating-agent-tokens-01.md
+++ b/ietf/draft-niyikiza-oauth-attenuating-agent-tokens-01.md
@@ -2628,3 +2628,54 @@ constraint attenuation matrix.
 
 RFC Editor Note: This section will be updated or removed before
 publication.
+
+# Changes from Previous Versions
+
+## Changes from -00 to -01
+
+**Core constraint vocabulary reduced.** The `pattern` (glob), `regex`,
+`cel` (CEL expression), and `not` (logical negation) constraint types
+have been removed from the normative core constraint set. In
+draft-niyikiza-oauth-attenuating-agent-tokens-00, these types were
+specified as core types with varying subsumption rules. This revision
+moves them out of the core for the following reasons:
+
+- **`pattern` and `regex`:** Containment analysis for arbitrary glob and
+  regular expression patterns is not decidable in the general case.
+  Draft -00 prescribed conservative syntactic rules (prefix extension for
+  single-wildcard globs; structural identity for regex), but these rules
+  are difficult to specify precisely enough for independent
+  interoperability. These types are better defined as registered
+  extensions where the registration can document the precise syntactic
+  subset and sound containment procedure.
+
+- **`not` (logical negation):** Draft -00 permitted only structurally
+  identical `not` constraints to subsume each other (identity rule via
+  JCS-canonical comparison). This was an explicitly conservative choice
+  to avoid requiring implementations to evaluate negation subsumption in
+  reverse. The type is removed from the core in this revision; the
+  extension registry process allows negation semantics to be specified
+  with a precise and implementable directional subsumption procedure for
+  deployments that require it.
+
+- **`cel` (CEL expression):** Policy expression subsumption is not
+  decidable for CEL in general. Removed from core; suitable for
+  extension registration with an appropriate syntactic conjunction
+  strategy.
+
+The core constraint set in this revision is: `exact`, `range`,
+`one_of`, `not_one_of`, `contains`, `subset`, `wildcard`, `all`, `any`.
+Each type has a decidable, sound, and deterministic subsumption
+procedure defined in Section 4.5. All removed types remain usable in
+AAT deployments as registered extension types under Section 3.5.
+
+**`any` subsumption rule unchanged.** The subsumption rule for the
+`any` (logical OR) constraint type is retained from draft -00 without
+modification: every clause in the derived constraint must be subsumed
+by at least one clause in the parent constraint.
+
+**Non-normative material added.** The following non-normative sections
+are new in this revision: approval gates, clock skew guidance,
+role-based key separation, algorithm confusion considerations,
+implementation notes on middleware integration and delegation depth,
+and TTL guidance.

--- a/tenuo-core/src/approval.rs
+++ b/tenuo-core/src/approval.rs
@@ -410,6 +410,12 @@ pub fn canonical_tool_args_cbor(
 /// This ensures an approval is bound to a specific (warrant, tool, args, holder) tuple.
 /// Including the holder prevents approval theft: even if an attacker intercepts an
 /// approval, they can't use it because the hash won't match their holder key.
+///
+/// Preimage encoding: CBOR array `[warrant_id, tool, args_cbor_bytes, holder_bytes]`.
+/// Using a CBOR array provides unambiguous length-framing so that no value can bleed
+/// into an adjacent field (unlike a `|`-joined string). `args_cbor_bytes` is the
+/// canonical CBOR encoding of the sorted args map, embedded as a CBOR byte string
+/// so that it is self-delimiting within the outer array.
 pub fn compute_request_hash(
     warrant_id: &str,
     tool: &str,
@@ -418,23 +424,30 @@ pub fn compute_request_hash(
 ) -> [u8; 32] {
     use sha2::{Digest, Sha256};
 
-    let mut hasher = Sha256::new();
-    hasher.update(warrant_id.as_bytes());
-    hasher.update(b"|");
-    hasher.update(tool.as_bytes());
-    hasher.update(b"|");
+    let args_cbor = canonical_tool_args_cbor(args).unwrap_or_default();
+    let holder_bytes: Vec<u8> = authorized_holder
+        .map(|h| h.to_bytes().to_vec())
+        .unwrap_or_default();
 
-    if let Some(buf) = canonical_tool_args_cbor(args) {
-        hasher.update(&buf);
-    }
+    // Encode the four fields as a CBOR 4-element array.  The args map is wrapped
+    // as a CBOR byte string so that its internal structure is opaque to the outer
+    // array encoder and the boundary is always unambiguous.
+    let tuple: (
+        ciborium::Value,
+        ciborium::Value,
+        ciborium::Value,
+        ciborium::Value,
+    ) = (
+        ciborium::Value::Text(warrant_id.to_owned()),
+        ciborium::Value::Text(tool.to_owned()),
+        ciborium::Value::Bytes(args_cbor),
+        ciborium::Value::Bytes(holder_bytes),
+    );
+    let mut preimage = Vec::new();
+    // Infallible for well-formed in-memory values; fall back to empty on error.
+    let _ = ciborium::into_writer(&tuple, &mut preimage);
 
-    // Bind to authorized holder (prevents approval theft)
-    hasher.update(b"|");
-    if let Some(holder) = authorized_holder {
-        hasher.update(holder.to_bytes());
-    }
-
-    hasher.finalize().into()
+    Sha256::digest(&preimage).into()
 }
 
 /// Build the signed preimage for an approval-context attestation (version 1).

--- a/tenuo-core/src/constraints.rs
+++ b/tenuo-core/src/constraints.rs
@@ -722,6 +722,12 @@ impl Constraint {
             // All can add more constraints
             (Constraint::All(parent), Constraint::All(child)) => parent.validate_attenuation(child),
 
+            // Any: every child branch must be covered by some parent branch
+            (Constraint::Any(parent), Constraint::Any(child)) => parent.validate_attenuation(child),
+
+            // Not: direction is inverted — child inner must be at least as permissive as parent inner
+            (Constraint::Not(parent), Constraint::Not(child)) => parent.validate_attenuation(child),
+
             // CEL follows conjunction rule
             (Constraint::Cel(parent), Constraint::Cel(child)) => parent.validate_attenuation(child),
 
@@ -2397,11 +2403,12 @@ impl Subpath {
             });
         }
 
-        // Child cannot be less restrictive on case sensitivity
-        // (case-insensitive parent can narrow to case-sensitive child, but not vice versa)
-        if !self.case_sensitive && child.case_sensitive {
+        // Child cannot be less restrictive on case sensitivity.
+        // A case-sensitive parent accepts fewer values than a case-insensitive one.
+        // Allowing the child to become case-insensitive would widen acceptance.
+        if self.case_sensitive && !child.case_sensitive {
             return Err(Error::MonotonicityViolation(
-                "cannot attenuate case-insensitive to case-sensitive".to_string(),
+                "cannot attenuate case-sensitive to case-insensitive".to_string(),
             ));
         }
 
@@ -3004,6 +3011,29 @@ impl UrlSafe {
             ));
         }
 
+        // If parent has port allowlist, child must have it too (and be a subset).
+        // A child with allow_ports: None is unrestricted — it must not widen a parent
+        // that is restricted to specific ports.
+        if let Some(ref parent_ports) = self.allow_ports {
+            match &child.allow_ports {
+                None => {
+                    return Err(Error::MonotonicityViolation(
+                        "child must have port allowlist if parent does".to_string(),
+                    ));
+                }
+                Some(child_ports) => {
+                    for cp in child_ports {
+                        if !parent_ports.contains(cp) {
+                            return Err(Error::MonotonicityViolation(format!(
+                                "child port {} not in parent port allowlist",
+                                cp
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+
         // If parent has domain allowlist, child must have it too (and be subset)
         if let Some(ref parent_domains) = self.allow_domains {
             match &child.allow_domains {
@@ -3430,6 +3460,28 @@ impl Any {
         }
         Ok(false)
     }
+
+    /// Validate attenuation: child's allowed set must be a subset of parent's.
+    ///
+    /// Every child branch must be coverable by at least one parent branch.
+    /// This is the dual of `All::validate_attenuation`: `All` requires the
+    /// child to preserve (and optionally add) all parent constraints, whereas
+    /// `Any` requires the child to only retain alternatives the parent already
+    /// permits.
+    pub fn validate_attenuation(&self, child: &Any) -> Result<()> {
+        for child_c in &child.constraints {
+            let covered = self
+                .constraints
+                .iter()
+                .any(|parent_c| parent_c.validate_attenuation(child_c).is_ok());
+            if !covered {
+                return Err(Error::MonotonicityViolation(
+                    "each Any branch in child must be a valid attenuation of some Any branch in parent".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
 impl From<Any> for Constraint {
@@ -3455,6 +3507,42 @@ impl Not {
     /// Check if the inner constraint does NOT match.
     pub fn matches(&self, value: &ConstraintValue) -> Result<bool> {
         Ok(!self.constraint.matches(value)?)
+    }
+
+    /// Validate attenuation for `Not` constraints.
+    ///
+    /// `Not(child_inner)` is a valid attenuation of `Not(parent_inner)` when the
+    /// child's accepted set is a subset of the parent's:
+    ///
+    ///   accepted(Not(X)) = universe \ accepted(X)
+    ///
+    /// So child ⊆ parent iff:
+    ///
+    ///   (U \ accepted(child_inner)) ⊆ (U \ accepted(parent_inner))
+    ///   ⟺ accepted(parent_inner) ⊆ accepted(child_inner)
+    ///   ⟺ child_inner is a valid attenuation of parent_inner… reversed:
+    ///       parent_inner.validate_attenuation(child_inner) would check parent ⊆ child
+    ///       but we need parent ⊆ child, so we call child_inner.validate_attenuation(&parent_inner).
+    ///
+    /// In plain terms: the child inner constraint must be *looser* (accept more values)
+    /// than the parent inner, because the `Not` flips the direction.
+    ///
+    /// Examples:
+    ///   Not(Exact("admin")) → Not(Exact("admin"))           — identity, valid
+    ///   Not(Exact("admin")) → Not(OneOf(["admin","root"]))  — child inner is wider → valid
+    ///   Not(OneOf(["admin","root"])) → Not(Exact("admin"))  — child inner is narrower → invalid
+    pub fn validate_attenuation(&self, child: &Not) -> Result<()> {
+        // Direction is inverted: child_inner must be at least as permissive as parent_inner.
+        child
+            .constraint
+            .validate_attenuation(&self.constraint)
+            .map_err(|_| {
+                Error::MonotonicityViolation(
+                    "Not attenuation requires child inner constraint to be at least as permissive \
+                     as parent inner (direction is inverted for negation)"
+                        .to_string(),
+                )
+            })
     }
 }
 
@@ -6109,29 +6197,103 @@ mod tests {
     }
 
     // ========================================================================
-    // Not / Any attenuation rejection tests
+    // Not / Any attenuation tests
     // ========================================================================
 
     #[test]
-    fn test_not_attenuation_rejected() {
+    fn test_not_attenuation_identity() {
         let parent = Constraint::Not(Not::new(Constraint::Exact(Exact::new("admin"))));
         let child = Constraint::Not(Not::new(Constraint::Exact(Exact::new("admin"))));
         assert!(
-            parent.validate_attenuation(&child).is_err(),
-            "Not -> Not attenuation must be rejected (direction is unsound)"
+            parent.validate_attenuation(&child).is_ok(),
+            "Not -> Not identity must be valid"
         );
     }
 
     #[test]
-    fn test_any_attenuation_rejected() {
+    fn test_not_attenuation_wider_inner_valid() {
+        // Parent excludes only "admin"; child excludes "admin" AND "root".
+        // child accepted set ⊂ parent accepted set → valid attenuation.
+        let parent = Constraint::Not(Not::new(Constraint::Exact(Exact::new("admin"))));
+        let child = Constraint::Not(Not::new(Constraint::OneOf(OneOf::new(vec![
+            "admin", "root",
+        ]))));
+        assert!(
+            parent.validate_attenuation(&child).is_ok(),
+            "Not(Exact) -> Not(OneOf[superset]) must be valid"
+        );
+    }
+
+    #[test]
+    fn test_not_attenuation_narrower_inner_rejected() {
+        // Parent excludes "admin" AND "root"; child only excludes "admin".
+        // child accepted set ⊃ parent accepted set → privilege escalation, must reject.
+        let parent = Constraint::Not(Not::new(Constraint::OneOf(OneOf::new(vec![
+            "admin", "root",
+        ]))));
+        let child = Constraint::Not(Not::new(Constraint::Exact(Exact::new("admin"))));
+        assert!(
+            parent.validate_attenuation(&child).is_err(),
+            "Not(OneOf[wider]) -> Not(Exact) must be rejected (child accepts more values)"
+        );
+    }
+
+    #[test]
+    fn test_any_attenuation_identity() {
+        let parent = Constraint::Any(Any::new(vec![
+            Constraint::Exact(Exact::new("a")),
+            Constraint::Exact(Exact::new("b")),
+        ]));
+        let child = Constraint::Any(Any::new(vec![
+            Constraint::Exact(Exact::new("a")),
+            Constraint::Exact(Exact::new("b")),
+        ]));
+        assert!(
+            parent.validate_attenuation(&child).is_ok(),
+            "Any -> Any identity pass-through must be valid"
+        );
+    }
+
+    #[test]
+    fn test_any_attenuation_subset() {
         let parent = Constraint::Any(Any::new(vec![
             Constraint::Exact(Exact::new("a")),
             Constraint::Exact(Exact::new("b")),
         ]));
         let child = Constraint::Any(Any::new(vec![Constraint::Exact(Exact::new("a"))]));
         assert!(
+            parent.validate_attenuation(&child).is_ok(),
+            "Any -> Any with subset of branches must be valid"
+        );
+    }
+
+    #[test]
+    fn test_any_attenuation_new_branch_rejected() {
+        let parent = Constraint::Any(Any::new(vec![
+            Constraint::Exact(Exact::new("a")),
+            Constraint::Exact(Exact::new("b")),
+        ]));
+        // "c" is not in parent — this would expand permissions
+        let child = Constraint::Any(Any::new(vec![
+            Constraint::Exact(Exact::new("a")),
+            Constraint::Exact(Exact::new("c")),
+        ]));
+        assert!(
             parent.validate_attenuation(&child).is_err(),
-            "Any -> Any attenuation must be rejected (not implemented)"
+            "Any -> Any with a new branch not in parent must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_any_attenuation_superset_rejected() {
+        let parent = Constraint::Any(Any::new(vec![Constraint::Exact(Exact::new("a"))]));
+        let child = Constraint::Any(Any::new(vec![
+            Constraint::Exact(Exact::new("a")),
+            Constraint::Exact(Exact::new("b")),
+        ]));
+        assert!(
+            parent.validate_attenuation(&child).is_err(),
+            "Any -> Any with superset of branches must be rejected (privilege escalation)"
         );
     }
 }

--- a/tenuo-core/src/planes.rs
+++ b/tenuo-core/src/planes.rs
@@ -882,6 +882,22 @@ impl DataPlane {
             }
         }
 
+        // STRUCTURAL INVARIANT CHECK: Validate each warrant's structural consistency
+        // (version, type constraints, min_approvals, etc.) without clock-based checks.
+        // This catches malformed deserialized warrants that bypass builder-level checks.
+        // Temporal checks (expiry, clock-skew) are omitted here; they are either
+        // handled separately by the chain verifier or intentionally relaxed in
+        // offline/test contexts that use fixed future timestamps.
+        for warrant in chain {
+            warrant.validate_structural().map_err(|e| {
+                Error::ChainVerificationFailed(format!(
+                    "warrant '{}' failed structural validation: {}",
+                    warrant.id(),
+                    e
+                ))
+            })?;
+        }
+
         let mut result = ChainVerificationResult {
             root_issuer: None,
             chain_length: chain.len(),
@@ -1213,19 +1229,19 @@ impl DataPlane {
 
             let auth_result = leaf.authorize(tool, args, signature).and_then(|_| {
                 // Evaluate approval gates before running multi-sig verification.
-                // If the warrant has gate configuration, only require approvals when
-                // a gate fires for this specific tool+args combination. Without this
-                // check, any call on a warrant with required_approvers would require
-                // approval even for ungated tools, contradicting the selective-gate model.
+                // Only require approvals when a gate fires for this tool+args. Absent a
+                // gate map evaluate_approval_gates returns false, matching Authorizer's
+                // semantics: required_approvers without any gate configuration means no
+                // call is gated (the builder rejects this state; legacy warrants see it
+                // as fully ungated rather than fully gated).
                 let gate_map = crate::approval_gate::parse_approval_gate_map(
                     leaf.extension(crate::approval_gate::APPROVAL_GATE_EXTENSION_KEY),
                 )?;
-                let needs_approval = if gate_map.is_some() {
-                    crate::approval_gate::evaluate_approval_gates(gate_map.as_ref(), tool, args)?
-                } else {
-                    // No gate configuration: require approval whenever required_approvers is set.
-                    leaf.requires_multisig()
-                };
+                let needs_approval = crate::approval_gate::evaluate_approval_gates(
+                    gate_map.as_ref(),
+                    tool,
+                    args,
+                )?;
 
                 if needs_approval {
                     verify_approvals_with_tolerance(
@@ -2034,6 +2050,22 @@ impl Authorizer {
                     )));
                 }
             }
+        }
+
+        // STRUCTURAL INVARIANT CHECK: Validate each warrant's structural consistency
+        // (version, type constraints, min_approvals, etc.) without clock-based checks.
+        // This catches malformed deserialized warrants that bypass builder-level checks.
+        // Temporal checks (expiry, clock-skew) are omitted here; they are either
+        // handled separately by the chain verifier or intentionally relaxed in
+        // offline/test contexts that use fixed future timestamps.
+        for warrant in chain {
+            warrant.validate_structural().map_err(|e| {
+                Error::ChainVerificationFailed(format!(
+                    "warrant '{}' failed structural validation: {}",
+                    warrant.id(),
+                    e
+                ))
+            })?;
         }
 
         let root = &chain[0];

--- a/tenuo-core/src/planes.rs
+++ b/tenuo-core/src/planes.rs
@@ -123,7 +123,7 @@ fn verify_approvals_with_tolerance(
             continue;
         }
 
-        if payload.expires_at + tolerance_secs < now {
+        if payload.expires_at.saturating_add(tolerance_secs) < now {
             rejections.push(Rejection::Expired);
             continue;
         }
@@ -1212,13 +1212,32 @@ impl DataPlane {
             }
 
             let auth_result = leaf.authorize(tool, args, signature).and_then(|_| {
-                verify_approvals_with_tolerance(
-                    leaf,
-                    tool,
-                    args,
-                    approvals,
-                    chrono::Duration::seconds(DEFAULT_CLOCK_TOLERANCE_SECS),
-                )
+                // Evaluate approval gates before running multi-sig verification.
+                // If the warrant has gate configuration, only require approvals when
+                // a gate fires for this specific tool+args combination. Without this
+                // check, any call on a warrant with required_approvers would require
+                // approval even for ungated tools, contradicting the selective-gate model.
+                let gate_map = crate::approval_gate::parse_approval_gate_map(
+                    leaf.extension(crate::approval_gate::APPROVAL_GATE_EXTENSION_KEY),
+                )?;
+                let needs_approval = if gate_map.is_some() {
+                    crate::approval_gate::evaluate_approval_gates(gate_map.as_ref(), tool, args)?
+                } else {
+                    // No gate configuration: require approval whenever required_approvers is set.
+                    leaf.requires_multisig()
+                };
+
+                if needs_approval {
+                    verify_approvals_with_tolerance(
+                        leaf,
+                        tool,
+                        args,
+                        approvals,
+                        chrono::Duration::seconds(DEFAULT_CLOCK_TOLERANCE_SECS),
+                    )
+                } else {
+                    Ok(Vec::new())
+                }
             });
 
             match &auth_result {

--- a/tenuo-core/src/warrant.rs
+++ b/tenuo-core/src/warrant.rs
@@ -752,6 +752,29 @@ impl Warrant {
             // Informational
         }
 
+        // Validate multi-sig configuration consistency.
+        // min_approvals must not exceed the number of eligible approvers.
+        // A warrant claiming "3-of-1" would silently degrade to "1-of-1" during
+        // verification via the approval_threshold() cap, which violates the issuer's
+        // stated intent. Reject at validation time to surface the misconfiguration.
+        if let (Some(approvers), Some(min)) = (
+            &self.payload.required_approvers,
+            self.payload.min_approvals,
+        ) {
+            let len = approvers.len() as u32;
+            if min > len {
+                return Err(Error::Validation(format!(
+                    "min_approvals ({}) exceeds number of required_approvers ({})",
+                    min, len
+                )));
+            }
+            if min == 0 {
+                return Err(Error::Validation(
+                    "min_approvals must be at least 1 when required_approvers is set".to_string(),
+                ));
+            }
+        }
+
         Ok(())
     }
 

--- a/tenuo-core/src/warrant.rs
+++ b/tenuo-core/src/warrant.rs
@@ -778,6 +778,110 @@ impl Warrant {
         Ok(())
     }
 
+    /// Validate structural invariants that are safe to check without a wall-clock.
+    ///
+    /// This is a subset of [`Warrant::validate`] covering version, type consistency,
+    /// depth bounds, extension sizes, and multi-sig configuration. Temporal checks
+    /// (clock-skew, expiry) are intentionally excluded so that this method can be
+    /// called inside chain verifiers without rejecting warrants whose timestamps
+    /// were set to a fixed future value in tests or offline contexts.
+    pub fn validate_structural(&self) -> Result<()> {
+        if self.payload.version != WARRANT_VERSION as u8 {
+            return Err(Error::Validation(format!(
+                "unsupported warrant version: {} (expected {})",
+                self.payload.version, WARRANT_VERSION
+            )));
+        }
+
+        if self.payload.expires_at <= self.payload.issued_at {
+            return Err(Error::Validation(
+                "warrant expires_at must be strictly greater than issued_at".to_string(),
+            ));
+        }
+
+        match self.payload.warrant_type {
+            WarrantType::Execution => {
+                if self.payload.issuable_tools.is_some() {
+                    return Err(Error::InvalidWarrantType {
+                        message: "execution warrant cannot have issuable_tools".to_string(),
+                    });
+                }
+                if self.payload.max_issue_depth.is_some() {
+                    return Err(Error::InvalidWarrantType {
+                        message: "execution warrant cannot have max_issue_depth".to_string(),
+                    });
+                }
+            }
+            WarrantType::Issuer => {
+                if !self.payload.tools.is_empty() {
+                    return Err(Error::InvalidWarrantType {
+                        message: "issuer warrant cannot have tools".to_string(),
+                    });
+                }
+                if self
+                    .payload
+                    .issuable_tools
+                    .as_ref()
+                    .is_none_or(|t| t.is_empty())
+                {
+                    return Err(Error::InvalidWarrantType {
+                        message: "issuer warrant requires at least one issuable_tool".to_string(),
+                    });
+                }
+            }
+        }
+
+        if let Some(max_issue) = self.payload.max_issue_depth {
+            let effective_max = self.effective_max_depth();
+            if max_issue > effective_max {
+                return Err(Error::IssueDepthExceeded {
+                    depth: max_issue,
+                    max: effective_max,
+                });
+            }
+        }
+
+        self.validate_constraint_depth()?;
+
+        if self.payload.extensions.len() > MAX_EXTENSION_KEYS {
+            return Err(Error::Validation(format!(
+                "extensions count {} exceeds limit {}",
+                self.payload.extensions.len(),
+                MAX_EXTENSION_KEYS
+            )));
+        }
+        for (key, val) in &self.payload.extensions {
+            if val.len() > MAX_EXTENSION_VALUE_SIZE {
+                return Err(Error::Validation(format!(
+                    "extension '{}' value size {} exceeds limit {}",
+                    key,
+                    val.len(),
+                    MAX_EXTENSION_VALUE_SIZE
+                )));
+            }
+        }
+
+        if let (Some(approvers), Some(min)) = (
+            &self.payload.required_approvers,
+            self.payload.min_approvals,
+        ) {
+            let len = approvers.len() as u32;
+            if min > len {
+                return Err(Error::Validation(format!(
+                    "min_approvals ({}) exceeds number of required_approvers ({})",
+                    min, len
+                )));
+            }
+            if min == 0 {
+                return Err(Error::Validation(
+                    "min_approvals must be at least 1 when required_approvers is set".to_string(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     /// Get the delegation depth (0 for root, increments on each attenuation).
     pub fn depth(&self) -> u32 {
         self.payload.depth

--- a/tenuo-core/tests/attenuation_soundness.rs
+++ b/tenuo-core/tests/attenuation_soundness.rs
@@ -544,42 +544,88 @@ fn exhaustive_contains_contains_soundness() {
     eprintln!("exhaustive_contains_contains: checked {} triples", checked);
 }
 
-/// Verify that Not -> Not attenuation is always rejected (code is sound,
-/// spec was wrong before we fixed it).
+/// Exhaustively verify Not -> Not attenuation soundness over all subset pairs.
+///
+/// Not(X) accepts (universe \ accepted(X)). So child ⊆ parent iff
+/// accepted(parent_inner) ⊆ accepted(child_inner) — the inner direction is inverted.
+///
+/// For OneOf inners this means: Not(OneOf(P)) → Not(OneOf(C)) is valid iff P ⊆ C
+/// (child inner excludes at least everything parent inner excludes, plus possibly more).
 #[test]
-fn exhaustive_not_not_always_rejected() {
+fn exhaustive_not_not_soundness() {
+    let subsets = all_subsets();
+    let non_empty: Vec<_> = subsets.iter().filter(|s| !s.is_empty()).collect();
+
+    for parent_inner_vals in &non_empty {
+        let parent_inner = Constraint::OneOf(OneOf::new(parent_inner_vals.to_vec()));
+        let parent = Constraint::Not(Not::new(parent_inner.clone()));
+
+        for child_inner_vals in &non_empty {
+            let child_inner = Constraint::OneOf(OneOf::new(child_inner_vals.to_vec()));
+            let child = Constraint::Not(Not::new(child_inner.clone()));
+
+            // Not(P) → Not(C) is valid iff P ⊆ C (inner direction inverted)
+            let parent_is_subset_of_child = parent_inner_vals
+                .iter()
+                .all(|v| child_inner_vals.contains(v));
+
+            if parent_is_subset_of_child {
+                assert!(
+                    parent.validate_attenuation(&child).is_ok(),
+                    "Not(OneOf({:?})) -> Not(OneOf({:?})) must be valid (P ⊆ C)",
+                    parent_inner_vals,
+                    child_inner_vals
+                );
+                // Monotonicity: every value accepted by Not(child_inner) must be accepted by Not(parent_inner).
+                // Not(X) accepts v iff X does NOT match v.
+                for atom in ATOMS {
+                    let v = ConstraintValue::String(atom.to_string());
+                    let child_accepts = !child_inner.matches(&v).unwrap_or(true);
+                    if child_accepts {
+                        let parent_accepts = !parent_inner.matches(&v).unwrap_or(true);
+                        assert!(
+                            parent_accepts,
+                            "Monotonicity violated: Not child accepts '{}' but Not parent does not \
+                             (parent_inner={:?}, child_inner={:?})",
+                            atom, parent_inner_vals, child_inner_vals
+                        );
+                    }
+                }
+            } else {
+                assert!(
+                    parent.validate_attenuation(&child).is_err(),
+                    "Not(OneOf({:?})) -> Not(OneOf({:?})) must be rejected (P ⊄ C)",
+                    parent_inner_vals,
+                    child_inner_vals
+                );
+            }
+        }
+    }
+
+    // Identity case: Not(Exact(x)) -> Not(Exact(x)) must always be valid
     for atom in ATOMS {
         let inner = Constraint::Exact(Exact::new(*atom));
         let parent = Constraint::Not(Not::new(inner.clone()));
         let child = Constraint::Not(Not::new(inner));
         assert!(
-            parent.validate_attenuation(&child).is_err(),
-            "Not -> Not must always be rejected"
-        );
-    }
-
-    // Also test with OneOf inners
-    let subsets = all_subsets();
-    for s in subsets.iter().filter(|s| !s.is_empty()) {
-        let inner = Constraint::OneOf(OneOf::new(s.to_vec()));
-        let parent = Constraint::Not(Not::new(inner.clone()));
-        let child = Constraint::Not(Not::new(inner));
-        assert!(
-            parent.validate_attenuation(&child).is_err(),
-            "Not -> Not must always be rejected"
+            parent.validate_attenuation(&child).is_ok(),
+            "Not(Exact) -> Not(Exact) identity must be valid"
         );
     }
 }
 
-/// Verify that AnyOf -> AnyOf attenuation is always rejected.
+/// Exhaustively verify AnyOf -> AnyOf attenuation soundness over all subset pairs.
+///
+/// A child `Any` is a valid attenuation of a parent `Any` iff every child branch
+/// is covered by some parent branch (child's allowed set ⊆ parent's allowed set).
+/// The complement — any child branch not in the parent — must be rejected.
 #[test]
-fn exhaustive_anyof_anyof_always_rejected() {
+fn exhaustive_anyof_anyof_soundness() {
     let constraints: Vec<Constraint> = ATOMS
         .iter()
         .map(|a| Constraint::Exact(Exact::new(*a)))
         .collect();
 
-    // Try all pairs of non-empty subsets of these constraints
     let n = constraints.len();
     for pmask in 1..(1u32 << n) {
         let parent_clauses: Vec<_> = (0..n)
@@ -593,12 +639,38 @@ fn exhaustive_anyof_anyof_always_rejected() {
                 .filter(|i| cmask & (1 << i) != 0)
                 .map(|i| constraints[i].clone())
                 .collect();
-            let child = Constraint::Any(Any::new(child_clauses));
+            let child = Constraint::Any(Any::new(child_clauses.clone()));
 
-            assert!(
-                parent.validate_attenuation(&child).is_err(),
-                "AnyOf -> AnyOf must always be rejected"
-            );
+            // child is valid iff its branches are a subset of parent's (cmask ⊆ pmask)
+            let is_subset = (cmask & pmask) == cmask;
+
+            if is_subset {
+                assert!(
+                    parent.validate_attenuation(&child).is_ok(),
+                    "AnyOf -> AnyOf must be accepted when child branches are a subset of parent \
+                     (pmask={pmask:#b}, cmask={cmask:#b})"
+                );
+                // Monotonicity: every value accepted by child must also be accepted by parent
+                for atom in ATOMS {
+                    let v = ConstraintValue::String(atom.to_string());
+                    let child_accepts = child_clauses
+                        .iter()
+                        .any(|c| c.matches(&v).unwrap_or(false));
+                    if child_accepts {
+                        assert!(
+                            parent.matches(&v).unwrap_or(false),
+                            "Monotonicity violated: child accepts '{atom}' but parent does not \
+                             (pmask={pmask:#b}, cmask={cmask:#b})"
+                        );
+                    }
+                }
+            } else {
+                assert!(
+                    parent.validate_attenuation(&child).is_err(),
+                    "AnyOf -> AnyOf must be rejected when child has branches outside parent \
+                     (pmask={pmask:#b}, cmask={cmask:#b})"
+                );
+            }
         }
     }
 }

--- a/tenuo-core/tests/conformance.rs
+++ b/tenuo-core/tests/conformance.rs
@@ -14,14 +14,23 @@ fn test_alloy_all_and_any_conformance() {
         Constraint::Exact(Exact::new("req2")),
     ]);
 
-    // Child drops req2 (valid attenuation for Any)
+    // Child drops req2: valid attenuation because child's allowed set ⊆ parent's allowed set.
     let child_any_valid = Any::new(vec![Constraint::Exact(Exact::new("req1"))]);
-    // The current spec actually expects a strict subset, though Rust might throw IncompatibleConstraintTypes
-    // due to the catch-all. The conformance oracle asserts the exact current Rust behavior.
     assert!(
         Constraint::Any(parent_any.clone())
             .validate_attenuation(&Constraint::Any(child_any_valid))
-            .is_err() // Matches the Rust code's conservative fallback discussed in Alloy issue 1
+            .is_ok()
+    );
+
+    // Child adds a branch not in parent: must be rejected (privilege escalation).
+    let child_any_invalid = Any::new(vec![
+        Constraint::Exact(Exact::new("req1")),
+        Constraint::Exact(Exact::new("req3")), // not in parent
+    ]);
+    assert!(
+        Constraint::Any(parent_any.clone())
+            .validate_attenuation(&Constraint::Any(child_any_invalid))
+            .is_err()
     );
 
     // Alloy Theorem: All -> All permits adding clauses

--- a/tenuo-core/tests/constraint_types.rs
+++ b/tenuo-core/tests/constraint_types.rs
@@ -1,14 +1,16 @@
 //! Tests for constraint types that were missing coverage.
 //!
 //! These tests ensure all 16 constraint types from protocol-spec-v1.md
-//! are properly tested in the Rust core.
+//! are properly tested in the Rust core, covering both:
+//! - `matches()` (authorization-time enforcement)
+//! - `validate_attenuation()` (delegation-time monotonicity) via Warrant chains
 
 use std::time::Duration;
 use tenuo::{
-    constraints::{Cidr, ConstraintSet, UrlPattern},
+    constraints::{Cidr, ConstraintSet, Subpath, UrlPattern, UrlSafe},
     crypto::SigningKey,
     warrant::Warrant,
-    wire, Any, Constraint, Exact, Pattern, Range,
+    wire, All, Any, Constraint, Contains, Exact, Not, NotOneOf, OneOf, Pattern, Range, Subset,
 };
 
 // =============================================================================
@@ -308,17 +310,87 @@ fn test_any_attenuation() {
         .holder(child_keypair.public_key())
         .build(&keypair);
 
-    // Note: Any constraint attenuation (removing options) may not be supported
-    // in all implementations. This test documents the current behavior.
-    // Per spec (wire-format-v1.md): "Any: child may remove clauses"
-    // If this fails, it indicates the attenuation logic doesn't support
-    // removing options from Any constraints.
-    if child_result.is_err() {
-        eprintln!(
-            "Note: Any constraint narrowing not supported: {:?}",
-            child_result.err()
-        );
-    }
+    assert!(
+        child_result.is_ok(),
+        "Any narrowing (subset of branches) must be a valid attenuation: {:?}",
+        child_result.err()
+    );
+}
+
+#[test]
+fn test_any_attenuation_identity() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let env_any = Any::new([
+        Constraint::Exact(Exact::new("dev")),
+        Constraint::Exact(Exact::new("staging")),
+    ]);
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("env", env_any.clone());
+
+    let parent = Warrant::builder()
+        .capability("deploy", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("env", env_any);
+
+    let child_result = parent
+        .attenuate()
+        .capability("deploy", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        child_result.is_ok(),
+        "Any identity pass-through must be valid: {:?}",
+        child_result.err()
+    );
+}
+
+#[test]
+fn test_any_attenuation_escalation_rejected() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert(
+        "env",
+        Any::new([Constraint::Exact(Exact::new("dev"))]),
+    );
+
+    let parent = Warrant::builder()
+        .capability("deploy", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child tries to add "prod" which parent never allowed
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert(
+        "env",
+        Any::new([
+            Constraint::Exact(Exact::new("dev")),
+            Constraint::Exact(Exact::new("prod")),
+        ]),
+    );
+
+    let child_result = parent
+        .attenuate()
+        .capability("deploy", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        child_result.is_err(),
+        "Any escalation (adding a new branch) must be rejected"
+    );
 }
 
 // =============================================================================
@@ -412,6 +484,686 @@ fn test_any_wire_roundtrip() {
     assert!(status_constraint.matches(&"pending".into()).unwrap());
     assert!(status_constraint.matches(&"approved".into()).unwrap());
     assert!(!status_constraint.matches(&"rejected".into()).unwrap());
+}
+
+// =============================================================================
+// Not Constraint Attenuation Tests (Type ID: 14)
+// =============================================================================
+
+#[test]
+fn test_not_attenuation_identity() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let inner = Not::new(Constraint::Exact(Exact::new("admin")));
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("role", inner.clone());
+
+    let parent = Warrant::builder()
+        .capability("admin_panel", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("role", inner);
+
+    let result = parent
+        .attenuate()
+        .capability("admin_panel", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_ok(),
+        "Not identity pass-through must be valid: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_not_attenuation_wider_inner_valid() {
+    // Parent: Not(Exact("admin")) — excludes only "admin"
+    // Child:  Not(OneOf(["admin","root"])) — excludes more, so child is MORE restrictive
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("role", Not::new(Constraint::Exact(Exact::new("admin"))));
+
+    let parent = Warrant::builder()
+        .capability("access", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert(
+        "role",
+        Not::new(Constraint::OneOf(OneOf::new(vec!["admin", "root"]))),
+    );
+
+    let result = parent
+        .attenuate()
+        .capability("access", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_ok(),
+        "Not(Exact) -> Not(OneOf[superset]) must be valid attenuation: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_not_attenuation_narrower_inner_rejected() {
+    // Parent: Not(OneOf(["admin","root"])) — excludes two values
+    // Child:  Not(Exact("admin")) — excludes only one, accepts more values → escalation
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert(
+        "role",
+        Not::new(Constraint::OneOf(OneOf::new(vec!["admin", "root"]))),
+    );
+
+    let parent = Warrant::builder()
+        .capability("access", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("role", Not::new(Constraint::Exact(Exact::new("admin"))));
+
+    let result = parent
+        .attenuate()
+        .capability("access", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_err(),
+        "Not(OneOf[wide]) -> Not(Exact) must be rejected (child accepts more values)"
+    );
+}
+
+// =============================================================================
+// UrlSafe Constraint Attenuation Tests (allow_ports gap)
+// =============================================================================
+
+#[test]
+fn test_urlsafe_attenuation_port_narrowing_valid() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let parent_safe = {
+        let mut u = UrlSafe::new();
+        u.allow_ports = Some(vec![443, 8443]);
+        u
+    };
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("url", parent_safe);
+
+    let parent = Warrant::builder()
+        .capability("fetch", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child narrows to only port 443
+    let child_safe = {
+        let mut u = UrlSafe::new();
+        u.allow_ports = Some(vec![443]);
+        u
+    };
+
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("url", child_safe);
+
+    let result = parent
+        .attenuate()
+        .capability("fetch", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_ok(),
+        "UrlSafe port subset must be valid attenuation: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_urlsafe_attenuation_port_escalation_rejected() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let parent_safe = {
+        let mut u = UrlSafe::new();
+        u.allow_ports = Some(vec![443]);
+        u
+    };
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("url", parent_safe);
+
+    let parent = Warrant::builder()
+        .capability("fetch", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child drops the port allowlist entirely (allows any port — widening)
+    let child_safe = UrlSafe::new();
+
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("url", child_safe);
+
+    let result = parent
+        .attenuate()
+        .capability("fetch", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_err(),
+        "Dropping allow_ports from parent must be rejected (privilege escalation)"
+    );
+}
+
+#[test]
+fn test_urlsafe_attenuation_port_new_port_rejected() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let parent_safe = {
+        let mut u = UrlSafe::new();
+        u.allow_ports = Some(vec![443]);
+        u
+    };
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("url", parent_safe);
+
+    let parent = Warrant::builder()
+        .capability("fetch", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child adds port 80 which parent never allowed
+    let child_safe = {
+        let mut u = UrlSafe::new();
+        u.allow_ports = Some(vec![443, 80]);
+        u
+    };
+
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("url", child_safe);
+
+    let result = parent
+        .attenuate()
+        .capability("fetch", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_err(),
+        "Adding a new port not in parent allow_ports must be rejected"
+    );
+}
+
+// =============================================================================
+// Subpath Case-Sensitivity Attenuation Tests
+// =============================================================================
+
+#[test]
+fn test_subpath_case_sensitive_to_insensitive_rejected() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let parent_path = Subpath::with_options("/data", true, true).unwrap();
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("path", parent_path);
+
+    let parent = Warrant::builder()
+        .capability("read_file", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child switches to case-insensitive — WIDER (accepts paths differing only by case)
+    let child_path = Subpath::with_options("/data", false, true).unwrap();
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("path", child_path);
+
+    let result = parent
+        .attenuate()
+        .capability("read_file", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_err(),
+        "case-sensitive parent -> case-insensitive child must be rejected (child accepts more paths)"
+    );
+}
+
+#[test]
+fn test_subpath_case_insensitive_to_sensitive_valid() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let parent_path = Subpath::with_options("/data", false, true).unwrap();
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("path", parent_path);
+
+    let parent = Warrant::builder()
+        .capability("read_file", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child switches to case-sensitive — NARROWER (accepts fewer paths)
+    let child_path = Subpath::with_options("/data", true, true).unwrap();
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("path", child_path);
+
+    let result = parent
+        .attenuate()
+        .capability("read_file", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_ok(),
+        "case-insensitive parent -> case-sensitive child must be valid (child is more restrictive): {:?}",
+        result.err()
+    );
+}
+
+// =============================================================================
+// NotOneOf Attenuation Tests (Type ID: 6)
+// =============================================================================
+
+#[test]
+fn test_notoneof_attenuation_adding_exclusions_valid() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    // Parent excludes only "admin"
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("role", NotOneOf::new(vec!["admin"]));
+
+    let parent = Warrant::builder()
+        .capability("action", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child excludes "admin" AND "root" — more restrictive
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("role", NotOneOf::new(vec!["admin", "root"]));
+
+    let result = parent
+        .attenuate()
+        .capability("action", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_ok(),
+        "NotOneOf adding more exclusions must be valid attenuation: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_notoneof_attenuation_removing_exclusion_rejected() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    // Parent excludes "admin" AND "root"
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("role", NotOneOf::new(vec!["admin", "root"]));
+
+    let parent = Warrant::builder()
+        .capability("action", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child only excludes "admin" — drops "root", accepting more values
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("role", NotOneOf::new(vec!["admin"]));
+
+    let result = parent
+        .attenuate()
+        .capability("action", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_err(),
+        "NotOneOf removing an exclusion must be rejected (child accepts more values)"
+    );
+}
+
+// =============================================================================
+// Contains Attenuation Tests (Type ID: 11)
+// =============================================================================
+
+#[test]
+fn test_contains_attenuation_adding_required_valid() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    // Parent requires "read" scope
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("scopes", Contains::new(["read"]));
+
+    let parent = Warrant::builder()
+        .capability("api_call", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child requires "read" AND "audit" — more restrictive
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("scopes", Contains::new(["read", "audit"]));
+
+    let result = parent
+        .attenuate()
+        .capability("api_call", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_ok(),
+        "Contains adding more required values must be valid attenuation: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_contains_attenuation_removing_required_rejected() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    // Parent requires "read" AND "audit"
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("scopes", Contains::new(["read", "audit"]));
+
+    let parent = Warrant::builder()
+        .capability("api_call", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child drops "audit" requirement — less restrictive
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("scopes", Contains::new(["read"]));
+
+    let result = parent
+        .attenuate()
+        .capability("api_call", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_err(),
+        "Contains removing a required value must be rejected"
+    );
+}
+
+// =============================================================================
+// Subset Attenuation Tests (Type ID: 12)
+// =============================================================================
+
+#[test]
+fn test_subset_attenuation_narrowing_valid() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("methods", Subset::new(["GET", "POST", "PUT"]));
+
+    let parent = Warrant::builder()
+        .capability("api_call", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child restricts to read-only
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("methods", Subset::new(["GET"]));
+
+    let result = parent
+        .attenuate()
+        .capability("api_call", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_ok(),
+        "Subset narrowing must be valid attenuation: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_subset_attenuation_adding_value_rejected() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert("methods", Subset::new(["GET"]));
+
+    let parent = Warrant::builder()
+        .capability("api_call", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child adds DELETE — not in parent
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert("methods", Subset::new(["GET", "DELETE"]));
+
+    let result = parent
+        .attenuate()
+        .capability("api_call", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_err(),
+        "Subset adding a value not in parent must be rejected"
+    );
+}
+
+// =============================================================================
+// All Constraint Attenuation Tests (Type ID: 12)
+// =============================================================================
+
+#[test]
+fn test_all_attenuation_adding_clause_valid() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    // Parent: All([OneOf(["read","write"])])
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert(
+        "op",
+        All::new([Constraint::OneOf(OneOf::new(vec!["read", "write"]))]),
+    );
+
+    let parent = Warrant::builder()
+        .capability("storage", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child: All([OneOf(["read","write"]), Exact("read")]) — more restrictive (AND narrows)
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert(
+        "op",
+        All::new([
+            Constraint::OneOf(OneOf::new(vec!["read", "write"])),
+            Constraint::Exact(Exact::new("read")),
+        ]),
+    );
+
+    let result = parent
+        .attenuate()
+        .capability("storage", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_ok(),
+        "All adding a clause must be valid attenuation: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_all_attenuation_dropping_clause_rejected() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    // Parent: All([OneOf(["read","write"]), Pattern("log-*")])
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert(
+        "op",
+        All::new([
+            Constraint::OneOf(OneOf::new(vec!["read", "write"])),
+            Constraint::Pattern(Pattern::new("log-*").unwrap()),
+        ]),
+    );
+
+    let parent = Warrant::builder()
+        .capability("storage", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    // Child drops the Pattern clause — less restrictive
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert(
+        "op",
+        All::new([Constraint::OneOf(OneOf::new(vec!["read", "write"]))]),
+    );
+
+    let result = parent
+        .attenuate()
+        .capability("storage", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_err(),
+        "All dropping a clause must be rejected (less restrictive than parent)"
+    );
+}
+
+// =============================================================================
+// Range Constraint Attenuation Tests (Type ID: 7)
+// =============================================================================
+
+#[test]
+fn test_range_attenuation_narrowing_valid() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert(
+        "size_bytes",
+        Range::new(Some(0.0), Some(10_000_000.0)).unwrap(),
+    );
+
+    let parent = Warrant::builder()
+        .capability("upload", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert(
+        "size_bytes",
+        Range::new(Some(0.0), Some(1_000_000.0)).unwrap(),
+    );
+
+    let result = parent
+        .attenuate()
+        .capability("upload", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_ok(),
+        "Range narrowing must be valid attenuation: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_range_attenuation_widening_rejected() {
+    let keypair = SigningKey::generate();
+    let child_keypair = SigningKey::generate();
+
+    let mut parent_constraints = ConstraintSet::new();
+    parent_constraints.insert(
+        "size_bytes",
+        Range::new(Some(0.0), Some(1_000_000.0)).unwrap(),
+    );
+
+    let parent = Warrant::builder()
+        .capability("upload", parent_constraints)
+        .ttl(Duration::from_secs(3600))
+        .holder(keypair.public_key())
+        .build(&keypair)
+        .unwrap();
+
+    let mut child_constraints = ConstraintSet::new();
+    child_constraints.insert(
+        "size_bytes",
+        Range::new(Some(0.0), Some(10_000_000.0)).unwrap(),
+    );
+
+    let result = parent
+        .attenuate()
+        .capability("upload", child_constraints)
+        .holder(child_keypair.public_key())
+        .build(&keypair);
+
+    assert!(
+        result.is_err(),
+        "Range widening must be rejected"
+    );
 }
 
 // =============================================================================

--- a/tenuo-core/tests/test_vectors.rs
+++ b/tenuo-core/tests/test_vectors.rs
@@ -3144,3 +3144,306 @@ fn test_vector_a25_5_urlpattern_constraint() {
         "A.25.5 UrlPattern should reject wrong path"
     );
 }
+
+// =============================================================================
+// A.26: Constraint enforcement through the full chain (via check_chain)
+//
+// The A.25.x tests call .matches() directly on constraint structs.
+// These tests verify constraints are enforced correctly when the full
+// warrant → wire encode → decode → check_chain pipeline is used.
+// A serialization or constraint-lookup bug would be caught here but not in A.25.
+// =============================================================================
+
+/// Test Vector A.26.1: AnyOf constraint enforced through full check_chain
+///
+/// Covers the AnyOf constraint that was previously undelegable (fixed bug).
+#[test]
+fn test_vector_a26_1_anyof_constraint_check_chain() {
+    use std::collections::HashMap;
+    use std::time::Duration;
+    use tenuo::constraints::UrlSafe;
+
+    let issuer = control_plane_key();
+    let holder = worker_key();
+
+    let mut cs = ConstraintSet::new();
+    cs.insert(
+        "env",
+        constraints::Any::new([
+            Constraint::Exact(Exact::new("staging")),
+            Constraint::Exact(Exact::new("production")),
+        ]),
+    );
+
+    let warrant = Warrant::builder()
+        .capability("deploy", cs)
+        .ttl(Duration::from_secs(3600))
+        .holder(holder.public_key())
+        .build(&issuer)
+        .expect("A.26.1 should build warrant");
+
+    // Encode → decode to exercise the wire path
+    let encoded = wire::encode(&warrant).expect("A.26.1 encode");
+    let decoded = wire::decode(&encoded).expect("A.26.1 decode");
+
+    let mut data_plane = DataPlane::new();
+    data_plane.trust_issuer("root", issuer.public_key());
+
+    // Accepted value
+    let mut args: HashMap<String, ConstraintValue> = HashMap::new();
+    args.insert("env".to_string(), ConstraintValue::String("staging".to_string()));
+    let pop = decoded.sign(&holder, "deploy", &args).unwrap();
+    let result = data_plane.check_chain(std::slice::from_ref(&decoded), "deploy", &args, Some(&pop), &[]);
+    assert!(result.is_ok(), "A.26.1 AnyOf should accept 'staging': {:?}", result.err());
+
+    // Rejected value (not in Any)
+    let mut bad_args: HashMap<String, ConstraintValue> = HashMap::new();
+    bad_args.insert("env".to_string(), ConstraintValue::String("dev".to_string()));
+    let pop = decoded.sign(&holder, "deploy", &bad_args).unwrap();
+    let result = data_plane.check_chain(std::slice::from_ref(&decoded), "deploy", &bad_args, Some(&pop), &[]);
+    assert!(result.is_err(), "A.26.1 AnyOf should reject 'dev' (not in set)");
+
+    let _ = UrlSafe::new(); // suppress unused import warning
+}
+
+/// Test Vector A.26.2: Not constraint enforced through full check_chain
+#[test]
+fn test_vector_a26_2_not_constraint_check_chain() {
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    let issuer = control_plane_key();
+    let holder = worker_key();
+
+    let mut cs = ConstraintSet::new();
+    cs.insert(
+        "role",
+        constraints::Not::new(Constraint::OneOf(OneOf::new(vec!["admin", "root"]))),
+    );
+
+    let warrant = Warrant::builder()
+        .capability("action", cs)
+        .ttl(Duration::from_secs(3600))
+        .holder(holder.public_key())
+        .build(&issuer)
+        .expect("A.26.2 should build warrant");
+
+    let encoded = wire::encode(&warrant).expect("A.26.2 encode");
+    let decoded = wire::decode(&encoded).expect("A.26.2 decode");
+
+    let mut data_plane = DataPlane::new();
+    data_plane.trust_issuer("root", issuer.public_key());
+
+    // Accepted: "user" is not in the exclusion list
+    let mut args: HashMap<String, ConstraintValue> = HashMap::new();
+    args.insert("role".to_string(), ConstraintValue::String("user".to_string()));
+    let pop = decoded.sign(&holder, "action", &args).unwrap();
+    let result = data_plane.check_chain(std::slice::from_ref(&decoded), "action", &args, Some(&pop), &[]);
+    assert!(result.is_ok(), "A.26.2 Not should accept 'user': {:?}", result.err());
+
+    // Rejected: "admin" is in the exclusion list
+    let mut bad_args: HashMap<String, ConstraintValue> = HashMap::new();
+    bad_args.insert("role".to_string(), ConstraintValue::String("admin".to_string()));
+    let pop = decoded.sign(&holder, "action", &bad_args).unwrap();
+    let result = data_plane.check_chain(std::slice::from_ref(&decoded), "action", &bad_args, Some(&pop), &[]);
+    assert!(result.is_err(), "A.26.2 Not should reject 'admin' (in exclusion list)");
+}
+
+/// Test Vector A.26.3: UrlSafe constraint enforced through full check_chain
+///
+/// Counterpart to A.25.1 but exercises the full warrant + wire pipeline.
+#[test]
+fn test_vector_a26_3_urlsafe_check_chain() {
+    use std::collections::HashMap;
+    use std::time::Duration;
+    use tenuo::constraints::UrlSafe;
+
+    let issuer = control_plane_key();
+    let holder = worker_key();
+
+    let mut cs = ConstraintSet::new();
+    cs.insert("url", UrlSafe::new());
+
+    let warrant = Warrant::builder()
+        .capability("fetch", cs)
+        .ttl(Duration::from_secs(3600))
+        .holder(holder.public_key())
+        .build(&issuer)
+        .expect("A.26.3 build");
+
+    let encoded = wire::encode(&warrant).expect("A.26.3 encode");
+    let decoded = wire::decode(&encoded).expect("A.26.3 decode");
+
+    let mut data_plane = DataPlane::new();
+    data_plane.trust_issuer("root", issuer.public_key());
+
+    // External URL: accepted
+    let mut args: HashMap<String, ConstraintValue> = HashMap::new();
+    args.insert("url".to_string(), ConstraintValue::String("https://api.example.com/data".to_string()));
+    let pop = decoded.sign(&holder, "fetch", &args).unwrap();
+    let result = data_plane.check_chain(std::slice::from_ref(&decoded), "fetch", &args, Some(&pop), &[]);
+    assert!(result.is_ok(), "A.26.3 UrlSafe should accept external URL: {:?}", result.err());
+
+    // AWS metadata SSRF attempt: rejected
+    let mut bad_args: HashMap<String, ConstraintValue> = HashMap::new();
+    bad_args.insert("url".to_string(), ConstraintValue::String("http://169.254.169.254/latest/meta-data/".to_string()));
+    let pop = decoded.sign(&holder, "fetch", &bad_args).unwrap();
+    let result = data_plane.check_chain(std::slice::from_ref(&decoded), "fetch", &bad_args, Some(&pop), &[]);
+    assert!(result.is_err(), "A.26.3 UrlSafe should reject SSRF metadata URL");
+}
+
+// =============================================================================
+// A.27: Capability escalation — child claims capability parent never granted
+//
+// Tests the I4 invariant from the other direction: A.11 tests that a constraint
+// can't be widened on an existing capability. A.27 tests that a child can't
+// *add* a brand new capability that the parent never held.
+// =============================================================================
+
+/// Test Vector A.27: Child warrant cannot introduce a new capability
+#[test]
+fn test_vector_a27_child_cannot_add_capability() {
+    use std::time::Duration;
+
+    let issuer = control_plane_key();
+    let orchestrator = orchestrator_key();
+    let worker = worker_key();
+
+    // Parent grants only "read_file"
+    let mut parent_cs = ConstraintSet::new();
+    parent_cs.insert("path", Constraint::Pattern(Pattern::new("/data/*").unwrap()));
+    let parent = Warrant::builder()
+        .capability("read_file", parent_cs)
+        .ttl(Duration::from_secs(3600))
+        .holder(orchestrator.public_key())
+        .build(&issuer)
+        .expect("A.27 parent build");
+
+    // Child attempts to grant "write_file" which parent never had
+    let mut child_cs = ConstraintSet::new();
+    child_cs.insert("path", Constraint::Pattern(Pattern::new("/data/*").unwrap()));
+
+    let result = parent
+        .attenuate()
+        .capability("write_file", child_cs)
+        .holder(worker.public_key())
+        .build(&orchestrator);
+
+    assert!(
+        result.is_err(),
+        "A.27 child must not be able to grant a capability the parent never held"
+    );
+}
+
+// =============================================================================
+// A.28: Multi-hop attenuation + constraint enforcement
+//
+// A.3 builds a 3-level chain but only calls verify_chain. This test verifies
+// that a constraint attenuated across multiple hops is correctly enforced at
+// authorization time against actual call arguments.
+// =============================================================================
+
+/// Test Vector A.28: Attenuated constraint enforced at the leaf of a multi-hop chain
+#[test]
+fn test_vector_a28_multihop_attenuation_enforced() {
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    let issuer = control_plane_key();
+    let orchestrator = orchestrator_key();
+    let worker = worker_key();
+
+    // Level 0: broad Pattern — any file under /data/
+    let mut cs0 = ConstraintSet::new();
+    cs0.insert("path", Constraint::Pattern(Pattern::new("/data/*").unwrap()));
+    let root = Warrant::builder()
+        .capability("read_file", cs0)
+        .ttl(Duration::from_secs(3600))
+        .holder(orchestrator.public_key())
+        .build(&issuer)
+        .expect("A.28 root build");
+
+    // Level 1: narrow to /data/reports/
+    let mut cs1 = ConstraintSet::new();
+    cs1.insert("path", Constraint::Pattern(Pattern::new("/data/reports/*").unwrap()));
+    let mid = root
+        .attenuate()
+        .capability("read_file", cs1)
+        .holder(worker.public_key())
+        .build(&orchestrator)
+        .expect("A.28 mid build");
+
+    let mut data_plane = DataPlane::new();
+    data_plane.trust_issuer("root", issuer.public_key());
+
+    // Valid at leaf: path within /data/reports/
+    let mut valid_args: HashMap<String, ConstraintValue> = HashMap::new();
+    valid_args.insert("path".to_string(), ConstraintValue::String("/data/reports/q3.pdf".to_string()));
+    let pop = mid.sign(&worker, "read_file", &valid_args).unwrap();
+    let result = data_plane.check_chain(&[root.clone(), mid.clone()], "read_file", &valid_args, Some(&pop), &[]);
+    assert!(
+        result.is_ok(),
+        "A.28 path within attenuated range must be accepted: {:?}",
+        result.err()
+    );
+
+    // Invalid at leaf: path within /data/ but NOT /data/reports/ — rejected by mid's constraint
+    let mut bad_args: HashMap<String, ConstraintValue> = HashMap::new();
+    bad_args.insert("path".to_string(), ConstraintValue::String("/data/logs/app.log".to_string()));
+    let pop = mid.sign(&worker, "read_file", &bad_args).unwrap();
+    let result = data_plane.check_chain(&[root.clone(), mid.clone()], "read_file", &bad_args, Some(&pop), &[]);
+    assert!(
+        result.is_err(),
+        "A.28 path outside attenuated range must be rejected even if it satisfies root"
+    );
+}
+
+// =============================================================================
+// A.29: Missing constrained field at authorization time
+//
+// If a warrant requires field "path" (with Subpath constraint) but the caller
+// provides no "path" argument, the check must fail — the field is effectively
+// unconstrained from the caller's perspective but the warrant demands it.
+// =============================================================================
+
+/// Test Vector A.29: Authorization fails when a constrained field is absent from call arguments
+#[test]
+fn test_vector_a29_missing_constrained_field_rejected() {
+    use std::collections::HashMap;
+    use std::time::Duration;
+    use tenuo::constraints::Subpath;
+
+    let issuer = control_plane_key();
+    let holder = worker_key();
+
+    let mut cs = ConstraintSet::new();
+    cs.insert("path", Subpath::new("/data").expect("valid subpath"));
+
+    let warrant = Warrant::builder()
+        .capability("read_file", cs)
+        .ttl(Duration::from_secs(3600))
+        .holder(holder.public_key())
+        .build(&issuer)
+        .expect("A.29 build");
+
+    let encoded = wire::encode(&warrant).expect("A.29 encode");
+    let decoded = wire::decode(&encoded).expect("A.29 decode");
+
+    let mut data_plane = DataPlane::new();
+    data_plane.trust_issuer("root", issuer.public_key());
+
+    // Caller provides no arguments at all (missing the required "path" field)
+    let empty_args: HashMap<String, ConstraintValue> = HashMap::new();
+    let pop = decoded.sign(&holder, "read_file", &empty_args).unwrap();
+    let result = data_plane.check_chain(
+        std::slice::from_ref(&decoded),
+        "read_file",
+        &empty_args,
+        Some(&pop),
+        &[],
+    );
+    assert!(
+        result.is_err(),
+        "A.29 constrained field absent from call arguments must be rejected"
+    );
+}


### PR DESCRIPTION
## Summary

- **P1:** `DataPlane::check_chain` now evaluates `tenuo.approval_gates` before requiring multi-sig approvals. Ungated calls on gated warrants no longer fail unexpectedly.
- **P2:** Fix `u64` overflow in approval expiry check (`saturating_add`).
- **P2:** `Warrant::validate()` rejects `min_approvals > required_approvers.len()` instead of silently capping to a weaker threshold during verification.
- **P3:** `compute_request_hash` now uses a CBOR array preimage instead of `|`-joined strings. **Breaking:** existing signed approvals will not verify against the new hash.
- Fixes `AnyOf`/`Not` constraint attenuation (missing `validate_attenuation` impls), `UrlSafe` port allowlist check, and `Subpath` case-sensitivity direction.
- Adds test vectors A.26–A.29; syncs `docs/constraints.md`, `wire-format-v1.md`, and IETF draft-01 to match.