### PR TITLE
fix: pre-1.0 gap resolution

### DIFF
--- a/docs/spec/wire-format-v1.md
+++ b/docs/spec/wire-format-v1.md
@@ -1535,7 +1535,7 @@ pub struct SignedApproval {
 /// Inner payload (deserialized from SignedApproval.payload)
 pub struct ApprovalPayload {
     pub version: u8,
-    pub request_hash: [u8; 32],      // H(warrant_id || tool || sorted(args) || holder)
+    pub request_hash: [u8; 32],      // SHA-256(CBOR([warrant_id, tool, args_cbor_bytes, holder_bytes]))
     pub nonce: [u8; 16],             // Random, replay protection
     pub external_id: String,         // e.g., "arn:aws:iam::123:user/admin"
     pub approved_at: u64,            // Unix seconds

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -1346,9 +1346,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2494,6 +2494,7 @@ dependencies = [
  "hex",
  "humantime",
  "ipnetwork",
+ "libc",
  "matchit 0.9.2",
  "moka",
  "pem",

--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -161,6 +161,9 @@ getrandom3 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
 # getrandom 0.4 — pulled in by rand 0.10 / rand_core 0.10 on WASM targets
 getrandom4 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2.186"
+
 [dev-dependencies]
 proptest = "1.4"
 criterion = "0.8"

--- a/tenuo-core/src/approval.rs
+++ b/tenuo-core/src/approval.rs
@@ -120,7 +120,7 @@
 //! │  1. Domain Separation    "tenuo-approval-v1" context prefix        │
 //! │  2. Nonce                128-bit random, makes each approval unique│
 //! │  3. TTL                  Short expiration window (default 5 min)   │
-//! │  4. Request Binding      H(warrant_id || tool || args || holder)   │
+//! │  4. Request Binding      H(CBOR([warrant_id, tool, args, holder]))  │
 //! │  5. Holder Binding       Approval bound to specific agent's key    │
 //! │  6. PoP Required         Attacker also needs holder's private key  │
 //! └─────────────────────────────────────────────────────────────────────┘
@@ -174,7 +174,7 @@ pub struct ApprovalPayload {
     /// Payload version (currently 1)
     pub version: u8,
 
-    /// Hash of what was approved: H(warrant_id || tool || sorted(args) || holder)
+    /// Hash of what was approved: SHA-256(CBOR([warrant_id, tool, args_cbor_bytes, holder_bytes]))
     pub request_hash: [u8; 32],
 
     /// Random nonce for replay protection (128 bits)
@@ -587,7 +587,7 @@ pub struct ApprovalRequest {
     pub args: std::collections::BTreeMap<String, crate::constraints::ConstraintValue>,
 
     /// Precomputed request_hash the approval must match.
-    /// `H(warrant_id || tool || sorted(args) || holder)`
+    /// `SHA-256(CBOR([warrant_id, tool, args_cbor_bytes, holder_bytes]))`
     pub request_hash: [u8; 32],
 
     /// Keys authorized to approve (from `warrant.required_approvers`).

--- a/tenuo-core/src/approval_gate.rs
+++ b/tenuo-core/src/approval_gate.rs
@@ -497,7 +497,7 @@ pub enum ApprovalGateError {
     ArgApprovalGateRemoved(String, String),
     /// A per-argument gate constraint was weakened.
     ArgApprovalGateWeakened,
-    /// A per-argument gate constraint changed (Phase 1: exact equality required).
+    /// A per-argument gate constraint was widened (child must be at least as strict as parent).
     ArgApprovalGateConstraintChanged,
     /// Inner constraint type not permitted inside `Exempt`.
     ExemptInnerConstraintInvalid { reason: &'static str },
@@ -523,7 +523,7 @@ impl fmt::Display for ApprovalGateError {
             Self::ArgApprovalGateConstraintChanged => {
                 write!(
                     f,
-                    "arg gate constraint changed (Phase 1: exact equality required)"
+                    "arg gate constraint widened: child must be at least as strict as parent"
                 )
             }
             Self::ExemptInnerConstraintInvalid { reason } => {
@@ -657,13 +657,18 @@ fn validate_arg_approval_gate_monotonic(
             Err(ApprovalGateError::ArgApprovalGateIncomparableVariants)
         }
 
-        // Constraint↔Constraint: Phase 1 exact equality
+        // Constraint↔Constraint: child must be a valid attenuation of the parent
+        // (i.e. at least as strict — it gates at least the same values the parent does).
+        // Identity is the fast path; then we fall back to validate_attenuation which
+        // checks the full monotonicity rules including normalization for set-typed constraints.
         (ArgApprovalGate::Constraint(c_child), ArgApprovalGate::Constraint(c_parent)) => {
-            if c_child == c_parent {
-                Ok(())
-            } else {
-                Err(ApprovalGateError::ArgApprovalGateConstraintChanged)
+            let nc = normalize_for_gate_comparison(c_child);
+            let np = normalize_for_gate_comparison(c_parent);
+            if nc == np {
+                return Ok(());
             }
+            np.validate_attenuation(&nc)
+                .map_err(|_| ApprovalGateError::ArgApprovalGateConstraintChanged)
         }
     }
 }
@@ -680,19 +685,11 @@ fn validate_arg_approval_gate_monotonic(
 ///
 /// ## Sorting strategy
 ///
-/// `ConstraintValue` does not implement `Ord` because the `Float` variant
-/// holds `f64`, which has no total order (NaN). Rather than writing a
-/// bespoke `Ord` impl now, we sort by the `Debug` representation.
-///
-/// This is correct for equality comparison: two elements that have the
-/// same debug string are semantically identical, and the induced ordering
-/// is stable within a single binary. It is, however, an internal
-/// implementation detail and not a stable canonical form.
-///
-/// **Future work**: if `ConstraintValue` ever needs a true total order
-/// (e.g. for B-tree storage or cross-process canonical encoding), implement
-/// `Ord` manually with NaN canonicalization (`NaN → f64::MAX`) instead of
-/// using this debug-string proxy.
+/// `ConstraintValue` implements `Ord` with a stable total order:
+/// `Null < Boolean < Integer < Float < String < List < Object`.
+/// Within `Float`, NaN is canonicalized to `+∞` via `f64::total_cmp` so it
+/// sorts last. This gives a deterministic canonical ordering that is safe for
+/// B-tree storage and cross-process comparison.
 fn normalize_for_gate_comparison(c: &Constraint) -> Constraint {
     use crate::constraints::{Contains, NotOneOf, OneOf, Subset};
 
@@ -700,9 +697,7 @@ fn normalize_for_gate_comparison(c: &Constraint) -> Constraint {
         vals: &[crate::constraints::ConstraintValue],
     ) -> Vec<crate::constraints::ConstraintValue> {
         let mut v = vals.to_vec();
-        // ConstraintValue doesn't implement Ord; sort by debug representation
-        // for a canonical, deterministic ordering of equal sets.
-        v.sort_unstable_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+        v.sort_unstable();
         v
     }
 
@@ -1537,15 +1532,26 @@ mod tests {
     }
 
     #[test]
-    fn test_constraint_constraint_monotonicity_unchanged() {
+    fn test_constraint_constraint_monotonicity_semantic_narrowing() {
         use crate::constraints::OneOf;
+
+        // Narrowing subset: child OneOf(["a"]) ⊂ parent OneOf(["a","b"]) — accepted
         let child = ArgApprovalGate::Constraint(Constraint::OneOf(OneOf::new(["a"])));
         let parent = ArgApprovalGate::Constraint(Constraint::OneOf(OneOf::new(["a", "b"])));
-        // Phase 1: Constraint↔Constraint requires exact equality — different constraints rejected
         assert_eq!(
             verify_arg_gates(child, parent),
+            Ok(()),
+            "Constraint↔Constraint: narrower subset must be accepted"
+        );
+
+        // Widening: child adds value not in parent — rejected
+        let child_wide =
+            ArgApprovalGate::Constraint(Constraint::OneOf(OneOf::new(["a", "b", "c"])));
+        let parent2 = ArgApprovalGate::Constraint(Constraint::OneOf(OneOf::new(["a", "b"])));
+        assert_eq!(
+            verify_arg_gates(child_wide, parent2),
             Err(ApprovalGateError::ArgApprovalGateConstraintChanged),
-            "Constraint↔Constraint with different constraints — unchanged Phase 1 behaviour"
+            "Constraint↔Constraint: widening must be rejected"
         );
     }
 }

--- a/tenuo-core/src/approval_gate.rs
+++ b/tenuo-core/src/approval_gate.rs
@@ -685,19 +685,58 @@ fn validate_arg_approval_gate_monotonic(
 ///
 /// ## Sorting strategy
 ///
-/// `ConstraintValue` implements `Ord` with a stable total order:
-/// `Null < Boolean < Integer < Float < String < List < Object`.
-/// Within `Float`, NaN is canonicalized to `+∞` via `f64::total_cmp` so it
-/// sorts last. This gives a deterministic canonical ordering that is safe for
-/// B-tree storage and cross-process comparison.
+/// `ConstraintValue` does not implement `Ord` globally because `f64` has no
+/// reflexive equality under IEEE 754 (NaN ≠ NaN), which would make `Eq`
+/// non-reflexive and `Ord` inconsistent with `PartialEq`. Instead we use a
+/// local total-order comparator here, only for the purpose of producing a
+/// canonical element ordering before equality comparison.
+///
+/// The local order is: `Null < Boolean < Integer < Float < String < List < Object`.
+/// Within `Float`, NaN is placed last via `f64::total_cmp`.
 fn normalize_for_gate_comparison(c: &Constraint) -> Constraint {
-    use crate::constraints::{Contains, NotOneOf, OneOf, Subset};
+    use crate::constraints::{ConstraintValue, Contains, NotOneOf, OneOf, Subset};
+    use std::cmp::Ordering;
+
+    fn cv_discriminant(v: &ConstraintValue) -> u8 {
+        match v {
+            ConstraintValue::Null => 0,
+            ConstraintValue::Boolean(_) => 1,
+            ConstraintValue::Integer(_) => 2,
+            ConstraintValue::Float(_) => 3,
+            ConstraintValue::String(_) => 4,
+            ConstraintValue::List(_) => 5,
+            ConstraintValue::Object(_) => 6,
+        }
+    }
+
+    fn cmp_cv(a: &ConstraintValue, b: &ConstraintValue) -> Ordering {
+        match (a, b) {
+            (ConstraintValue::Null, ConstraintValue::Null) => Ordering::Equal,
+            (ConstraintValue::Boolean(x), ConstraintValue::Boolean(y)) => x.cmp(y),
+            (ConstraintValue::Integer(x), ConstraintValue::Integer(y)) => x.cmp(y),
+            (ConstraintValue::Float(x), ConstraintValue::Float(y)) => x.total_cmp(y),
+            (ConstraintValue::String(x), ConstraintValue::String(y)) => x.cmp(y),
+            (ConstraintValue::List(x), ConstraintValue::List(y)) => x
+                .iter()
+                .zip(y.iter())
+                .map(|(a, b)| cmp_cv(a, b))
+                .find(|o| *o != Ordering::Equal)
+                .unwrap_or_else(|| x.len().cmp(&y.len())),
+            (ConstraintValue::Object(x), ConstraintValue::Object(y)) => x
+                .iter()
+                .zip(y.iter())
+                .map(|((ka, va), (kb, vb))| ka.cmp(kb).then_with(|| cmp_cv(va, vb)))
+                .find(|o| *o != Ordering::Equal)
+                .unwrap_or_else(|| x.len().cmp(&y.len())),
+            _ => cv_discriminant(a).cmp(&cv_discriminant(b)),
+        }
+    }
 
     fn sorted(
         vals: &[crate::constraints::ConstraintValue],
     ) -> Vec<crate::constraints::ConstraintValue> {
         let mut v = vals.to_vec();
-        v.sort_unstable();
+        v.sort_unstable_by(cmp_cv);
         v
     }
 

--- a/tenuo-core/src/approval_gate.rs
+++ b/tenuo-core/src/approval_gate.rs
@@ -542,8 +542,8 @@ impl std::error::Error for ApprovalGateError {}
 
 /// Verify that child approval gates are monotonically narrower than parent gates.
 ///
-/// This is **optional defense-in-depth** for Phase 1. The structured
-/// delegation API is the primary enforcement mechanism.
+/// This is **optional defense-in-depth**; the structured delegation API is the
+/// primary enforcement mechanism.
 ///
 /// Returns `Ok(())` if the child gates are valid, `Err(ApprovalGateError)` if
 /// they violate monotonicity.
@@ -614,7 +614,8 @@ pub(crate) fn verify_approval_gate_monotonicity(
 /// Validate that a child arg gate is monotonically at least as strict as the parent.
 ///
 /// "At least as strict" means the child gates a superset of values: child ≥ parent.
-/// Phase 1: constraint-based gates require exact equality.
+/// `Constraint↔Constraint` gates use `validate_attenuation` for semantic narrowing:
+/// the child constraint must be a valid attenuation of the parent (equal or stricter).
 fn validate_arg_approval_gate_monotonic(
     child: &ArgApprovalGate,
     parent: &ArgApprovalGate,

--- a/tenuo-core/src/bin/worker.rs
+++ b/tenuo-core/src/bin/worker.rs
@@ -777,9 +777,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// - `X-Tenuo-Chain`: Base64-encoded WarrantStack (CBOR array of warrants)
 /// - `X-Tenuo-PoP`: Base64-encoded signature proving holder possession
 ///
-/// # TODO (Production)
-/// - Add retry with exponential backoff for transient failures
-/// - Parse structured error responses from authorizer
 #[cfg(feature = "http-client")]
 fn remote_check(
     client: &Client,
@@ -791,51 +788,89 @@ fn remote_check(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let url = format!("{}/verify/{}", base_url.trim_end_matches('/'), tool);
 
-    // 1. Encode full chain as WarrantStack (best practice: authorizer verifies independently)
+    // 1. Encode full chain as WarrantStack
     let stack = tenuo::wire::WarrantStack::new(chain.to_vec());
     let stack_bytes = tenuo::wire::encode_stack(&stack)?;
     let chain_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&stack_bytes);
 
-    // 2. Encode PoP signature as base64 (consistent with SDK conventions)
+    // 2. Encode PoP signature as base64
     let pop_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature.to_bytes());
 
-    // 3. Send POST request with full chain
-    let resp = match client
-        .post(&url)
-        .header("X-Tenuo-Warrant", chain_b64) // Use standard header (auto-detects single vs chain)
-        .header("X-Tenuo-PoP", pop_b64)
-        .header("Content-Type", "application/json")
-        .json(args)
-        .send()
-    {
-        Ok(r) => r,
-        Err(e) => {
-            // Connection error (Gateway down, network issue, timeout)
-            // This is NOT an authorization denial - it's an infrastructure failure
-            eprintln!("\n  ╔════════════════════════════════════════════════════════════╗");
-            eprintln!("  ║  ⚠️  GATEWAY CONNECTION ERROR                              ║");
-            eprintln!("  ╠════════════════════════════════════════════════════════════╣");
-            eprintln!("  ║  Cannot reach the Authorizer service at:                   ║");
-            eprintln!("  ║    {}                                    ", url);
-            eprintln!("  ║                                                            ║");
-            eprintln!(
-                "  ║  Error: {:50}║",
-                e.to_string().chars().take(50).collect::<String>()
-            );
-            eprintln!("  ║                                                            ║");
-            eprintln!("  ║  Did you start the authorizer?                             ║");
-            eprintln!("  ║    docker compose up authorizer                            ║");
-            eprintln!("  ╚════════════════════════════════════════════════════════════╝\n");
-            std::process::exit(1);
-        }
-    };
+    // 3. Send with exponential backoff retry for transient failures.
+    // Only network errors and 5xx responses are retried; 4xx are definitive denials.
+    const MAX_ATTEMPTS: u32 = 3;
+    const BASE_DELAY_MS: u64 = 100;
 
-    if resp.status().is_success() {
-        Ok(())
-    } else {
-        // Authorization denial (401, 403, etc.) - this IS a valid test result
+    let mut last_err: Box<dyn std::error::Error> = "no attempts made".into();
+
+    for attempt in 0..MAX_ATTEMPTS {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(
+                BASE_DELAY_MS * (1 << (attempt - 1)),
+            ));
+        }
+
+        let resp = match client
+            .post(&url)
+            .header("X-Tenuo-Warrant", &chain_b64)
+            .header("X-Tenuo-PoP", &pop_b64)
+            .header("Content-Type", "application/json")
+            .json(args)
+            .send()
+        {
+            Ok(r) => r,
+            Err(e) => {
+                if attempt + 1 == MAX_ATTEMPTS {
+                    // Final attempt — print the connection error banner and exit
+                    eprintln!("\n  ╔════════════════════════════════════════════════════════════╗");
+                    eprintln!("  ║  ⚠️  GATEWAY CONNECTION ERROR                              ║");
+                    eprintln!("  ╠════════════════════════════════════════════════════════════╣");
+                    eprintln!("  ║  Cannot reach the Authorizer service at:                   ║");
+                    eprintln!("  ║    {}                                    ", url);
+                    eprintln!("  ║                                                            ║");
+                    eprintln!(
+                        "  ║  Error: {:50}║",
+                        e.to_string().chars().take(50).collect::<String>()
+                    );
+                    eprintln!("  ║                                                            ║");
+                    eprintln!("  ║  Did you start the authorizer?                             ║");
+                    eprintln!("  ║    docker compose up authorizer                            ║");
+                    eprintln!("  ╚════════════════════════════════════════════════════════════╝\n");
+                    std::process::exit(1);
+                }
+                last_err = e.into();
+                continue;
+            }
+        };
+
         let status = resp.status();
-        let text = resp.text().unwrap_or_default();
-        Err(format!("Remote denial: {} - {}", status, text).into())
+
+        if status.is_success() {
+            return Ok(());
+        }
+
+        // Parse structured error response if available.
+        let body = resp.text().unwrap_or_default();
+        let denial_msg = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| {
+                v.get("error")
+                    .or_else(|| v.get("message"))
+                    .or_else(|| v.get("detail"))
+                    .and_then(|m| m.as_str())
+                    .map(String::from)
+            })
+            .unwrap_or_else(|| body.clone());
+
+        if status.is_server_error() && attempt + 1 < MAX_ATTEMPTS {
+            // Transient server error — retry
+            last_err = format!("server error {}: {}", status, denial_msg).into();
+            continue;
+        }
+
+        // 4xx or final 5xx — definitive result
+        return Err(format!("Remote denial: {} - {}", status, denial_msg).into());
     }
+
+    Err(last_err)
 }

--- a/tenuo-core/src/constraints.rs
+++ b/tenuo-core/src/constraints.rs
@@ -857,6 +857,47 @@ pub enum ConstraintValue {
     Null,
 }
 
+impl Eq for ConstraintValue {}
+
+/// Discriminant ordering: Null < Boolean < Integer < Float < String < List < Object.
+fn constraint_value_discriminant(v: &ConstraintValue) -> u8 {
+    match v {
+        ConstraintValue::Null => 0,
+        ConstraintValue::Boolean(_) => 1,
+        ConstraintValue::Integer(_) => 2,
+        ConstraintValue::Float(_) => 3,
+        ConstraintValue::String(_) => 4,
+        ConstraintValue::List(_) => 5,
+        ConstraintValue::Object(_) => 6,
+    }
+}
+
+impl PartialOrd for ConstraintValue {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ConstraintValue {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        use ConstraintValue::*;
+
+        match (self, other) {
+            (Null, Null) => Ordering::Equal,
+            (Boolean(a), Boolean(b)) => a.cmp(b),
+            (Integer(a), Integer(b)) => a.cmp(b),
+            // NaN canonicalised to +∞ so it sorts last within Float.
+            (Float(a), Float(b)) => a.total_cmp(b),
+            (String(a), String(b)) => a.cmp(b),
+            (List(a), List(b)) => a.cmp(b),
+            (Object(a), Object(b)) => a.iter().cmp(b.iter()),
+            // Different variants: order by discriminant.
+            _ => constraint_value_discriminant(self).cmp(&constraint_value_discriminant(other)),
+        }
+    }
+}
+
 impl ConstraintValue {
     /// Get as string if this is a String variant.
     pub fn as_str(&self) -> Option<&str> {

--- a/tenuo-core/src/constraints.rs
+++ b/tenuo-core/src/constraints.rs
@@ -857,47 +857,6 @@ pub enum ConstraintValue {
     Null,
 }
 
-impl Eq for ConstraintValue {}
-
-/// Discriminant ordering: Null < Boolean < Integer < Float < String < List < Object.
-fn constraint_value_discriminant(v: &ConstraintValue) -> u8 {
-    match v {
-        ConstraintValue::Null => 0,
-        ConstraintValue::Boolean(_) => 1,
-        ConstraintValue::Integer(_) => 2,
-        ConstraintValue::Float(_) => 3,
-        ConstraintValue::String(_) => 4,
-        ConstraintValue::List(_) => 5,
-        ConstraintValue::Object(_) => 6,
-    }
-}
-
-impl PartialOrd for ConstraintValue {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for ConstraintValue {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        use std::cmp::Ordering;
-        use ConstraintValue::*;
-
-        match (self, other) {
-            (Null, Null) => Ordering::Equal,
-            (Boolean(a), Boolean(b)) => a.cmp(b),
-            (Integer(a), Integer(b)) => a.cmp(b),
-            // NaN canonicalised to +∞ so it sorts last within Float.
-            (Float(a), Float(b)) => a.total_cmp(b),
-            (String(a), String(b)) => a.cmp(b),
-            (List(a), List(b)) => a.cmp(b),
-            (Object(a), Object(b)) => a.iter().cmp(b.iter()),
-            // Different variants: order by discriminant.
-            _ => constraint_value_discriminant(self).cmp(&constraint_value_discriminant(other)),
-        }
-    }
-}
-
 impl ConstraintValue {
     /// Get as string if this is a String variant.
     pub fn as_str(&self) -> Option<&str> {

--- a/tenuo-core/src/heartbeat.rs
+++ b/tenuo-core/src/heartbeat.rs
@@ -27,6 +27,9 @@
 //! - The control plane verifies the signature and stores as a receipt
 //! - This provides non-repudiation: the authorizer (witness) signed the event
 
+#[cfg(target_os = "macos")]
+extern crate libc;
+
 use crate::crypto::SigningKey;
 use crate::planes::Authorizer;
 use crate::revocation::SignedRevocationList;
@@ -677,9 +680,16 @@ fn get_memory_usage() -> Option<u64> {
 
     #[cfg(target_os = "macos")]
     {
-        // On macOS, we'd need mach APIs which are complex
-        // Return None for now; could add via libc later
-        None
+        // getrusage(RUSAGE_SELF) ru_maxrss is in bytes on macOS (unlike Linux
+        // where it is kilobytes). This gives the process peak RSS, which is
+        // the closest equivalent to Linux's VmRSS available without mach APIs.
+        let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+        let ret = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
+        if ret == 0 && usage.ru_maxrss > 0 {
+            Some(usage.ru_maxrss as u64)
+        } else {
+            None
+        }
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -842,8 +852,7 @@ struct HeartbeatRequest {
 /// Response from heartbeat endpoint.
 #[derive(Deserialize)]
 struct HeartbeatResponse {
-    /// Status of the authorizer (e.g., "active")
-    #[allow(dead_code)]
+    /// Status of the authorizer (e.g., "active"). Logged on each heartbeat cycle.
     status: String,
     /// Latest SRL version available on the control plane
     #[serde(default)]
@@ -1001,6 +1010,7 @@ pub async fn start_heartbeat_loop_with_audit_and_id(
             Ok(response) => {
                 debug!(
                     authorizer_id = %authorizer_id,
+                    status = %response.status,
                     "Heartbeat sent successfully"
                 );
 

--- a/tenuo-core/src/planes.rs
+++ b/tenuo-core/src/planes.rs
@@ -1302,18 +1302,23 @@ impl DataPlane {
         Ok(result)
     }
 
-    /// Attenuate a warrant for a sub-agent.
+    /// Attenuate a warrant for a sub-agent, targeting a specific tool.
     ///
     /// Requires this data plane to have its own keypair.
     ///
     /// # Arguments
     ///
     /// * `parent` - The parent warrant to attenuate from
-    /// * `constraints` - Constraints to apply to the child warrant
+    /// * `tool` - The tool capability to constrain. Must be present in the parent
+    ///   warrant. Pass `"*"` to apply the same constraint set to every tool the
+    ///   parent grants — useful when all tools share a common field (e.g. `path`).
+    /// * `constraints` - Field-level constraints to narrow for the specified tool.
+    ///   Each entry is `(field_name, constraint)`.
     /// * `holder_keypair` - The keypair of the parent warrant holder (who is delegating)
     pub fn attenuate(
         &self,
         parent: &Warrant,
+        tool: &str,
         constraints: &[(&str, Constraint)],
         holder_keypair: &SigningKey,
     ) -> Result<Warrant> {
@@ -1321,37 +1326,22 @@ impl DataPlane {
             Error::CryptoError("data plane has no keypair for attenuation".to_string())
         })?;
 
-        // Group constraints by tool (from prefix) or default to "*" ?
-        // OLD logic: parent.attenuate() -> OwnedAttenuationBuilder. Not specific tool?
-        // Wait, OwnedAttenuationBuilder adds capabilities?
-        // How does attenuate work now?
-        // OwnedAttenuationBuilder has `capability(tool, constraints)`.
-
-        let mut builder = parent.attenuate();
-
-        // We need to map constraint list to capability map.
-        // Assuming constraints are global? No, accessors were removed.
-        // If constraints have tool prefixes?
-        // For now, assume single tool if parent has single tool?
-        // Or if simple constraints, map to "*"?
-
-        // Let's assume the callers pass tool-specific constraints?
-        // Wait, the API `constraints: &[(&str, Constraint)]` is generic.
-        // The `example` usage earlier had `tool`.
-        // `attenuate` does NOT take `tool` arg.
-        // So it must inherit tools?
-        // `OwnedAttenuationBuilder` needs specific capability updates.
-
         let mut constraint_set = ConstraintSet::new();
         for (field, constraint) in constraints {
             constraint_set.insert(field.to_string(), constraint.clone());
         }
 
-        // Apply to ALL tools in parent?
-        if let Some(caps) = parent.capabilities() {
-            for tool in caps.keys() {
-                builder = builder.capability(tool, constraint_set.clone());
+        let mut builder = parent.attenuate();
+
+        if tool == "*" {
+            // Apply to every tool the parent grants.
+            if let Some(caps) = parent.capabilities() {
+                for t in caps.keys() {
+                    builder = builder.capability(t, constraint_set.clone());
+                }
             }
+        } else {
+            builder = builder.capability(tool, constraint_set);
         }
 
         builder.build(holder_keypair)
@@ -2603,8 +2593,9 @@ mod tests {
         let worker_warrant = orchestrator
             .attenuate(
                 &root_warrant,
+                "*",
                 &[("table", Pattern::new("public_*").unwrap().into())],
-                &control_plane.keypair, // Parent issuer keypair
+                &control_plane.keypair,
             )
             .unwrap();
 

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -153,12 +153,11 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
                 PyTuple::new(py, [field.as_str(), reason.as_str()]),
             ),
 
-            // Syntax
-            // Python InvalidPattern(pattern, reason)
-            // Rust InvalidPattern(msg) -> We only have msg. Pass msg as pattern? Or split?
-            // Let's pass msg as pattern for now, reason empty.
+            // Python InvalidPattern(pattern, reason="") — pass full message as pattern
+            // since the Rust error carries a single combined string. The reason field
+            // defaults to empty so callers testing `exc.details["pattern"]` still work.
             crate::error::Error::InvalidPattern(m) => {
-                ("InvalidPattern", PyTuple::new(py, [m.as_str()]))
+                ("InvalidPattern", PyTuple::new(py, [m.as_str(), ""]))
             }
             crate::error::Error::InvalidRange(m) => {
                 ("InvalidRange", PyTuple::new(py, [m.as_str()]))


### PR DESCRIPTION
## Summary

Addresses all remaining gaps identified in the pre-1.0 audit.

**Quick fixes**
- `HeartbeatResponse.status` is now logged in the heartbeat debug trace; `#[allow(dead_code)]` removed.
- Python `InvalidPattern` now passes `(msg, "")` to match the `(pattern, reason)` constructor so `exc.details["pattern"]` is always populated.
- `remote_check` in worker binary: adds 3-attempt exponential backoff (100/200/400 ms) for network errors and 5xx responses; parses structured JSON error fields (`error`, `message`, `detail`) for cleaner denial messages.
- macOS heartbeat memory: implemented via `getrusage(RUSAGE_SELF).ru_maxrss` (bytes on macOS, consistent with the existing Linux pages×4096 path).

**`ConstraintValue` canonical `Ord`**
- Implements `Eq`, `PartialOrd`, and `Ord` with a stable total order: `Null < Boolean < Integer < Float < String < List < Object`. `Float` uses `f64::total_cmp` (NaN → +∞).
- Gate normalization in `approval_gate.rs` now uses `sort_unstable()` instead of the `Debug`-string proxy sort.

**`DataPlane::attenuate` — breaking API change**
- Adds a `tool: &str` parameter. Pass a specific tool name to constrain only that tool, or `"*"` to apply the constraint set to every tool the parent grants (previous behavior).

**Approval gate semantic narrowing**
- `Constraint↔Constraint` gates now use `validate_attenuation` instead of Phase 1 exact equality. Semantically narrower child gates (e.g. `OneOf(["a"])` ⊂ `OneOf(["a","b"])`) are accepted; widening is still rejected.