### PR TITLE
fix: distinct InsufficientApprovals signal across integrations

### DIFF
--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -610,6 +610,41 @@ This simplifies proxy and load-balancer configurations (one header to forward in
 
 ---
 
+## Human Approval
+
+Define gates and approvers on the warrant. On retry, attach `SignedApproval` objects via header or param. See [Human Approvals](approvals.md) for minting and signing.
+
+```python
+from tenuo.a2a import A2AClient, ApprovalRequiredError, InsufficientApprovalsError
+from tenuo.approval import sign_approval
+
+try:
+    result = await client.send_task(skill="transfer", arguments={"amount": 5000})
+except ApprovalRequiredError as e:
+    # -32019 — gate fired; e.data has request_hash, min_approvals, skill
+    signed = sign_approval(approval_request, approver_key)  # from your UI flow
+    result = await client.send_task(
+        skill="transfer",
+        arguments={"amount": 5000},
+        approvals=[signed],  # encoded into X-Tenuo-Approvals
+    )
+except InsufficientApprovalsError as e:
+    # -32020 — collect additional signatures; check e.data["required"] vs ["received"]
+    ...
+```
+
+**Wire encoding:** `X-Tenuo-Approvals` = `base64(JSON(["base64(CBOR SignedApproval)", ...]))`. Same outer wrapper as FastAPI.
+
+| A2A JSON-RPC | Wire code | When | Key `data` fields |
+|--------------|-----------|------|-------------------|
+| **-32019** | 1707 | Gate fired, no approvals | `request_hash`, `min_approvals`, `skill` |
+| **-32020** | 1700 | Partial multi-sig | `required`, `received` |
+| **-32021** | 1701 | Invalid / malformed approval | `reason` |
+
+> **Note:** A2A `-32002` is **invalid signature** (1100), not approval. Do not reuse MCP's `-32002` semantics on A2A.
+
+---
+
 ## Error Handling
 
 All A2A errors inherit from `A2AError` and map to JSON-RPC error codes with canonical wire codes:
@@ -627,6 +662,9 @@ from tenuo.a2a import (
     ConstraintViolationError,  # -32008: Argument violates constraint
     ChainInvalidError,         # -32010: Delegation chain validation failed
     KeyMismatchError,          # -32012: Public key doesn't match pinned key
+    ApprovalRequiredError,     # -32019: Approval gate fired
+    InsufficientApprovalsError,  # -32020: Partial multi-sig
+    InvalidApprovalError,      # -32021: Bad signed approval
 )
 
 try:
@@ -671,6 +709,9 @@ This enables:
 | -32007 | 1500 | Tool not authorized |
 | -32008 | 1501 | Constraint violation |
 | -32010 | 1405 | Chain invalid |
+| -32019 | 1707 | Approval required (gate fired) |
+| -32020 | 1700 | Insufficient approvals (partial multi-sig) |
+| -32021 | 1701 | Invalid approval |
 
 See [wire format specification](./spec/wire-format-v1#appendix-a-error-codes) for the complete list.
 

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -20,7 +20,7 @@ warrant = (Warrant.mint_builder()
     .capability("transfer")
     .approval_gates({"transfer": None})       # this tool needs approval
     .required_approvers([approver_key.public_key])
-    .approval_threshold(1)
+    .min_approvals(1)
     .holder(agent_key.public_key)
     .ttl(3600)
     .mint(control_key)
@@ -36,13 +36,15 @@ result = enforce_tool_call(
 )
 ```
 
-**Three things to configure:**
+**Three things to configure on the warrant:**
 
-| On the warrant | Purpose |
-|----------------|---------|
+| Method | Purpose |
+|--------|---------|
 | `.approval_gates({...})` | Which tool calls trigger approval |
 | `.required_approvers([...])` | Who may sign |
-| `.approval_threshold(n)` | How many valid signatures (m-of-n) |
+| `.min_approvals(n)` | How many valid signatures (m-of-n) |
+
+> **Naming:** use `.min_approvals()` when **minting**. On issued warrants, read the threshold with `warrant.approval_threshold()`. The wire field is `min_approvals`.
 
 **Two ways to supply approvals at runtime:**
 
@@ -58,22 +60,22 @@ Gates are evaluated per call. Listing `required_approvers` alone does **not** re
 ## Approval Gates
 
 ```python
+from tenuo_core import Exact
+
 warrant = (Warrant.mint_builder()
     .capability("search")
-    .capability("transfer")
+    .capability("restart_service")
     .approval_gates({
-        "transfer": None,   # all transfer calls
-        # "search" — no gate, proceeds without approval
+        "restart_service": {"environment": Exact("production")},  # prod only
+        # whole-tool gate: "transfer": None
     })
     .required_approvers([approver_key.public_key])
-    .approval_threshold(1)
+    .min_approvals(1)
     .holder(agent_key.public_key)
     .ttl(3600)
     .mint(control_key)
 )
 ```
-
-Per-argument gates are supported — see [MCP approval gates](mcp.md#approval-gates) for constraint-keyed examples.
 
 ---
 
@@ -84,7 +86,7 @@ warrant = (Warrant.mint_builder()
     .capability("deploy_prod")
     .approval_gates({"deploy_prod": None})
     .required_approvers([alice.public_key, bob.public_key, carol.public_key])
-    .approval_threshold(2)   # any 2-of-3
+    .min_approvals(2)   # any 2-of-3
     .holder(agent_key.public_key)
     .ttl(3600)
     .mint(control_key)
@@ -104,25 +106,54 @@ Call without approvals
   → threshold met → proceed
 ```
 
-Sign approvals with `sign_approval(request, approver_key)` or a built-in handler (`cli_prompt`, custom Slack handler, etc.).
+Sign with `sign_approval(request, approver_key)` or a built-in handler (`cli_prompt`, etc.). Default approval TTL: handler `ttl_seconds` → **300s**.
+
+**Branch on the signal, not the message:**
+- First attempt → look for `request_hash` (or `ApprovalRequired` / `approval_required`)
+- Partial multi-sig → look for `got`/`need` or `required`/`received` (or `InsufficientApprovals`)
+
+---
+
+## Wire Format (retry payloads)
+
+Each `SignedApproval` is CBOR bytes. Adapters differ in how they wrap the list:
+
+| Integration | Where | Encoding |
+|-------------|-------|----------|
+| **MCP** | `params._meta.tenuo.approvals` | JSON array of **base64(CBOR)** strings — no outer wrapper |
+| **FastAPI / A2A** | `X-Tenuo-Approvals` header (A2A also accepts `x-tenuo-approvals` param) | **base64(JSON array of base64(CBOR) strings)** |
+| **Temporal** | `x-tenuo-approvals` activity header | **JSON array of base64(CBOR) strings** — no outer base64 wrapper |
+
+```python
+import base64, json
+from tenuo.approval import sign_approval
+
+signed = sign_approval(request, approver_key)
+
+# MCP / Temporal — array of base64 CBOR blobs
+approvals_wire = [base64.b64encode(signed.to_bytes()).decode("ascii")]
+
+# FastAPI / A2A — outer base64 JSON wrapper
+header_value = base64.b64encode(json.dumps(approvals_wire).encode()).decode()
+```
+
+See integration guides: [MCP](mcp.md#approval-gates), [FastAPI](fastapi.md#headers), [A2A](a2a.md#human-approval), [Temporal](temporal-reference.md#set_activity_approvals---pre-supply-multisig-approvals).
 
 ---
 
 ## Signals by Integration
-
-Use these to branch client/workflow retry logic. **Do not** parse denial message strings.
 
 | Integration | First call (gate, no approvals) | Partial multi-sig | Retry with |
 |-------------|--------------------------------|-------------------|------------|
 | **In-process** | `tenuo.approval.ApprovalRequired` | `tenuo.exceptions.InsufficientApprovals` | Same call + `approvals=[...]` or `approval_handler` |
 | **MCP** | JSON-RPC `-32002` + `request_hash` | JSON-RPC `-32002` + `got` / `need` | `_meta.tenuo.approvals` |
 | **FastAPI** | HTTP **409** `error: "approval_required"` + `request_hash` | HTTP **409** `error: "insufficient_approvals"` + `got` / `need` | `X-Tenuo-Approvals` header |
-| **A2A** | JSON-RPC **-32019** + `request_hash` | JSON-RPC **-32020** + `required` / `received` | Approvals in request metadata |
+| **A2A** | JSON-RPC **-32019** + `request_hash` | JSON-RPC **-32020** + `required` / `received` | `X-Tenuo-Approvals` header or `x-tenuo-approvals` param |
 | **Temporal** | `ApplicationError.type == "approval_required"` | `ApplicationError.type == "insufficient_approvals"` | `x-tenuo-approvals` header or `set_activity_approvals()` |
 
-Scope denials (wrong tool, constraint, expired warrant) use different codes — see each integration guide.
+Scope denials use different codes — see each integration guide.
 
-**Field names:** Python exceptions use `required` / `received` in `.details`. HTTP and MCP retry payloads use `got` / `need`. A2A uses `required` / `received`.
+**Field names:** Python `.details` use `required` / `received`. HTTP and MCP retry payloads use `got` / `need`. A2A error `data` uses `required` / `received`.
 
 ---
 
@@ -163,7 +194,7 @@ guard = (GuardBuilder()
     .build())
 ```
 
-See [LangChain](langchain.md), [CrewAI](crewai.md), [OpenAI](openai.md), [AutoGen](autogen.md), [Google ADK](google-adk.md), [MCP](mcp.md), [FastAPI](fastapi.md), [Temporal](temporal-reference.md).
+See [LangChain](langchain.md), [CrewAI](crewai.md), [OpenAI](openai.md), [AutoGen](autogen.md), [Google ADK](google-adk.md), [MCP](mcp.md), [FastAPI](fastapi.md), [A2A](a2a.md#human-approval), [Temporal](temporal-reference.md#human-approval).
 
 ### Temporal
 
@@ -203,7 +234,7 @@ def slack_approval(request):
     return sign_approval(request, approver_key, external_id=reaction.user, ttl_seconds=60)
 ```
 
-Async handlers are supported. Default approval TTL: handler `ttl_seconds` → **300s** fallback.
+Async handlers are supported.
 
 ---
 
@@ -223,26 +254,11 @@ from tenuo.approval import ApprovalRequired, ApprovalDenied, cli_prompt
 from tenuo.exceptions import InsufficientApprovals, ApprovalGateTriggered
 ```
 
-`InsufficientApprovals` message shape: `Insufficient approvals: required 2, received 1 [rejected: ...]`
-
 ---
 
 ## Cryptographic Model
 
-Every approval binds to `(warrant_id, tool, args, holder)` via SHA-256:
-
-```python
-from tenuo import compute_request_hash
-
-hash = compute_request_hash(
-    warrant_id=warrant.id,
-    tool="transfer",
-    args={"amount": 50000, "to": "alice"},
-    holder=agent_key.public_key,
-)
-```
-
-`SignedApproval` = Ed25519 signature over `ApprovalPayload` (`request_hash`, `nonce`, `expires_at`, ...). Rust core verifies signature, hash, expiry (30s clock tolerance), approver trust, deduplication, and threshold.
+Every approval binds to `(warrant_id, tool, args, holder)` via SHA-256 (`compute_request_hash`). `SignedApproval` = Ed25519 over `ApprovalPayload`. Rust verifies signature, hash, expiry (30s clock tolerance), approver trust, deduplication, and threshold.
 
 ---
 

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -2,114 +2,23 @@
 
 > **Cryptographically verified human-in-the-loop authorization for AI agent tool calls.**
 
-Warrants define *what* an agent can do — including *which* tool calls require human approval, *who* can approve, and *how many* must agree. Every approval is cryptographically signed; there is no unsigned path.
-
----
-
-## Architecture
-
-```
-Tool Call ──► Rust Core verifies warrant ──► Approval gate fires?
-              (PoP, expiration, constraints)        |
-                                              no gate → proceed
-                                              gate fires → invoke handler
-                                                    |
-                                              handler(s) sign → collect approvals
-                                                    |
-                                              Rust core verifies signatures
-                                              + hash binding + expiry + trust
-                                                    |
-                                              threshold met (m-of-n) → proceed
-                                              threshold not met → raise error
-```
-
-**Key separation**:
-
-| Concern | Mechanism | Where |
-|---------|-----------|-------|
-| *What* an agent can do | Warrant capabilities + constraints | Rust core |
-| *When* a human must confirm | Approval gates (in warrant) | Rust core |
-| *Who* can confirm | `required_approvers` (in warrant) | Rust core |
-| *How many* must confirm | `approval_threshold` (in warrant) | Rust core |
-| *Proof* of confirmation | SignedApproval (Ed25519) | Rust core |
-| *How* confirmation happens | `approval_handler` callback | Python adapter |
-
----
-
-## Cryptographic Model
-
-### Request Hash
-
-Every approval is bound to a specific `(warrant_id, tool, args, holder)` tuple via a SHA-256 request hash computed in the Rust core:
-
-```python
-from tenuo import compute_request_hash
-
-hash = compute_request_hash(
-    warrant_id="tnu_wrt_...",
-    tool="transfer",
-    args={"amount": 50000, "to": "alice"},
-    holder=agent_key.public_key,  # binds to specific agent
-)
-# Returns 32-byte SHA-256 hash
-```
-
-The hash ensures:
-- An approval for `transfer(amount=50000)` cannot be reused for `transfer(amount=999999)`
-- An approval for warrant A cannot be replayed against warrant B
-- An approval for agent X cannot be stolen by agent Y (holder binding)
-
-### SignedApproval
-
-The `SignedApproval` is the cryptographic proof. It contains:
-
-| Field | Purpose |
-|-------|---------|
-| `approval_version` | Protocol version (currently 1) |
-| `payload` | CBOR-encoded `ApprovalPayload` (signed content) |
-| `approver_key` | Ed25519 public key of the approver |
-| `signature` | Ed25519 signature over the payload |
-
-The `ApprovalPayload` contains:
-
-| Field | Purpose |
-|-------|---------|
-| `request_hash` | SHA-256 hash binding to the exact call |
-| `nonce` | 16-byte random nonce (replay protection) |
-| `external_id` | Identity of the approver (e.g., email) |
-| `approved_at` | Unix timestamp when approved |
-| `expires_at` | Unix timestamp when the approval expires |
-
-### Verification Pipeline
-
-When `enforce_tool_call()` receives `SignedApproval`(s) from a handler, the Rust core verifies each one:
-
-1. **Signature** — Ed25519 signature check
-2. **Hash match** — `payload.request_hash == expected_hash` (prevents reuse across calls)
-3. **Expiry** — `payload.expires_at > now` (with 30-second clock tolerance for distributed systems)
-4. **Key trust** — `signed.approver_key in warrant.required_approvers()` (prevents rogue approvers)
-5. **Deduplication** — one vote per approver key (prevents double-counting)
-6. **Threshold** — valid approval count >= `warrant.approval_threshold()` (m-of-n satisfaction)
-
-For **1-of-1** failures, the Rust core returns the specific rejection reason (e.g., "request hash mismatch", "approval expired"). For **m-of-n** failures, it returns a summary of all rejection reasons (e.g., "required 2, received 1 [rejected: 1 expired, 1 not trusted]").
+Define **who must approve**, **how many**, and **which calls** in the warrant. Collect `SignedApproval` signatures and retry. There is no unsigned path.
 
 ---
 
 ## Quick Start
 
 ```python
-from tenuo import SigningKey, Warrant, sign_approval, cli_prompt
+from tenuo import SigningKey, Warrant, BoundWarrant, enforce_tool_call, cli_prompt
 
-# 1. Keys
-control_key = SigningKey.generate()    # control plane
-agent_key = SigningKey.generate()      # the AI agent
-approver_key = SigningKey.generate()   # the human approver
+control_key = SigningKey.generate()
+agent_key = SigningKey.generate()
+approver_key = SigningKey.generate()
 
-# 2. Warrant — defines capabilities, approval gates, and who can approve
+# 1. Warrant — capabilities, gates, approvers, threshold
 warrant = (Warrant.mint_builder()
     .capability("transfer")
-    .capability("search")
-    .approval_gates({"transfer": None})  # all transfer calls need approval
+    .approval_gates({"transfer": None})       # this tool needs approval
     .required_approvers([approver_key.public_key])
     .approval_threshold(1)
     .holder(agent_key.public_key)
@@ -117,9 +26,7 @@ warrant = (Warrant.mint_builder()
     .mint(control_key)
 )
 
-# 3. Enforce with an approval handler
-from tenuo import enforce_tool_call, BoundWarrant
-
+# 2. Enforce — handler prompts and signs on gate fire
 result = enforce_tool_call(
     tool_name="transfer",
     tool_args={"amount": 50_000, "to": "alice"},
@@ -127,156 +34,112 @@ result = enforce_tool_call(
     trusted_roots=[control_key.public_key],
     approval_handler=cli_prompt(approver_key=approver_key),
 )
-# The CLI prompts the human. If they type 'y', a SignedApproval is
-# created, verified, and the call proceeds. If 'n', ApprovalDenied is raised.
 ```
+
+**Three things to configure:**
+
+| On the warrant | Purpose |
+|----------------|---------|
+| `.approval_gates({...})` | Which tool calls trigger approval |
+| `.required_approvers([...])` | Who may sign |
+| `.approval_threshold(n)` | How many valid signatures (m-of-n) |
+
+**Two ways to supply approvals at runtime:**
+
+| Mechanism | When |
+|-----------|------|
+| `approval_handler=...` | Prompt or call your approval UI when a gate fires |
+| `approvals=[signed, ...]` | Pre-collected `SignedApproval` objects (retry / out-of-band) |
+
+Gates are evaluated per call. Listing `required_approvers` alone does **not** require approval unless a gate fires for that `(tool, args)`.
 
 ---
 
 ## Approval Gates
 
-Approval gates are defined in the warrant and evaluated by the Rust core. They determine *which* tool calls require human confirmation:
-
 ```python
 warrant = (Warrant.mint_builder()
     .capability("search")
     .capability("transfer")
-    .capability("delete_user")
     .approval_gates({
-        "transfer": None,           # all transfer calls need approval
-        "delete_user": None,        # all delete_user calls need approval
-        # "search" has no gate — proceeds without approval
+        "transfer": None,   # all transfer calls
+        # "search" — no gate, proceeds without approval
     })
     .required_approvers([approver_key.public_key])
+    .approval_threshold(1)
     .holder(agent_key.public_key)
     .ttl(3600)
     .mint(control_key)
 )
 ```
 
-When `enforce_tool_call()` or a framework adapter processes a tool call, the Rust core runs `evaluate_approval_gates(warrant, tool_name, tool_args)`. If a gate fires, the enforcement layer invokes the `approval_handler` to collect signatures.
+Per-argument gates are supported — see [MCP approval gates](mcp.md#approval-gates) for constraint-keyed examples.
 
 ---
 
 ## M-of-N Multi-Sig
 
-Require multiple approvers to sign before a tool call proceeds.
-Approvers and threshold are set **in the warrant** — the single source of truth:
-
 ```python
 warrant = (Warrant.mint_builder()
     .capability("deploy_prod")
-    .capability("transfer_funds")
-    .approval_gates({
-        "deploy_prod": None,
-        "transfer_funds": None,
-    })
+    .approval_gates({"deploy_prod": None})
     .required_approvers([alice.public_key, bob.public_key, carol.public_key])
-    .approval_threshold(2)  # any 2-of-3 must approve
+    .approval_threshold(2)   # any 2-of-3
     .holder(agent_key.public_key)
     .ttl(3600)
     .mint(control_key)
 )
 ```
 
-| `approval_threshold` | `required_approvers` | Meaning |
-|----------------------|----------------------|---------|
-| 1 | `[alice]` | Single approver (default) |
-| 2 | `[alice, bob, carol]` | Any 2 of 3 must approve |
-| 3 | `[alice, bob, carol]` | All 3 must approve |
+---
 
-Validation rules:
-- `approval_threshold` must be >= 1
-- `approval_threshold` must be <= `len(required_approvers)` in the warrant
-- Each approver can only contribute one vote (duplicates are rejected)
+## Retry Flow
+
+```
+Call without approvals
+  → gate fires
+  → caller gets approval_required (or insufficient_approvals if partial)
+  → collect SignedApproval(s) bound to request_hash
+  → retry same call with approvals attached
+  → threshold met → proceed
+```
+
+Sign approvals with `sign_approval(request, approver_key)` or a built-in handler (`cli_prompt`, custom Slack handler, etc.).
 
 ---
 
-## TTL Hierarchy
+## Signals by Integration
 
-Approval TTL (how long a signed approval remains valid) is resolved in priority order:
+Use these to branch client/workflow retry logic. **Do not** parse denial message strings.
 
-```
-1. Handler-level ttl_seconds argument         (highest priority)
-2. 300 seconds (5 minutes)                    (fallback)
-```
+| Integration | First call (gate, no approvals) | Partial multi-sig | Retry with |
+|-------------|--------------------------------|-------------------|------------|
+| **In-process** | `tenuo.approval.ApprovalRequired` | `tenuo.exceptions.InsufficientApprovals` | Same call + `approvals=[...]` or `approval_handler` |
+| **MCP** | JSON-RPC `-32002` + `request_hash` | JSON-RPC `-32002` + `got` / `need` | `_meta.tenuo.approvals` |
+| **FastAPI** | HTTP **409** `error: "approval_required"` + `request_hash` | HTTP **409** `error: "insufficient_approvals"` + `got` / `need` | `X-Tenuo-Approvals` header |
+| **A2A** | JSON-RPC **-32019** + `request_hash` | JSON-RPC **-32020** + `required` / `received` | Approvals in request metadata |
+| **Temporal** | `ApplicationError.type == "approval_required"` | `ApplicationError.type == "insufficient_approvals"` | `x-tenuo-approvals` header or `set_activity_approvals()` |
 
-Examples:
+Scope denials (wrong tool, constraint, expired warrant) use different codes — see each integration guide.
 
-```python
-# Handler with a short window
-handler = cli_prompt(approver_key=ops_key, ttl_seconds=60)
-
-# Handler with the default 5-minute window
-handler = cli_prompt(approver_key=ops_key)
-```
-
-For long-running approval flows (e.g., Slack-based, email-based), pass a longer `ttl_seconds` to `sign_approval()` in your custom handler.
+**Field names:** Python exceptions use `required` / `received` in `.details`. HTTP and MCP retry payloads use `got` / `need`. A2A uses `required` / `received`.
 
 ---
 
 ## Framework Integration
 
-All framework adapters accept `approval_handler` directly — the callback invoked when an approval gate fires.
+Gates and approvers live on the **warrant**. Pass `approval_handler` (or pre-built `approvals`) to the adapter.
 
-### CrewAI
-
-```python
-from tenuo.crewai import GuardBuilder
-from tenuo import SigningKey, cli_prompt
-
-approver_key = SigningKey.generate()
-
-guard = (GuardBuilder()
-    .allow("search", query=Wildcard())
-    .allow("transfer_funds", amount=Range(0, 100_000))
-    .with_warrant(warrant, agent_key)
-    .on_approval(cli_prompt(approver_key=approver_key))
-    .build())
-
-guard.register()
-crew.kickoff()
-```
-
-### AutoGen
+### LangChain
 
 ```python
-from tenuo.autogen import GuardBuilder
+from tenuo.langchain import guard
+from tenuo.approval import cli_prompt
 
-guard = (GuardBuilder()
-    .allow("transfer_funds")
-    .with_warrant(warrant, agent_key)
-    .on_approval(cli_prompt(approver_key=approver_key))
-    .build())
-
-protected = guard.guard_tool(transfer_funds)
-```
-
-### OpenAI
-
-```python
-from tenuo.openai import GuardBuilder
-
-client = (GuardBuilder(openai.OpenAI())
-    .allow("transfer_funds")
-    .with_warrant(warrant, agent_key)
-    .on_approval(cli_prompt(approver_key=approver_key))
-    .build())
-```
-
-### Google ADK
-
-```python
-from tenuo.google_adk import GuardBuilder
-
-guard = (GuardBuilder()
-    .with_warrant(warrant, agent_key)
-    .on_approval(cli_prompt(approver_key=approver_key))
-    .build())
-
-agent = Agent(
-    tools=guard.filter_tools(tools),
-    before_tool_callback=guard.before_tool,
+tools = guard(
+    [search, transfer_funds],
+    bound_warrant,
+    approval_handler=cli_prompt(approver_key=approver_key),
 )
 ```
 
@@ -288,40 +151,23 @@ from tenuo.langgraph import TenuoMiddleware
 middleware = TenuoMiddleware(
     approval_handler=cli_prompt(approver_key=approver_key),
 )
-
-agent = create_agent(
-    model="gpt-4.1",
-    tools=tools,
-    middleware=[middleware],
-)
 ```
 
-### LangChain
+### CrewAI / AutoGen / OpenAI / Google ADK
 
 ```python
-from tenuo.langchain import guard
-
-tools = guard(
-    [search, transfer_funds],
-    bound_warrant,
-    approval_handler=cli_prompt(approver_key=approver_key),
-)
+guard = (GuardBuilder()
+    .allow("transfer_funds", amount=Range(0, 100_000))
+    .with_warrant(warrant, agent_key)
+    .on_approval(cli_prompt(approver_key=approver_key))
+    .build())
 ```
+
+See [LangChain](langchain.md), [CrewAI](crewai.md), [OpenAI](openai.md), [AutoGen](autogen.md), [Google ADK](google-adk.md), [MCP](mcp.md), [FastAPI](fastapi.md), [Temporal](temporal-reference.md).
 
 ### Temporal
 
 ```python
-from temporalio.client import Client
-from tenuo.temporal import (
-    TenuoTemporalPlugin,
-    TenuoPluginConfig,
-    EnvKeyResolver,
-)
-
-# Use whichever KeyResolver matches your deployment
-# (EnvKeyResolver, AWSSecretsManagerKeyResolver, VaultKeyResolver, ...).
-resolver = EnvKeyResolver()
-
 plugin = TenuoTemporalPlugin(
     TenuoPluginConfig(
         key_resolver=resolver,
@@ -329,150 +175,80 @@ plugin = TenuoTemporalPlugin(
         approval_handler=cli_prompt(approver_key=approver_key),
     )
 )
-
-client = await Client.connect("localhost:7233", plugins=[plugin])
 ```
 
 ---
 
 ## Built-in Handlers
 
-| Handler | Signs? | Use Case |
-|---------|--------|----------|
-| `cli_prompt(approver_key=key)` | Yes | Local development — prompts in terminal |
-| `auto_approve(approver_key=key)` | Yes | Testing — signs everything automatically |
-| `auto_deny(reason=...)` | No (raises) | Dry-run / audit mode |
+| Handler | Use Case |
+|---------|----------|
+| `cli_prompt(approver_key=key)` | Local dev — terminal prompt |
+| `auto_approve(approver_key=key)` | Tests — signs automatically |
+| `auto_deny(reason=...)` | Dry-run — always raises |
 
-All signing handlers require the approver's `SigningKey`. This is the key that produces the `SignedApproval`. It should be held by the human (or approval service), not the agent.
+All signing handlers require the approver's `SigningKey` (held by the human or approval service, not the agent).
 
 ---
 
 ## Custom Handlers
 
-Handlers implement a simple protocol: receive an `ApprovalRequest`, return a `SignedApproval` (or raise `ApprovalDenied`).
-
 ```python
 from tenuo.approval import sign_approval, ApprovalDenied
 
 def slack_approval(request):
-    """Post to Slack, wait for reaction."""
-    channel_response = post_to_slack(
-        channel="#approvals",
-        text=f"Approve {request.tool}({request.arguments})?",
-    )
-    reaction = wait_for_reaction(channel_response, timeout=300)
-
+    reaction = wait_for_slack_reaction(request, timeout=300)
     if reaction != "thumbsup":
-        raise ApprovalDenied(request, reason=f"denied in Slack by {reaction.user}")
-
-    return sign_approval(
-        request,
-        approver_key,
-        external_id=reaction.user,
-        ttl_seconds=60,
-    )
+        raise ApprovalDenied(request, reason="denied in Slack")
+    return sign_approval(request, approver_key, external_id=reaction.user, ttl_seconds=60)
 ```
 
-### Async Handlers
-
-Async handlers are supported natively:
-
-```python
-async def async_handler(request):
-    result = await call_approval_service(request)
-    if not result.approved:
-        raise ApprovalDenied(request, reason=result.reason)
-    return sign_approval(request, approver_key)
-```
-
-### The `sign_approval` Helper
-
-The canonical way to produce a `SignedApproval`:
-
-```python
-from tenuo import sign_approval
-
-signed = sign_approval(
-    request,                           # ApprovalRequest
-    approver_key,                      # SigningKey
-    external_id="alice@company.com",   # who approved (metadata)
-    ttl_seconds=300,                   # approval validity window
-)
-```
-
-This handles nonce generation, timestamps, and signing. You can also construct the `ApprovalPayload` and `SignedApproval` manually for full control.
+Async handlers are supported. Default approval TTL: handler `ttl_seconds` → **300s** fallback.
 
 ---
 
 ## Exceptions
 
-All approval exceptions are in `tenuo.approval`:
+| Exception | Module | When |
+|-----------|--------|------|
+| `ApprovalRequired` | `tenuo.approval` | Gate fired; no `approval_handler` / `approvals` (`enforce_tool_call`) |
+| `ApprovalGateTriggered` | `tenuo.exceptions` | Gate fired; direct `Authorizer` / MCP PEP path |
+| `InsufficientApprovals` | `tenuo.exceptions` | Approvals supplied but below threshold |
+| `ApprovalDenied` / `ApprovalTimeout` | `tenuo.approval` | Handler denied or timed out |
+| `ApprovalVerificationError` | `tenuo.approval` | Bad signature, hash mismatch, expired, untrusted key |
+| `InvalidApproval` / `ApprovalExpired` | `tenuo.exceptions` | Invalid or expired signed approval on wire paths |
 
 ```python
-from tenuo.approval import (
-    ApprovalRequired,
-    ApprovalDenied,
-    ApprovalTimeout,
-    ApprovalVerificationError,
+from tenuo.approval import ApprovalRequired, ApprovalDenied, cli_prompt
+from tenuo.exceptions import InsufficientApprovals, ApprovalGateTriggered
+```
+
+`InsufficientApprovals` message shape: `Insufficient approvals: required 2, received 1 [rejected: ...]`
+
+---
+
+## Cryptographic Model
+
+Every approval binds to `(warrant_id, tool, args, holder)` via SHA-256:
+
+```python
+from tenuo import compute_request_hash
+
+hash = compute_request_hash(
+    warrant_id=warrant.id,
+    tool="transfer",
+    args={"amount": 50000, "to": "alice"},
+    holder=agent_key.public_key,
 )
 ```
 
-| Exception | When | Contains |
-|-----------|------|----------|
-| `ApprovalRequired` | Gate triggered but no handler configured | `request` |
-| `ApprovalDenied` | Handler explicitly denied | `request`, `reason` |
-| `ApprovalTimeout` | Handler timed out (subclass of `ApprovalDenied`) | `request`, `timeout_seconds` |
-| `ApprovalVerificationError` | Crypto verification failed | `request`, `reason` |
-
-`ApprovalVerificationError` reasons include:
-- `"invalid signature: ..."` — Ed25519 signature check failed
-- `"request hash mismatch (approval was signed for a different request)"` — replay attempt
-- `"approval expired (beyond clock tolerance)"` — `expires_at` in the past (with 30s tolerance)
-- `"approver not in trusted set"` — untrusted key
-- `"duplicate approval from same approver"` — same key signed twice
-
-For m-of-n failures, `InsufficientApprovals` is raised with a diagnostic summary:
-```
-Insufficient approvals: required 2, received 1 [rejected: 1 expired, 1 not trusted]
-```
-
----
-
-## Security Properties
-
-| Property | Mechanism | Test |
-|----------|-----------|------|
-| **No unsigned approvals** | Handler must return `SignedApproval`; no `approved=True` boolean | `TestAutoApprove`, `TestCliPrompt` |
-| **Call binding** | SHA-256 request hash over `(warrant, tool, args, holder)` | `TestRequestHashBinding` |
-| **Replay prevention** | Different warrant/tool/args/holder = different hash; random nonce | `test_approval_reuse_across_warrants_fails` |
-| **Forgery resistance** | Ed25519 signature verification in Rust core | `test_tampered_bytes_fail_verify` |
-| **Key trust** | `required_approvers` in warrant | `TestMultiApprover`, `test_untrusted_key_rejected` |
-| **Time-bound** | `expires_at` checked with 30s clock tolerance | `test_expired_approval_rejected` |
-| **Fail-closed** | Buggy handler = `internal_error` denial | `test_handler_exception_is_fail_closed` |
-| **Warrant priority** | Warrant denial short-circuits before approval check | `test_warrant_denial_takes_priority` |
-| **Constraint priority** | Constraint violation short-circuits before approval check | `test_constraint_violation_skips_approval` |
-| **M-of-N threshold** | Rust core counts valid approvals, rejects duplicates | `TestMofN` (13 Rust + 11 Python tests) |
-| **Diagnostic errors** | Specific rejection reasons for 1-of-1; summary for m-of-n | `test_1of1_*`, `test_mofn_diagnostic_*` |
-
----
-
-## Warrants vs Approvals
-
-| | Warrants | Approvals |
-|---|---------|-----------|
-| **Question** | "Can this agent do X?" | "Should this specific call proceed?" |
-| **Issuer** | Control plane / parent agent | Human approver |
-| **Scope** | Capabilities + constraints | Single tool call |
-| **Lifetime** | TTL (minutes to hours) | TTL (seconds to minutes) |
-| **Enforcement** | Rust core (security boundary) | Python + Rust crypto (defense in depth) |
-| **Bypass impact** | Full security breach | Operational control loss (warrant still enforced) |
-
-Warrants are the security boundary. Approvals are defense in depth. Even if the approval layer is bypassed (compromised Python process), the warrant still limits what the agent can do.
+`SignedApproval` = Ed25519 signature over `ApprovalPayload` (`request_hash`, `nonce`, `expires_at`, ...). Rust core verifies signature, hash, expiry (30s clock tolerance), approver trust, deduplication, and threshold.
 
 ---
 
 ## See Also
 
-- [Enforcement Architecture](enforcement.md) — Where approvals fit in the enforcement pipeline
-- [AI Agents Security](ai-agents.md) — The 4-layer defense strategy
-- [Concepts](concepts.md) — Warrants, PoP, attenuation
+- [Enforcement Architecture](enforcement.md#human-approvals) — Where approvals sit in the pipeline
+- [MCP Approval Gates](mcp.md#approval-gates) — Remote PEP retry flow
+- [FastAPI](fastapi.md#error-handling) — HTTP 409 approval responses
+- [Wire format §16](spec/wire-format-v1.md#16-approval-wire-format) — `SignedApproval` bytes

--- a/docs/autogen.md
+++ b/docs/autogen.md
@@ -60,18 +60,16 @@ asyncio.run(main())
 
 ## Human Approval
 
-Add human-in-the-loop approval with `.approval_policy()` and `.on_approval()` when using GuardBuilder. See [Human Approvals](approvals.md) for the full guide.
+Define gates and approvers on the warrant, then pass `.on_approval()`. See [Human Approvals](approvals.md) for the full guide.
 
 ```python
-from tenuo import SigningKey, cli_prompt
+from tenuo import cli_prompt
 from tenuo.autogen import GuardBuilder
 
-key = SigningKey.generate()
-
 guard = (GuardBuilder()
-    ...
-    .approval_policy(policy)
-    .on_approval(cli_prompt(approver_key=key))
+    .allow("transfer_funds")
+    .with_warrant(warrant, agent_key)
+    .on_approval(cli_prompt(approver_key=approver_key))
     .build())
 ```
 

--- a/docs/crewai.md
+++ b/docs/crewai.md
@@ -129,16 +129,16 @@ guard.register()
 
 ### Human Approval
 
-Add human-in-the-loop approval with `.approval_policy()` and `.on_approval()`. See [Human Approvals](approvals.md) for the full guide.
+Define gates and approvers on the warrant, then pass `.on_approval()`. See [Human Approvals](approvals.md) for the full guide.
 
 ```python
 from tenuo.approval import cli_prompt
 from tenuo.crewai import GuardBuilder
 
 guard = (GuardBuilder()
-    ...
-    .approval_policy(policy)
-    .on_approval(cli_prompt(approver_key=key))
+    .allow("transfer_funds", amount=Range(0, 100_000))
+    .with_warrant(warrant, agent_key)
+    .on_approval(cli_prompt(approver_key=approver_key))
     .build())
 
 guard.register()

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -53,6 +53,16 @@ Integrates with the frameworks teams already use:
 
 All integrations share a single enforcement code path through the Rust core: same behavior, same audit log, same security guarantees regardless of framework.
 
+### Human Approvals
+
+After PoP and constraint checks, the Rust core evaluates **approval gates** on the warrant. If a gate fires:
+
+1. Collect `SignedApproval`(s) from `required_approvers` (via handler or pre-supplied approvals).
+2. Verify signatures, request-hash binding, expiry, and m-of-n threshold.
+3. Proceed or return a typed retry signal (`approval_required` vs `insufficient_approvals`).
+
+Gates, approvers, and threshold are defined on the warrant — not in adapter config. See [Human Approvals](approvals.md) for quick start and per-integration retry codes.
+
 > [!NOTE]
 > **Limitation**: In-process enforcement cannot survive agent compromise (RCE). If an attacker gets code execution inside the agent, they can call tools directly. For that threat, add a sidecar.
 

--- a/docs/fastapi.md
+++ b/docs/fastapi.md
@@ -284,7 +284,11 @@ Common error codes:
 | 1500 | `tool-not-authorized` | 403 | Tool not in warrant's allowed list |
 | 1501 | `constraint-violation` | 403 | Argument violates constraint |
 | 1600 | `pop-signature-mismatch` | 403 | PoP verification failed |
+| 1700 | `insufficient-approvals` | **409** | Multi-sig threshold not met (`got` / `need` in body) |
+| 1707 | `approval-required` | **409** | Approval gate fired (`request_hash` in body) |
 | 1800 | `warrant-revoked` | 401 | Warrant revoked by issuer |
+
+Approval retries use **409 Conflict** (not 403) so clients can branch separately from scope denials. Re-submit with `X-Tenuo-Approvals`. See [Human Approvals](approvals.md#signals-by-integration).
 
 See [wire format specification](/docs/spec/wire-format-v1#appendix-a-error-codes) for the complete list.
 

--- a/docs/fastapi.md
+++ b/docs/fastapi.md
@@ -240,15 +240,19 @@ Tenuo expects these HTTP headers:
 |--------|-------------|
 | `X-Tenuo-Warrant` | Base64-encoded warrant (or warrant stack) |
 | `X-Tenuo-PoP` | Base64-encoded Proof-of-Possession signature |
-| `X-Tenuo-Approvals` | Base64-encoded signed approvals (optional) |
+| `X-Tenuo-Approvals` | Base64-encoded JSON array of base64 CBOR `SignedApproval` blobs (optional, for retry) |
 
-**Example request:**
+**Example request (with approval retry):**
 
 ```bash
+# approvals_b64 = base64(json.dumps([base64(cbor_signed_approval), ...]))
 curl -X GET "https://api.example.com/search?query=test" \
   -H "X-Tenuo-Warrant: eyJ3YXJyYW50IjoiLi4uIn0=" \
-  -H "X-Tenuo-PoP: SGVsbG8gV29ybGQ="
+  -H "X-Tenuo-PoP: SGVsbG8gV29ybGQ=" \
+  -H "X-Tenuo-Approvals: W3siLi4uIn1d"
 ```
+
+On **409** with `"error": "approval_required"`, read `request_hash` from the body, sign, and re-submit with `X-Tenuo-Approvals`. See [Human Approvals](approvals.md#wire-format-retry-payloads).
 
 ---
 

--- a/docs/google-adk.md
+++ b/docs/google-adk.md
@@ -119,13 +119,14 @@ agent = Agent(
 
 ### Human Approval
 
-Add human-in-the-loop approval with `.approval_policy()` and `.on_approval()`. See [Human Approvals](approvals.md) for the full guide.
+Define gates and approvers on the warrant, then pass `.on_approval()`. See [Human Approvals](approvals.md) for the full guide.
 
 ```python
+from tenuo.approval import cli_prompt
+
 guard = (GuardBuilder()
-    ...
-    .approval_policy(policy)
-    .on_approval(cli_prompt(approver_key=key))
+    .with_warrant(warrant, agent_key)
+    .on_approval(cli_prompt(approver_key=approver_key))
     .build())
 ```
 

--- a/docs/langchain.md
+++ b/docs/langchain.md
@@ -533,25 +533,25 @@ result = protected.invoke({"input": "Read /data/report.txt"})
 
 ## Human Approval
 
-Add human-in-the-loop approval with `approval_handler` and `approvals` parameters on `guard_tools()` or `TenuoTool`. See [Human Approvals](approvals.md) for the full guide.
+Define gates and approvers on the warrant, then pass `approval_handler` to `guard()` or `TenuoTool`. See [Human Approvals](approvals.md) for the full guide.
 
 ```python
-from tenuo.langchain import guard_tools, TenuoTool
+from tenuo.langchain import guard, TenuoTool
 from tenuo.approval import cli_prompt
 
 approver_key = SigningKey.generate()
 
-# Via guard_tools: specify which tools require approval and the handler
-protected = guard_tools(
-    [search, delete_database],
+# warrant must include .approval_gates(...) and .required_approvers([...])
+tools = guard(
+    [search, transfer_funds],
     bound_warrant,
-    approvals=["delete_database"],
     approval_handler=cli_prompt(approver_key=approver_key),
 )
 
-# Or per-tool via TenuoTool
+# Or per-tool
 tool = TenuoTool(
-    inner=delete_database,
+    transfer_funds,
+    bound_warrant=bound_warrant,
     approval_handler=cli_prompt(approver_key=approver_key),
 )
 ```

--- a/docs/langchain.md
+++ b/docs/langchain.md
@@ -608,7 +608,7 @@ with chain_scope([root]):
 ## See Also
 
 - [LangGraph Integration](./langgraph)  -- Multi-agent graph security
-- [Human Approvals](./approvals)  -- Approval policy guide
+- [Human Approvals](./approvals)  -- Approval gates and handlers guide
 - [Argument Extraction](./constraints#argument-extraction)  -- How extraction works
 - [Security](./security)  -- Threat model, best practices
 - [API Reference](./api-reference)  -- Full Python API documentation

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -343,11 +343,13 @@ except MCPApprovalRequired as e:
 
 ### JSON-RPC Error Codes
 
-| Code | Meaning | Action |
-|------|---------|--------|
-| `-32602` | Invalid params (missing required extraction field) | Fix arguments |
-| `-32001` | Access denied (constraint violation, expired, bad signature) | Request new warrant |
-| `-32002` | Approval required (approval gate triggered) | Collect approvals and re-submit |
+| Code | Meaning | `error.data` | Action |
+|------|---------|--------------|--------|
+| `-32602` | Invalid params (missing required extraction field) | — | Fix arguments |
+| `-32001` | Access denied (constraint, expired, bad PoP, invalid approval) | — | Fix warrant or args |
+| `-32002` | Approval retry (gate fired **or** insufficient multi-sig) | `request_hash` and/or `got` / `need` | Collect `SignedApproval`(s), re-submit with `_meta.tenuo.approvals` |
+
+Both first-call gate hits and partial multi-sig use `-32002` so clients can share one retry branch. Distinguish partial multi-sig by presence of `got` / `need`. See [Human Approvals](approvals.md#signals-by-integration).
 
 ---
 

--- a/docs/openai.md
+++ b/docs/openai.md
@@ -131,13 +131,15 @@ response = client.chat.completions.create(...)
 
 ### Human Approval
 
-Add human-in-the-loop approval with `.with_approvals()` and `.on_approval()`. See [Human Approvals](approvals.md) for the full guide.
+Define gates and approvers on the warrant, then pass `.on_approval()`. See [Human Approvals](approvals.md) for the full guide.
 
 ```python
+from tenuo.approval import cli_prompt
+
 client = (GuardBuilder(openai.OpenAI())
-    ...
-    .with_approvals(policy)
-    .on_approval(cli_prompt(approver_key=key))
+    .allow("transfer_funds")
+    .with_warrant(warrant, agent_key)
+    .on_approval(cli_prompt(approver_key=approver_key))
     .build())
 ```
 

--- a/docs/owasp.md
+++ b/docs/owasp.md
@@ -418,7 +418,7 @@ Attackers exploit the trust humans place in agent outputs. Deceptive summaries, 
 
 ### How Tenuo helps
 
-Tenuo supports cryptographic human approvals through its guards mechanism. When an action requires human authorization, the approval is not a log entry or an API call. It is a cryptographic artifact binding a specific tool call to a specific human's key, verifiable offline and recorded as a signed receipt. The artifact survives database tampering, log loss, and post-hoc dispute.
+Tenuo supports cryptographic human approvals through **approval gates** on warrants. When an action requires human authorization, the approval is not a log entry or an API call. It is a cryptographic artifact binding a specific tool call to a specific human's key, verifiable offline and recorded as a signed receipt. The artifact survives database tampering, log loss, and post-hoc dispute.
 
 Three properties the deployed baseline lacks:
 

--- a/docs/spec/protocol-spec-v1.md
+++ b/docs/spec/protocol-spec-v1.md
@@ -477,8 +477,12 @@ def authorize(warrant, tool, args, pop_signature, approvals=[], tool_reqs={}):
     # 5. Verify Proof-of-Possession (§7)
     verify_pop(warrant, pop_signature, tool, args)
     
-    # 6. Multi-sig enforcement (if required)
-    if warrant.required_approvers():
+    # 6. Multi-sig enforcement (if an approval gate fires for this call)
+    if evaluate_approval_gates(warrant, tool, args):
+        if not warrant.required_approvers():
+            raise ApprovalGateMisconfigured()
+        if approvals.is_empty():
+            raise ApprovalRequired(tool, request_hash=compute_request_hash(...))
         valid = count_valid_approvals(warrant, tool, args, approvals)
         if valid < warrant.min_approvals():
             raise InsufficientApprovals(f"Got {valid}, need {warrant.min_approvals()}")

--- a/docs/spec/wire-format-v1.md
+++ b/docs/spec/wire-format-v1.md
@@ -2195,6 +2195,7 @@ pub enum ErrorCode {
     UnsupportedApprovalVersion = 1704,
     ApprovalPayloadInvalid = 1705,
     ApprovalRequestHashMismatch = 1706,
+    ApprovalRequired = 1707,  // Gate fired; no valid approvals supplied yet
     
     // Revocation errors (1800-1899)
     WarrantRevoked = 1800,
@@ -2275,6 +2276,9 @@ Uses standard JSON-RPC negative codes (-32001 to -32099) with canonical code in 
 - `-32009` (REVOKED) <--> `1800` (WarrantRevoked)
 - `-32010` (CHAIN_INVALID) <--> `1405` (ChainBroken)
 - `-32016` (POP_FAILED) <--> `1600` (PopSignatureInvalid)
+- `-32019` (APPROVAL_REQUIRED) <--> `1707` (ApprovalRequired)
+- `-32020` (INSUFFICIENT_APPROVALS) <--> `1700` (InsufficientApprovals)
+- `-32021` (INVALID_APPROVAL) <--> `1701` (ApprovalInvalid)
 
 Some A2A errors are protocol-specific (e.g., `-32001` MISSING_WARRANT, `-32005` AUDIENCE_MISMATCH) and have no wire format equivalent.
 
@@ -2291,7 +2295,8 @@ MCP tool calls carry warrant data in `params._meta.tenuo` -- the MCP spec's desi
   "_meta": {
     "tenuo": {
       "warrant": "<base64url CBOR WarrantStack>",
-      "pop": "<base64url PoP signature>"
+      "signature": "<base64url PoP signature>",
+      "approvals": ["<base64 CBOR SignedApproval>", "..."]
     }
   }
 }
@@ -2303,19 +2308,30 @@ MCP tool calls carry warrant data in `params._meta.tenuo` -- the MCP spec's desi
 {
   "jsonrpc": "2.0",
   "error": {
-    "code": -32001,
-    "message": "authorization_denied",
+    "code": -32002,
+    "message": "approval_required",
     "data": {
-      "tenuo_code": 1501,
-      "tool": "query_database"
+      "tenuo_code": 1707,
+      "request_hash": "a1b2c3..."
     }
   }
 }
 ```
 
+Partial multi-sig uses the same `-32002` code with `got` / `need` in `data` (wire `1700`):
+
+```json
+{
+  "error": {
+    "code": -32002,
+    "data": { "got": 1, "need": 2, "tenuo_code": 1700 }
+  }
+}
+```
+
 **Key mappings:**
-- `-32001` (DENIED) <--> Authorization denied (missing warrant, chain invalid, constraint violation)
-- `-32002` (APPROVAL_REQUIRED) <--> `1700` (InsufficientApprovals)
+- `-32001` (DENIED) <--> Authorization denied (missing warrant, chain invalid, constraint violation, invalid approval)
+- `-32002` (APPROVAL_RETRY) <--> `1707` (gate fired, `request_hash` in data) **or** `1700` (partial multi-sig, `got`/`need` in data)
 - `-32602` (INVALID_PARAMS) <--> Malformed or missing `_meta.tenuo` in request params
 
 **Server-side verification flow:**
@@ -2344,7 +2360,7 @@ All three representations are equally valid; the numeric codes 1000-2199 are can
 | 1400-1499 | 403 Forbidden | Chain validation failed |
 | 1500-1599 | 403 Forbidden | Authorization denied |
 | 1600-1699 | 401 Unauthorized | PoP verification failed |
-| 1700-1799 | 403 Forbidden | Approval requirements not met |
+| 1700-1799 | 403 Forbidden (409 in FastAPI adapter) | Approval requirements not met |
 | 1800-1899 | 401 Unauthorized | Warrant revoked |
 | 1900-1999 | 413 Payload Too Large | Size limits exceeded |
 | 2000-2099 | 400 Bad Request | Invalid extension |

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -784,9 +784,30 @@ TenuoPluginConfig(
 
 Both `tool_mappings` and `@tool()` can coexist; `tool_mappings` takes precedence.
 
+## Human Approval
+
+Gates and approvers live on the warrant. Configure `approval_handler` on `TenuoPluginConfig`, or pre-supply approvals per activity.
+
+| Signal | `ApplicationError.type` | Retry with |
+|--------|-------------------------|------------|
+| Gate fired, no approvals | `"approval_required"` | `set_activity_approvals()` or `x-tenuo-approvals` header |
+| Partial multi-sig | `"insufficient_approvals"` | Additional `SignedApproval` objects on retry |
+
+**Header encoding:** `x-tenuo-approvals` = JSON array of base64(CBOR) strings — **no** outer base64 wrapper (differs from FastAPI). See [Human Approvals](approvals.md#wire-format-retry-payloads).
+
+```python
+TenuoPluginConfig(
+    key_resolver=resolver,
+    trusted_roots=[issuer_public_key],
+    approval_handler=cli_prompt(approver_key=approver_key),
+)
+```
+
 ### set_activity_approvals() - Pre-Supply Multisig Approvals
 
-Call from a workflow before `workflow.execute_activity()` when the warrant has guards that require approval. The outbound interceptor attaches the approvals to the next activity dispatch.
+Call from a **workflow** immediately before `workflow.execute_activity()` when the warrant has **approval gates** for that activity.
+
+**One-shot:** approvals attach to the **next** activity dispatch only, then clear. For parallel activities, call `set_activity_approvals` before each dispatch — not once before `asyncio.gather`.
 
 ```python
 from tenuo.temporal import set_activity_approvals
@@ -798,6 +819,8 @@ await workflow.execute_activity(
     start_to_close_timeout=timedelta(seconds=30),
 )
 ```
+
+On denial, the worker raises non-retryable `ApplicationError` with `type` of `"approval_required"` or `"insufficient_approvals"`. Retry explicitly from the workflow after collecting signatures — Temporal will not auto-retry auth failures.
 
 ### tenuo_warrant_context() - Warrant Context for Plain Client Calls
 
@@ -926,6 +949,12 @@ from tenuo.temporal import (
 )
 ```
 
+Approval denials surface as `ApplicationError(non_retryable=True)` with `type`:
+- `"approval_required"` — gate fired, resubmit with approvals
+- `"insufficient_approvals"` — partial multi-sig, collect more signatures
+
+See [Human Approval](#human-approval) and [Human Approvals](approvals.md#signals-by-integration).
+
 ## Failure Semantics
 
 Authorization failures are wrapped in `ApplicationError(non_retryable=True)` to prevent retrying permanent denials.
@@ -935,6 +964,7 @@ Authorization failures are wrapped in `ApplicationError(non_retryable=True)` to 
 | Missing/invalid warrant | `TemporalConstraintViolation` / `ChainValidationError` | **No** |
 | Invalid PoP or replay | `PopVerificationError` | **No** |
 | Expired warrant | `WarrantExpired` | **No** — mint a new warrant |
+| Approval gate / partial multi-sig | `ApplicationError` (`approval_required` / `insufficient_approvals`) | **No** — workflow must collect signatures and retry |
 | Local activity without `@unprotected` | `LocalActivityError` | **No** |
 | Key resolution failure | `KeyResolutionError` | Retry only for transient backend failures |
 | Missing `trusted_roots` | `ConfigurationError` | Fix config |

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -224,20 +224,16 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
                     Ok(v) => v,
                     Err(e) => return py_validation_err(e.to_string()),
                 };
-                let elements = vec![
-                    req,
-                    rec,
-                    det,
-                ];
-                (
-                    "InsufficientApprovals",
-                    PyTuple::new(py, elements),
-                )
+                let elements = vec![req, rec, det];
+                ("InsufficientApprovals", PyTuple::new(py, elements))
             }
             crate::error::Error::InvalidApproval(m) => {
                 ("InvalidApproval", PyTuple::new(py, [m.as_str()]))
             }
-            crate::error::Error::ApprovalRequired { ref tool, ref request } => {
+            crate::error::Error::ApprovalRequired {
+                ref tool,
+                ref request,
+            } => {
                 let request_hash_hex = hex::encode(request.request_hash);
                 let request_id_hex = hex::encode(request.request_id);
                 (
@@ -402,14 +398,12 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
                     )],
                 ),
             ),
-            crate::error::Error::ConfigurationError(msg) => (
-                "ConfigurationError",
-                PyTuple::new(py, [msg.as_str()]),
-            ),
-            crate::error::Error::FeatureNotEnabled { feature } => (
-                "FeatureNotEnabled",
-                PyTuple::new(py, [feature]),
-            ),
+            crate::error::Error::ConfigurationError(msg) => {
+                ("ConfigurationError", PyTuple::new(py, [msg.as_str()]))
+            }
+            crate::error::Error::FeatureNotEnabled { feature } => {
+                ("FeatureNotEnabled", PyTuple::new(py, [feature]))
+            }
             crate::error::Error::PathNotContained { path, root } => (
                 "ConstraintViolation",
                 PyTuple::new(
@@ -426,13 +420,7 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
             }
             crate::error::Error::UrlNotSafe { url, reason } => (
                 "ConstraintViolation",
-                PyTuple::new(
-                    py,
-                    [
-                        "url",
-                        &format!("URL '{}' blocked: {}", url, reason),
-                    ],
-                ),
+                PyTuple::new(py, ["url", &format!("URL '{}' blocked: {}", url, reason)]),
             ),
         };
 

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -407,14 +407,8 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
                 PyTuple::new(py, [msg.as_str()]),
             ),
             crate::error::Error::FeatureNotEnabled { feature } => (
-                "RuntimeError",
-                PyTuple::new(
-                    py,
-                    [&format!(
-                        "{} requires the '{}' feature. Enable with: tenuo = {{ features = [\"{}\"] }}",
-                        feature, feature, feature
-                    )],
-                ),
+                "FeatureNotEnabled",
+                PyTuple::new(py, [feature.as_str()]),
             ),
             crate::error::Error::PathNotContained { path, root } => (
                 "ConstraintViolation",

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -408,7 +408,7 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
             ),
             crate::error::Error::FeatureNotEnabled { feature } => (
                 "FeatureNotEnabled",
-                PyTuple::new(py, [feature.as_str()]),
+                PyTuple::new(py, [feature]),
             ),
             crate::error::Error::PathNotContained { path, root } => (
                 "ConstraintViolation",

--- a/tenuo-python/README.md
+++ b/tenuo-python/README.md
@@ -599,8 +599,7 @@ async def read_file(path: str, **kwargs) -> str:
     return open(clean["path"]).read()
 ```
 
-Guard-protected tools return JSON-RPC error `-32002` when approval is required.
-See `examples/mcp/` for complete examples.
+MCP servers return JSON-RPC `-32002` when an approval gate fires or multi-sig threshold is not met — retry with `_meta.tenuo.approvals`. See [Human Approvals](../docs/approvals.md).
 
 ## Security Considerations
 

--- a/tenuo-python/examples/jit_warrant_demo/README.md
+++ b/tenuo-python/examples/jit_warrant_demo/README.md
@@ -52,40 +52,16 @@ python demo.py --auto-approve --delegation
 
 Both system AND human must cryptographically approve before authorization succeeds.
 
-This demo uses Tenuo's real `Approval` class:
-- Each approver creates a signed `Approval` object bound to a specific request
-- Approvals are passed to `Authorizer.authorize()` for verification
+This demo uses Tenuo's `SignedApproval` + `sign_approval()`:
+- Each approver signs an `ApprovalPayload` bound to the specific `(warrant, tool, args, holder)` request hash
+- Approvals are passed to `Authorizer.authorize_one()` / `enforce_tool_call()` for verification
 - Both approvals must be valid (not expired) and correctly signed
 
 ```python
-from tenuo import Approval
+from tenuo.approval import sign_approval
 
-# System creates its approval
-system_approval = Approval.create(
-    warrant=warrant,
-    tool="fetch_url",
-    args={"url": "https://docs.python.org"},
-    keypair=system_key,
-    external_id="control_plane@system",
-    provider="policy-engine",
-    ttl_secs=300,
-)
-
-# Human reviews and creates their approval
-human_approval = Approval.create(
-    warrant=warrant,
-    tool="fetch_url",
-    args={"url": "https://docs.python.org"},
-    keypair=human_key,
-    external_id="reviewer@company.com",
-    provider="human-review",
-    ttl_secs=300,
-    reason="Approved for scheduled task"
-)
-
-# Both approvals passed to authorization
-authorizer.authorize(warrant, tool, args, signature, 
-                     approvals=[system_approval, human_approval])
+# After human reviews the proposed call:
+signed = sign_approval(approval_request, human_key, external_id="reviewer@company.com")
 ```
 
 ```

--- a/tenuo-python/tenuo/_enforcement.py
+++ b/tenuo-python/tenuo/_enforcement.py
@@ -57,6 +57,10 @@ from .exceptions import (
     ExpiredError,
     InsufficientApprovals,
     InvalidApproval,
+    MissingSignature,
+    RevokedError,
+    SignatureInvalid,
+    SignatureMismatch,
     TenuoError,
     ToolNotAuthorized,
 )
@@ -109,21 +113,49 @@ class EnforcementResult:
 
     def raise_if_denied(self) -> None:
         """
-        Raise appropriate exception if authorization was denied.
+        Raise a typed exception matching ``error_type``.
 
         Raises:
-            ConstraintViolation: If a specific constraint was violated
-            ToolNotAuthorized: If tool is not in warrant or general denial
+            InsufficientApprovals: Multi-sig threshold not met (retry with approvals)
+            ExpiredError: Warrant or approval expired
+            ConstraintViolation: Argument violates a warrant constraint
+            ToolNotAuthorized: Tool not granted by the warrant
+            SignatureInvalid: PoP / signature verification failed
+            ToolNotAuthorized: Generic authorization denial fallback
         """
-        if not self.allowed:
-            if self.constraint_violated:
-                raise ConstraintViolation(
-                    field=self.constraint_violated,
-                    reason=self.denial_reason or "Constraint violation",
-                    value=None,
-                )
-            else:
+        if self.allowed:
+            return
+
+        error_type = self.error_type or "authorization_failed"
+
+        if error_type == "insufficient_approvals":
+            meta = self.approval_metadata or {}
+            raise InsufficientApprovals(
+                required=meta.get("need", 0),
+                received=meta.get("got", 0),
+                detail=self.denial_reason or "",
+            )
+
+        if error_type == "expired":
+            raise ExpiredError(self.denial_reason or "Warrant expired")
+
+        if error_type == "tool_not_allowed":
+            raise ToolNotAuthorized(tool=self.tool)
+
+        if error_type == "invalid_pop":
+            raise SignatureInvalid(self.denial_reason or "Invalid proof-of-possession")
+
+        if error_type == "constraint_violation" or self.constraint_violated:
+            # Rust maps missing tool scope to constraint_violation on field "tool".
+            if self.constraint_violated == "tool":
                 raise ToolNotAuthorized(tool=self.tool)
+            raise ConstraintViolation(
+                field=self.constraint_violated or "unknown",
+                reason=self.denial_reason or "Constraint violation",
+                value=None,
+            )
+
+        raise ToolNotAuthorized(tool=self.tool)
 
 
 # =============================================================================
@@ -303,6 +335,24 @@ def _enforcement_result_from_chain_error(
             arguments=tool_args,
             denial_reason=str(exc),
             error_type="tool_not_allowed",
+            warrant_id=warrant_id,
+        )
+    if isinstance(exc, (SignatureInvalid, MissingSignature, SignatureMismatch)):
+        return EnforcementResult(
+            allowed=False,
+            tool=tool_name,
+            arguments=tool_args,
+            denial_reason=str(exc),
+            error_type="invalid_pop",
+            warrant_id=warrant_id,
+        )
+    if isinstance(exc, RevokedError):
+        return EnforcementResult(
+            allowed=False,
+            tool=tool_name,
+            arguments=tool_args,
+            denial_reason=str(exc),
+            error_type="revoked",
             warrant_id=warrant_id,
         )
     if isinstance(exc, ConstraintViolation):
@@ -930,11 +980,6 @@ def enforce_tool_call(
                         warrant_id=warrant_id,
                     )
             except Exception as _exc:
-                from tenuo.exceptions import ExpiredError as _ExpiredError
-                from tenuo.exceptions import MissingSignature as _MissingSignature
-                from tenuo.exceptions import SignatureInvalid as _SignatureInvalid
-                if isinstance(_exc, (_ExpiredError, _SignatureInvalid, _MissingSignature)):
-                    raise
                 logger.debug(f"Authorization denied for {tool_name}: {_exc}")
                 return _enforcement_result_from_chain_error(
                     _exc,
@@ -1291,11 +1336,6 @@ async def enforce_tool_call_async(
                         error_type="invalid_pop", warrant_id=warrant_id,
                     )
             except Exception as _exc:
-                from tenuo.exceptions import ExpiredError as _ExpiredError
-                from tenuo.exceptions import MissingSignature as _MissingSignature
-                from tenuo.exceptions import SignatureInvalid as _SignatureInvalid
-                if isinstance(_exc, (_ExpiredError, _SignatureInvalid, _MissingSignature)):
-                    raise
                 logger.debug(f"Authorization denied for {tool_name}: {_exc}")
                 return _enforcement_result_from_chain_error(
                     _exc,

--- a/tenuo-python/tenuo/_enforcement.py
+++ b/tenuo-python/tenuo/_enforcement.py
@@ -54,6 +54,7 @@ from .exceptions import (
     ConfigurationError,
     ConstraintViolation,
     ExpiredError,
+    InsufficientApprovals,
     TenuoError,
     ToolNotAuthorized,
 )
@@ -78,13 +79,20 @@ class EnforcementResult:
         arguments: Arguments that were passed to the tool
         denial_reason: Human-readable reason for denial (if not allowed)
         constraint_violated: Which constraint failed (if applicable)
-        error_type: Structured error category (e.g. "expired", "tool_not_allowed")
+        error_type: Structured error category (e.g. "expired", "tool_not_allowed",
+            "insufficient_approvals").  When ``error_type`` is
+            ``"insufficient_approvals"``, ``approval_metadata`` carries the
+            structured counts needed to build a retry-with-approval loop.
         warrant_id: ID of the warrant for audit correlation
         chain_result: Rust ``ChainVerificationResult`` from ``authorize_one`` /
             ``check_chain``.  Present only on successful authorization.
             Pass to ``emit_for_enforcement(chain_result=...)`` so receipts
             are signed with Rust-attested fields (approvals, warrant stack,
             root issuer) instead of Python-supplied metadata.
+        approval_metadata: Populated when ``error_type == "insufficient_approvals"``.
+            Contains ``{"got": int, "need": int}`` so callers can tell "re-submit
+            with more approvals" from a flat scope denial without parsing the
+            human-readable ``denial_reason``.
     """
 
     allowed: bool
@@ -95,6 +103,7 @@ class EnforcementResult:
     error_type: Optional[str] = None
     warrant_id: Optional[str] = None
     chain_result: Optional[Any] = None
+    approval_metadata: Optional[Dict[str, Any]] = None
 
     def raise_if_denied(self) -> None:
         """
@@ -392,6 +401,11 @@ def _collect_approvals_for_approval_gate(
 
     try:
         _verify_approvals(request_hash, collected, trusted_approvers, threshold)
+    except InsufficientApprovals:
+        # Re-raise directly so the enforcement layer can surface it as a
+        # distinct "insufficient_approvals" signal rather than collapsing it
+        # into the generic ApprovalVerificationError bucket.
+        raise
     except Exception as e:
         raise ApprovalVerificationError(request, reason=str(e)) from e
 
@@ -454,6 +468,8 @@ async def _collect_approvals_for_approval_gate_async(
 
     try:
         _verify_approvals(request_hash, collected, trusted_approvers, threshold)
+    except InsufficientApprovals:
+        raise
     except Exception as e:
         raise ApprovalVerificationError(request, reason=str(e)) from e
 
@@ -821,6 +837,25 @@ def enforce_tool_call(
                 from tenuo.exceptions import SignatureInvalid as _SignatureInvalid
                 if isinstance(_exc, (_ExpiredError, _SignatureInvalid, _MissingSignature)):
                     raise
+                # Insufficient approvals is structurally different from a scope
+                # denial — the caller can satisfy it by resubmitting with more
+                # approval signatures.  Preserve the got/need counts so
+                # integrations can emit the correct protocol signal (-32002, 409,
+                # etc.) without having to parse the human-readable message.
+                if isinstance(_exc, InsufficientApprovals):
+                    logger.debug(f"Insufficient approvals for {tool_name}: {_exc}")
+                    return EnforcementResult(
+                        allowed=False,
+                        tool=tool_name,
+                        arguments=tool_args,
+                        denial_reason=str(_exc),
+                        error_type="insufficient_approvals",
+                        warrant_id=warrant_id,
+                        approval_metadata={
+                            "got": _exc.details.get("received", 0) if hasattr(_exc, "details") else 0,
+                            "need": _exc.details.get("required", 0) if hasattr(_exc, "details") else 0,
+                        },
+                    )
                 # Use why_denied() to get the structured field name instead of
                 # regexing the error string — why_denied is available even when
                 # authorize_one raises because it interrogates the warrant directly.
@@ -917,6 +952,22 @@ def enforce_tool_call(
             chain_result=_chain_result,
         )
 
+    except InsufficientApprovals as e:
+        # Multi-sig threshold not met — structurally different from a scope
+        # denial.  Preserve got/need so integrations emit the correct signal.
+        logger.debug(f"Insufficient approvals for {tool_name}: {e}")
+        return EnforcementResult(
+            allowed=False,
+            tool=tool_name,
+            arguments=tool_args,
+            denial_reason=str(e),
+            error_type="insufficient_approvals",
+            warrant_id=warrant_id,
+            approval_metadata={
+                "got": e.details.get("received", 0) if hasattr(e, "details") else 0,
+                "need": e.details.get("required", 0) if hasattr(e, "details") else 0,
+            },
+        )
     except (ConstraintViolation, ExpiredError, ToolNotAuthorized) as e:
         # Known authorization failures - expected behavior
         logger.debug(f"Authorization denied for {tool_name}: {e}")
@@ -1175,6 +1226,18 @@ async def enforce_tool_call_async(
                 from tenuo.exceptions import SignatureInvalid as _SignatureInvalid
                 if isinstance(_exc, (_ExpiredError, _SignatureInvalid, _MissingSignature)):
                     raise
+                if isinstance(_exc, InsufficientApprovals):
+                    logger.debug(f"Insufficient approvals for {tool_name}: {_exc}")
+                    return EnforcementResult(
+                        allowed=False, tool=tool_name, arguments=tool_args,
+                        denial_reason=str(_exc),
+                        error_type="insufficient_approvals",
+                        warrant_id=warrant_id,
+                        approval_metadata={
+                            "got": _exc.details.get("received", 0) if hasattr(_exc, "details") else 0,
+                            "need": _exc.details.get("required", 0) if hasattr(_exc, "details") else 0,
+                        },
+                    )
                 try:
                     _why = _warrant.why_denied(tool_name, _constraint_auth_args)
                     violated_field = getattr(_why, "field", None)
@@ -1240,6 +1303,18 @@ async def enforce_tool_call_async(
             warrant_id=warrant_id, chain_result=_chain_result,
         )
 
+    except InsufficientApprovals as e:
+        logger.debug(f"Insufficient approvals for {tool_name}: {e}")
+        return EnforcementResult(
+            allowed=False, tool=tool_name, arguments=tool_args,
+            denial_reason=str(e),
+            error_type="insufficient_approvals",
+            warrant_id=warrant_id,
+            approval_metadata={
+                "got": e.details.get("received", 0) if hasattr(e, "details") else 0,
+                "need": e.details.get("required", 0) if hasattr(e, "details") else 0,
+            },
+        )
     except (ConstraintViolation, ExpiredError, ToolNotAuthorized) as e:
         logger.debug(f"Authorization denied for {tool_name}: {e}")
         if isinstance(e, ExpiredError):

--- a/tenuo-python/tenuo/_enforcement.py
+++ b/tenuo-python/tenuo/_enforcement.py
@@ -51,10 +51,12 @@ if TYPE_CHECKING:
 
 from .bound_warrant import BoundWarrant
 from .exceptions import (
+    ApprovalExpired,
     ConfigurationError,
     ConstraintViolation,
     ExpiredError,
     InsufficientApprovals,
+    InvalidApproval,
     TenuoError,
     ToolNotAuthorized,
 )
@@ -248,6 +250,93 @@ def handle_denial(
 # =============================================================================
 
 
+def _constraint_field_from_exception(exc: BaseException) -> Optional[str]:
+    """Extract the violated constraint field from a Tenuo exception."""
+    field = getattr(exc, "field", None)
+    if field:
+        return field
+    details = getattr(exc, "details", None)
+    if isinstance(details, dict):
+        field = details.get("field")
+        if field:
+            return field
+    return _extract_violated_field(str(exc))
+
+
+def _enforcement_result_from_chain_error(
+    exc: BaseException,
+    tool_name: str,
+    tool_args: Dict[str, Any],
+    warrant_id: Optional[str],
+    *,
+    constraint_auth_args: Optional[Dict[str, Any]] = None,
+    warrant: Optional[Any] = None,
+) -> EnforcementResult:
+    """Map a Rust/core authorization exception to an ``EnforcementResult``."""
+    if isinstance(exc, InsufficientApprovals):
+        details = getattr(exc, "details", {}) or {}
+        return EnforcementResult(
+            allowed=False,
+            tool=tool_name,
+            arguments=tool_args,
+            denial_reason=str(exc),
+            error_type="insufficient_approvals",
+            warrant_id=warrant_id,
+            approval_metadata={
+                "got": details.get("received", 0),
+                "need": details.get("required", 0),
+            },
+        )
+    if isinstance(exc, ExpiredError):
+        return EnforcementResult(
+            allowed=False,
+            tool=tool_name,
+            arguments=tool_args,
+            denial_reason=str(exc),
+            error_type="expired",
+            warrant_id=warrant_id,
+        )
+    if isinstance(exc, ToolNotAuthorized):
+        return EnforcementResult(
+            allowed=False,
+            tool=tool_name,
+            arguments=tool_args,
+            denial_reason=str(exc),
+            error_type="tool_not_allowed",
+            warrant_id=warrant_id,
+        )
+    if isinstance(exc, ConstraintViolation):
+        return EnforcementResult(
+            allowed=False,
+            tool=tool_name,
+            arguments=tool_args,
+            denial_reason=str(exc),
+            constraint_violated=_constraint_field_from_exception(exc),
+            error_type="constraint_violation",
+            warrant_id=warrant_id,
+        )
+
+    violated_field = None
+    if warrant is not None and constraint_auth_args is not None:
+        try:
+            _why = warrant.why_denied(tool_name, constraint_auth_args)
+            violated_field = getattr(_why, "field", None)
+        except Exception:
+            violated_field = None
+    if violated_field is None:
+        violated_field = _constraint_field_from_exception(exc)
+
+    return EnforcementResult(
+        allowed=False,
+        tool=tool_name,
+        arguments=tool_args,
+        denial_reason=str(exc) or "Authorization failed",
+        constraint_violated=violated_field,
+        error_type="authorization_failed",
+        warrant_id=warrant_id,
+    )
+
+
 def _extract_violated_field(reason: Optional[str]) -> Optional[str]:
     """
     Extract the violated constraint field name from a validation reason.
@@ -399,12 +488,17 @@ def _collect_approvals_for_approval_gate(
     if not collected:
         raise ApprovalRequired(request)
 
+    from tenuo.exceptions import ApprovalExpired, InvalidApproval
+
     try:
         _verify_approvals(request_hash, collected, trusted_approvers, threshold)
     except InsufficientApprovals:
         # Re-raise directly so the enforcement layer can surface it as a
         # distinct "insufficient_approvals" signal rather than collapsing it
         # into the generic ApprovalVerificationError bucket.
+        raise
+    except (ApprovalExpired, InvalidApproval):
+        # Preserve typed approval failures for integration-specific handlers.
         raise
     except Exception as e:
         raise ApprovalVerificationError(request, reason=str(e)) from e
@@ -466,9 +560,13 @@ async def _collect_approvals_for_approval_gate_async(
     if not collected:
         raise ApprovalRequired(request)
 
+    from tenuo.exceptions import ApprovalExpired, InvalidApproval
+
     try:
         _verify_approvals(request_hash, collected, trusted_approvers, threshold)
     except InsufficientApprovals:
+        raise
+    except (ApprovalExpired, InvalidApproval):
         raise
     except Exception as e:
         raise ApprovalVerificationError(request, reason=str(e)) from e
@@ -837,42 +935,14 @@ def enforce_tool_call(
                 from tenuo.exceptions import SignatureInvalid as _SignatureInvalid
                 if isinstance(_exc, (_ExpiredError, _SignatureInvalid, _MissingSignature)):
                     raise
-                # Insufficient approvals is structurally different from a scope
-                # denial — the caller can satisfy it by resubmitting with more
-                # approval signatures.  Preserve the got/need counts so
-                # integrations can emit the correct protocol signal (-32002, 409,
-                # etc.) without having to parse the human-readable message.
-                if isinstance(_exc, InsufficientApprovals):
-                    logger.debug(f"Insufficient approvals for {tool_name}: {_exc}")
-                    return EnforcementResult(
-                        allowed=False,
-                        tool=tool_name,
-                        arguments=tool_args,
-                        denial_reason=str(_exc),
-                        error_type="insufficient_approvals",
-                        warrant_id=warrant_id,
-                        approval_metadata={
-                            "got": _exc.details.get("received", 0) if hasattr(_exc, "details") else 0,
-                            "need": _exc.details.get("required", 0) if hasattr(_exc, "details") else 0,
-                        },
-                    )
-                # Use why_denied() to get the structured field name instead of
-                # regexing the error string — why_denied is available even when
-                # authorize_one raises because it interrogates the warrant directly.
-                try:
-                    _why = _warrant.why_denied(tool_name, _constraint_auth_args)
-                    violated_field = getattr(_why, "field", None)
-                except Exception:
-                    violated_field = None
                 logger.debug(f"Authorization denied for {tool_name}: {_exc}")
-                return EnforcementResult(
-                    allowed=False,
-                    tool=tool_name,
-                    arguments=tool_args,
-                    denial_reason=str(_exc) or "Authorization failed",
-                    constraint_violated=violated_field,
-                    error_type="authorization_failed",
-                    warrant_id=warrant_id,
+                return _enforcement_result_from_chain_error(
+                    _exc,
+                    tool_name,
+                    tool_args,
+                    warrant_id,
+                    constraint_auth_args=_constraint_auth_args,
+                    warrant=_warrant,
                 )
         else:
             # verify_mode == "verify"
@@ -922,16 +992,14 @@ def enforce_tool_call(
                         approvals=_gate_approvals or [],
                     )
             except Exception as chain_err:
-                denial_reason = str(chain_err)
-                error_type = "authorization_failed"
-                return EnforcementResult(
-                    allowed=False,
-                    tool=tool_name,
-                    arguments=tool_args,
-                    denial_reason=denial_reason,
-                    constraint_violated=None,
-                    error_type=error_type,
-                    warrant_id=warrant_id,
+                logger.debug(f"Authorization denied for {tool_name}: {chain_err}")
+                return _enforcement_result_from_chain_error(
+                    chain_err,
+                    tool_name,
+                    tool_args,
+                    warrant_id,
+                    constraint_auth_args=_constraint_auth_args,
+                    warrant=bound_warrant.warrant,
                 )
 
         # Success - log for audit trail
@@ -968,6 +1036,8 @@ def enforce_tool_call(
                 "need": e.details.get("required", 0) if hasattr(e, "details") else 0,
             },
         )
+    except (InvalidApproval, ApprovalExpired):
+        raise
     except (ConstraintViolation, ExpiredError, ToolNotAuthorized) as e:
         # Known authorization failures - expected behavior
         logger.debug(f"Authorization denied for {tool_name}: {e}")
@@ -987,7 +1057,7 @@ def enforce_tool_call(
             tool=tool_name,
             arguments=tool_args,
             denial_reason=str(e),
-            constraint_violated=getattr(e, "field", None) or _extract_violated_field(str(e)),
+            constraint_violated=_constraint_field_from_exception(e),
             error_type=err_type,
             warrant_id=warrant_id,
         )
@@ -1226,29 +1296,14 @@ async def enforce_tool_call_async(
                 from tenuo.exceptions import SignatureInvalid as _SignatureInvalid
                 if isinstance(_exc, (_ExpiredError, _SignatureInvalid, _MissingSignature)):
                     raise
-                if isinstance(_exc, InsufficientApprovals):
-                    logger.debug(f"Insufficient approvals for {tool_name}: {_exc}")
-                    return EnforcementResult(
-                        allowed=False, tool=tool_name, arguments=tool_args,
-                        denial_reason=str(_exc),
-                        error_type="insufficient_approvals",
-                        warrant_id=warrant_id,
-                        approval_metadata={
-                            "got": _exc.details.get("received", 0) if hasattr(_exc, "details") else 0,
-                            "need": _exc.details.get("required", 0) if hasattr(_exc, "details") else 0,
-                        },
-                    )
-                try:
-                    _why = _warrant.why_denied(tool_name, _constraint_auth_args)
-                    violated_field = getattr(_why, "field", None)
-                except Exception:
-                    violated_field = None
                 logger.debug(f"Authorization denied for {tool_name}: {_exc}")
-                return EnforcementResult(
-                    allowed=False, tool=tool_name, arguments=tool_args,
-                    denial_reason=str(_exc) or "Authorization failed",
-                    constraint_violated=violated_field,
-                    error_type="authorization_failed", warrant_id=warrant_id,
+                return _enforcement_result_from_chain_error(
+                    _exc,
+                    tool_name,
+                    tool_args,
+                    warrant_id,
+                    constraint_auth_args=_constraint_auth_args,
+                    warrant=_warrant,
                 )
         else:
             if authorizer is None:
@@ -1286,12 +1341,14 @@ async def enforce_tool_call_async(
                         approvals=_gate_approvals or [],
                     )
             except Exception as chain_err:
-                denial_reason = str(chain_err)
-                error_type = "authorization_failed"
-                return EnforcementResult(
-                    allowed=False, tool=tool_name, arguments=tool_args,
-                    denial_reason=denial_reason, constraint_violated=None,
-                    error_type=error_type, warrant_id=warrant_id,
+                logger.debug(f"Authorization denied for {tool_name}: {chain_err}")
+                return _enforcement_result_from_chain_error(
+                    chain_err,
+                    tool_name,
+                    tool_args,
+                    warrant_id,
+                    constraint_auth_args=_constraint_auth_args,
+                    warrant=bound_warrant.warrant,
                 )
 
         logger.info(
@@ -1315,6 +1372,8 @@ async def enforce_tool_call_async(
                 "need": e.details.get("required", 0) if hasattr(e, "details") else 0,
             },
         )
+    except (InvalidApproval, ApprovalExpired):
+        raise
     except (ConstraintViolation, ExpiredError, ToolNotAuthorized) as e:
         logger.debug(f"Authorization denied for {tool_name}: {e}")
         if isinstance(e, ExpiredError):
@@ -1328,7 +1387,7 @@ async def enforce_tool_call_async(
         return EnforcementResult(
             allowed=False, tool=tool_name, arguments=tool_args,
             denial_reason=str(e),
-            constraint_violated=getattr(e, "field", None) or _extract_violated_field(str(e)),
+            constraint_violated=_constraint_field_from_exception(e),
             error_type=err_type, warrant_id=warrant_id,
         )
     except TenuoError as e:

--- a/tenuo-python/tenuo/_enforcement.py
+++ b/tenuo-python/tenuo/_enforcement.py
@@ -387,6 +387,40 @@ def _enforcement_result_from_chain_error(
     )
 
 
+def _log_chain_enforcement_denial(
+    tool_name: str,
+    exc: BaseException,
+    error_type: Optional[str],
+) -> None:
+    """Log authorization denials from chain/sign paths at the right severity."""
+    msg = f"Authorization denied for {tool_name}: {exc}"
+    if error_type in ("invalid_pop", "revoked"):
+        logger.warning(msg)
+    else:
+        logger.debug(msg)
+
+
+def _enforcement_result_from_chain_error_with_logging(
+    exc: BaseException,
+    tool_name: str,
+    tool_args: Dict[str, Any],
+    warrant_id: Optional[str],
+    *,
+    constraint_auth_args: Optional[Dict[str, Any]] = None,
+    warrant: Optional[Any] = None,
+) -> EnforcementResult:
+    result = _enforcement_result_from_chain_error(
+        exc,
+        tool_name,
+        tool_args,
+        warrant_id,
+        constraint_auth_args=constraint_auth_args,
+        warrant=warrant,
+    )
+    _log_chain_enforcement_denial(tool_name, exc, result.error_type)
+    return result
+
+
 def _extract_violated_field(reason: Optional[str]) -> Optional[str]:
     """
     Extract the violated constraint field name from a validation reason.
@@ -980,8 +1014,7 @@ def enforce_tool_call(
                         warrant_id=warrant_id,
                     )
             except Exception as _exc:
-                logger.debug(f"Authorization denied for {tool_name}: {_exc}")
-                return _enforcement_result_from_chain_error(
+                return _enforcement_result_from_chain_error_with_logging(
                     _exc,
                     tool_name,
                     tool_args,
@@ -1037,8 +1070,7 @@ def enforce_tool_call(
                         approvals=_gate_approvals or [],
                     )
             except Exception as chain_err:
-                logger.debug(f"Authorization denied for {tool_name}: {chain_err}")
-                return _enforcement_result_from_chain_error(
+                return _enforcement_result_from_chain_error_with_logging(
                     chain_err,
                     tool_name,
                     tool_args,
@@ -1336,8 +1368,7 @@ async def enforce_tool_call_async(
                         error_type="invalid_pop", warrant_id=warrant_id,
                     )
             except Exception as _exc:
-                logger.debug(f"Authorization denied for {tool_name}: {_exc}")
-                return _enforcement_result_from_chain_error(
+                return _enforcement_result_from_chain_error_with_logging(
                     _exc,
                     tool_name,
                     tool_args,
@@ -1381,8 +1412,7 @@ async def enforce_tool_call_async(
                         approvals=_gate_approvals or [],
                     )
             except Exception as chain_err:
-                logger.debug(f"Authorization denied for {tool_name}: {chain_err}")
-                return _enforcement_result_from_chain_error(
+                return _enforcement_result_from_chain_error_with_logging(
                     chain_err,
                     tool_name,
                     tool_args,

--- a/tenuo-python/tenuo/a2a/errors.py
+++ b/tenuo-python/tenuo/a2a/errors.py
@@ -89,7 +89,7 @@ class A2AErrorCode:
     POP_REQUIRED = -32015  # -> 1600 (PopSignatureInvalid)
     POP_FAILED = -32016  # -> 1600 (PopSignatureInvalid)
     APPROVAL_REQUIRED = -32019  # -> 1707 (ApprovalRequired)
-    INSUFFICIENT_APPROVALS = -32020  # -> 1702 (InsufficientApprovals)
+    INSUFFICIENT_APPROVALS = -32020  # -> 1700 (InsufficientApprovals)
     INVALID_APPROVAL = -32021  # -> 1701 (ApprovalInvalid)
     REGISTRATION_DISABLED = -32017  # agent/register called but no handler configured
     REGISTRATION_DENIED = -32018  # handler explicitly denied the warrant request
@@ -113,7 +113,7 @@ class A2AErrorCode:
             cls.POP_REQUIRED: 1600,
             cls.POP_FAILED: 1600,
             cls.APPROVAL_REQUIRED: 1707,
-            cls.INSUFFICIENT_APPROVALS: 1702,
+            cls.INSUFFICIENT_APPROVALS: 1700,
             cls.INVALID_APPROVAL: 1701,
         }
         return mapping.get(jsonrpc_code)
@@ -134,8 +134,9 @@ class A2AErrorCode:
             1501: cls.CONSTRAINT_VIOLATION,
             1504: cls.UNKNOWN_CONSTRAINT,
             1600: cls.POP_FAILED,
+            1700: cls.INSUFFICIENT_APPROVALS,
             1701: cls.INVALID_APPROVAL,
-            1702: cls.INSUFFICIENT_APPROVALS,
+            1702: cls.INVALID_APPROVAL,
             1707: cls.APPROVAL_REQUIRED,
             1800: cls.REVOKED,
         }

--- a/tenuo-python/tenuo/a2a/errors.py
+++ b/tenuo-python/tenuo/a2a/errors.py
@@ -136,6 +136,8 @@ class A2AErrorCode:
             1600: cls.POP_FAILED,
             1700: cls.INSUFFICIENT_APPROVALS,
             1701: cls.INVALID_APPROVAL,
+            # A2A has no dedicated ApproverNotAuthorized JSON-RPC code; 1702
+            # (wire APPROVER_NOT_AUTHORIZED) maps to INVALID_APPROVAL (-32021).
             1702: cls.INVALID_APPROVAL,
             1707: cls.APPROVAL_REQUIRED,
             1800: cls.REVOKED,

--- a/tenuo-python/tenuo/a2a/server.py
+++ b/tenuo-python/tenuo/a2a/server.py
@@ -1174,14 +1174,15 @@ class A2AServer:
                 if isinstance(e, _ApprovalGate):
                     raise ApprovalRequiredError(
                         skill_id,
-                        request_hash=getattr(e, "request_hash", ""),
-                        min_approvals=getattr(e, "min_approvals", 1),
+                        request_hash=getattr(e, "request_hash", "") or e.details.get("request_hash", ""),
+                        min_approvals=getattr(e, "min_approvals", 1) or e.details.get("min_approvals", 1),
                     ) from e
                 if isinstance(e, _InsufficientApprovals):
+                    _details = getattr(e, "details", {}) or {}
                     raise InsufficientApprovalsError(
                         str(e),
-                        required=getattr(e, "required", 0),
-                        received=getattr(e, "received", 0),
+                        required=_details.get("required", 0),
+                        received=_details.get("received", 0),
                     ) from e
                 if isinstance(e, _InvalidApproval):
                     raise InvalidApprovalError(str(e)) from e

--- a/tenuo-python/tenuo/a2a/server.py
+++ b/tenuo-python/tenuo/a2a/server.py
@@ -1167,6 +1167,7 @@ class A2AServer:
                 logger.debug(f"PoP verified for skill '{skill_id}'")
             except Exception as e:
                 from tenuo.exceptions import (
+                    ApprovalExpired as _ApprovalExpired,
                     ApprovalGateTriggered as _ApprovalGate,
                     InsufficientApprovals as _InsufficientApprovals,
                     InvalidApproval as _InvalidApproval,
@@ -1185,6 +1186,8 @@ class A2AServer:
                         received=_details.get("received", 0),
                     ) from e
                 if isinstance(e, _InvalidApproval):
+                    raise InvalidApprovalError(str(e)) from e
+                if isinstance(e, _ApprovalExpired):
                     raise InvalidApprovalError(str(e)) from e
                 # Map PoP errors
                 error_msg = str(e)

--- a/tenuo-python/tenuo/a2a/server.py
+++ b/tenuo-python/tenuo/a2a/server.py
@@ -1840,9 +1840,8 @@ class A2AServer:
 
             raw_list = json.loads(_b64.b64decode(raw))
             return [SignedApproval.from_bytes(_b64.b64decode(item)) for item in raw_list]
-        except Exception:
-            logger.warning("Failed to decode %s", APPROVALS_HEADER, exc_info=True)
-            return None
+        except Exception as exc:
+            raise InvalidApprovalError(str(exc)) from exc
 
     # -------------------------------------------------------------------------
     # Audit Logging

--- a/tenuo-python/tenuo/autogen.py
+++ b/tenuo-python/tenuo/autogen.py
@@ -35,6 +35,7 @@ from .config import resolve_trusted_roots
 from .exceptions import (
     AuthorizationDenied,
     ConstraintViolation,
+    InsufficientApprovals,
     ToolNotAuthorized,
 )
 
@@ -437,6 +438,13 @@ class _Guard:
                 elif _is_tool_not_authorized(result.denial_reason or ""):
                     # Handle tool not in warrant from Rust Authorizer messages
                     raise ToolNotAuthorized(tool=tool_name)
+                elif result.error_type == "insufficient_approvals":
+                    meta = result.approval_metadata or {}
+                    raise InsufficientApprovals(
+                        required=meta.get("need", 0),
+                        received=meta.get("got", 0),
+                        detail=result.denial_reason or "",
+                    )
 
                 # Default to AuthorizationDenied for constraint violations and others
                 constraint_results = []
@@ -492,6 +500,13 @@ class _Guard:
                     )
                 elif _is_tool_not_authorized(result.denial_reason or ""):
                     raise ToolNotAuthorized(tool=tool_name)
+                elif result.error_type == "insufficient_approvals":
+                    meta = result.approval_metadata or {}
+                    raise InsufficientApprovals(
+                        required=meta.get("need", 0),
+                        received=meta.get("got", 0),
+                        detail=result.denial_reason or "",
+                    )
 
                 constraint_results = []
                 if result.constraint_violated:

--- a/tenuo-python/tenuo/crewai.py
+++ b/tenuo-python/tenuo/crewai.py
@@ -412,6 +412,29 @@ class WarrantToolDenied(TenuoCrewAIError):
         super().__init__(msg)
 
 
+class InsufficientApprovalsDenied(TenuoCrewAIError):
+    """Multi-sig threshold not met — caller should collect more approvals."""
+
+    error_code = "INSUFFICIENT_APPROVALS"
+
+    def __init__(
+        self,
+        tool: str,
+        reason: str,
+        *,
+        got: int = 0,
+        need: int = 0,
+        warrant_id: Optional[str] = None,
+    ):
+        self.tool = tool
+        self.got = got
+        self.need = need
+        self.warrant_id = warrant_id
+        super().__init__(
+            f"Insufficient approvals for '{tool}': got {got}, need {need}. {reason}"
+        )
+
+
 # =============================================================================
 # Audit Support
 # =============================================================================
@@ -1116,6 +1139,9 @@ class CrewAIGuard:
         if enforcement.error_type == "expired":
             return WarrantExpired(reason=reason)
         elif enforcement.error_type == "constraint_violation":
+            if enforcement.constraint_violated == "tool":
+                bound = self._warrant.bind(self._signing_key) if self._warrant and self._signing_key else None
+                return WarrantToolDenied(tool=tool_name, warrant_id=getattr(bound, "id", None))
             from tenuo import Wildcard as _Wildcard
             violated_field = enforcement.constraint_violated or "unknown_field"
             return CrewAIConstraintViolation(
@@ -1128,6 +1154,16 @@ class CrewAIGuard:
         elif enforcement.error_type == "tool_not_allowed":
             bound = self._warrant.bind(self._signing_key) if self._warrant and self._signing_key else None
             return WarrantToolDenied(tool=tool_name, warrant_id=getattr(bound, "id", None))
+        elif enforcement.error_type == "insufficient_approvals":
+            meta = enforcement.approval_metadata or {}
+            bound = self._warrant.bind(self._signing_key) if self._warrant and self._signing_key else None
+            return InsufficientApprovalsDenied(
+                tool_name,
+                reason,
+                got=meta.get("got", 0),
+                need=meta.get("need", 0),
+                warrant_id=getattr(bound, "id", None),
+            )
         elif enforcement.error_type in ("invalid_pop", "signature_invalid", "missing_signature"):
             return InvalidPoP(reason=reason)
         elif enforcement.error_type in ("authorization_failed", "configuration_error"):

--- a/tenuo-python/tenuo/exceptions.py
+++ b/tenuo-python/tenuo/exceptions.py
@@ -1227,7 +1227,7 @@ class InsufficientApprovals(ApprovalError):
     def __init__(self, required: int, received: int, detail: str = "", hint: Optional[str] = None):
         msg = f"Insufficient approvals: required {required}, received {received}"
         if detail:
-            msg = f"{msg}{detail}"
+            msg = f"{msg}: {detail}"
         super().__init__(msg, hint=hint)
         self.details = {"required": required, "received": received, "detail": detail}
 

--- a/tenuo-python/tenuo/fastapi.py
+++ b/tenuo-python/tenuo/fastapi.py
@@ -546,6 +546,19 @@ class TenuoGuard:
             expose_details = _config.get("expose_error_details", False)
 
             # Map specific errors to HTTP codes
+            if enforcement.error_type == "insufficient_approvals":
+                meta = enforcement.approval_metadata or {}
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "error": "insufficient_approvals",
+                        "message": reason,
+                        "got": meta.get("got", 0),
+                        "need": meta.get("need", 0),
+                        "request_id": request_id,
+                    },
+                )
+
             if enforcement.error_type == "expired" or (
                 "expired" in reason.lower() and "proof-of-possession" not in reason.lower()
             ):

--- a/tenuo-python/tenuo/fastapi.py
+++ b/tenuo-python/tenuo/fastapi.py
@@ -30,7 +30,14 @@ from typing import Any, Callable, Dict, List, Optional
 from tenuo_core import PublicKey, Warrant  # type: ignore[import-untyped]
 
 from tenuo._enforcement import EnforcementResult
-from tenuo.exceptions import ApprovalGateTriggered, DeserializationError, InsufficientApprovals, TenuoError
+from tenuo.approval import ApprovalRequired
+from tenuo.exceptions import (
+    ApprovalGateTriggered,
+    DeserializationError,
+    ErrorCode,
+    InsufficientApprovals,
+    TenuoError,
+)
 
 logger = logging.getLogger("tenuo.fastapi")
 
@@ -153,11 +160,16 @@ def configure_tenuo(
     @app.exception_handler(TenuoError)
     async def tenuo_error_handler(request: Request, exc: TenuoError):
         """Handle TenuoError exceptions with canonical wire codes."""
+        wire_code = exc.get_wire_code()
+        if wire_code in (ErrorCode.INSUFFICIENT_APPROVALS, ErrorCode.APPROVAL_GATE_TRIGGERED):
+            http_status = status.HTTP_409_CONFLICT
+        else:
+            http_status = exc.get_http_status()
         return JSONResponse(
-            status_code=exc.get_http_status(),
+            status_code=http_status,
             content={
                 "error": exc.get_wire_name(),
-                "error_code": exc.get_wire_code(),
+                "error_code": wire_code,
                 "message": str(exc),
                 "details": exc.details if expose_error_details else {},
             },
@@ -498,6 +510,21 @@ class TenuoGuard:
                 pop_signature=pop_sig_bytes,
                 parents=parents,
                 approvals=decoded_approvals,
+            )
+        except ApprovalRequired as approval_required:
+            req = approval_required.request
+            _rh = req.request_hash
+            if isinstance(_rh, (bytes, bytearray)):
+                _rh = _rh.hex()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "approval_required",
+                    "message": str(approval_required),
+                    "tool": req.tool,
+                    "request_hash": _rh,
+                    "min_approvals": req.min_approvals or 1,
+                },
             )
         except ApprovalGateTriggered as gate:
             raise HTTPException(

--- a/tenuo-python/tenuo/fastapi.py
+++ b/tenuo-python/tenuo/fastapi.py
@@ -30,7 +30,7 @@ from typing import Any, Callable, Dict, List, Optional
 from tenuo_core import PublicKey, Warrant  # type: ignore[import-untyped]
 
 from tenuo._enforcement import EnforcementResult
-from tenuo.exceptions import ApprovalGateTriggered, DeserializationError, TenuoError
+from tenuo.exceptions import ApprovalGateTriggered, DeserializationError, InsufficientApprovals, TenuoError
 
 logger = logging.getLogger("tenuo.fastapi")
 
@@ -509,6 +509,19 @@ class TenuoGuard:
                     "request_id": gate.request_id,
                     "request_hash": gate.request_hash,
                     "min_approvals": gate.min_approvals,
+                },
+            )
+        except InsufficientApprovals as insuf:
+            # Multi-sig threshold not met — distinct from a scope denial.
+            # 409 Conflict mirrors the ApprovalGateTriggered shape so callers
+            # can use the same retry-with-approval branch for both flows.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "insufficient_approvals",
+                    "message": str(insuf),
+                    "got": insuf.details.get("received", 0) if hasattr(insuf, "details") else 0,
+                    "need": insuf.details.get("required", 0) if hasattr(insuf, "details") else 0,
                 },
             )
 

--- a/tenuo-python/tenuo/fastapi.py
+++ b/tenuo-python/tenuo/fastapi.py
@@ -513,16 +513,13 @@ class TenuoGuard:
             )
         except ApprovalRequired as approval_required:
             req = approval_required.request
-            _rh = req.request_hash
-            if isinstance(_rh, (bytes, bytearray)):
-                _rh = _rh.hex()
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail={
                     "error": "approval_required",
                     "message": str(approval_required),
                     "tool": req.tool,
-                    "request_hash": _rh,
+                    "request_hash": req.request_hash.hex(),
                     "min_approvals": req.min_approvals or 1,
                 },
             )

--- a/tenuo-python/tenuo/fastapi.py
+++ b/tenuo-python/tenuo/fastapi.py
@@ -497,8 +497,14 @@ class TenuoGuard:
 
                 raw_list = json.loads(base64.b64decode(x_tenuo_approvals))
                 decoded_approvals = [SignedApproval.from_bytes(base64.b64decode(item)) for item in raw_list]
-            except Exception:
-                logger.warning("Failed to decode X-Tenuo-Approvals header", exc_info=True)
+            except Exception as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={
+                        "error": "invalid_approval",
+                        "message": f"Invalid X-Tenuo-Approvals header: {exc}",
+                    },
+                ) from exc
 
         # 5. Authorize using Adapter (include delegation chain parents if present)
         parents = getattr(request.state, "tenuo_parents", [])

--- a/tenuo-python/tenuo/google_adk/guard.py
+++ b/tenuo-python/tenuo/google_adk/guard.py
@@ -68,6 +68,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from tenuo._enforcement import EnforcementResult, enforce_tool_call, enforce_tool_call_async
 from tenuo.config import resolve_trusted_roots
+from tenuo.exceptions import InsufficientApprovals
 
 if TYPE_CHECKING:
     from google.adk.tools.base_tool import BaseTool  # type: ignore[import-not-found,import-untyped]
@@ -426,18 +427,22 @@ class TenuoGuard:
                     if result.error_type == "expired":
                         return self._deny("Warrant expired", tool.name, args,
                                           start_ns=start_ns, _cp_already_emitted=True)
-                    else:
-                        # Get detailed reason for other denial types
-                        reason, constraint_param, constraint = self._get_denial_info(warrant, skill_name, validation_args)
-                        return self._deny(
-                            f"Authorization failed: {reason}",
-                            tool.name,
-                            args,
-                            constraint_param=constraint_param,
-                            constraint=constraint,
-                            start_ns=start_ns,
-                            _cp_already_emitted=True,
+                    if result.error_type == "insufficient_approvals":
+                        return self._deny_insufficient_approvals(
+                            result, tool.name, args,
+                            start_ns=start_ns, _cp_already_emitted=True,
                         )
+                    # Get detailed reason for other denial types
+                    reason, constraint_param, constraint = self._get_denial_info(warrant, skill_name, validation_args)
+                    return self._deny(
+                        f"Authorization failed: {reason}",
+                        tool.name,
+                        args,
+                        constraint_param=constraint_param,
+                        constraint=constraint,
+                        start_ns=start_ns,
+                        _cp_already_emitted=True,
+                    )
 
                 # PoP authorized - tool call is allowed
                 self._audit("tool_allowed", tool.name, args, warrant)
@@ -620,17 +625,21 @@ class TenuoGuard:
                     if result.error_type == "expired":
                         return self._deny("Warrant expired", tool.name, args,
                                           start_ns=start_ns, _cp_already_emitted=True)
-                    else:
-                        reason, constraint_param, constraint = self._get_denial_info(warrant, skill_name, validation_args)
-                        return self._deny(
-                            f"Authorization failed: {reason}",
-                            tool.name,
-                            args,
-                            constraint_param=constraint_param,
-                            constraint=constraint,
-                            start_ns=start_ns,
-                            _cp_already_emitted=True,
+                    if result.error_type == "insufficient_approvals":
+                        return self._deny_insufficient_approvals(
+                            result, tool.name, args,
+                            start_ns=start_ns, _cp_already_emitted=True,
                         )
+                    reason, constraint_param, constraint = self._get_denial_info(warrant, skill_name, validation_args)
+                    return self._deny(
+                        f"Authorization failed: {reason}",
+                        tool.name,
+                        args,
+                        constraint_param=constraint_param,
+                        constraint=constraint,
+                        start_ns=start_ns,
+                        _cp_already_emitted=True,
+                    )
 
                 self._audit("tool_allowed", tool.name, args, warrant)
                 return None
@@ -777,6 +786,44 @@ class TenuoGuard:
         except Exception as e:
             logger.debug(f"why_denied() failed: {e}")
         return "not authorized", None, None
+
+    def _deny_insufficient_approvals(
+        self,
+        result: EnforcementResult,
+        tool_name: str,
+        args: Dict[str, Any],
+        *,
+        start_ns: Optional[int] = None,
+        _cp_already_emitted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Handle partial multi-sig with structured got/need for retry loops."""
+        meta = result.approval_metadata or {}
+        got = meta.get("got", 0)
+        need = meta.get("need", 0)
+        reason = result.denial_reason or f"Insufficient approvals: got {got}, need {need}"
+
+        if self._dry_run:
+            logger.warning(f"DRY RUN: Would deny {tool_name} - {reason}")
+            self._audit("tool_dry_run_denied", tool_name, args, reason=reason)
+            return None
+
+        self._audit("tool_denied", tool_name, args, reason=reason)
+
+        if self._on_denial == "raise":
+            raise InsufficientApprovals(
+                required=need,
+                received=got,
+                detail=reason,
+            )
+
+        message = reason if self._denial_detail == "full" else "Insufficient approvals."
+        return {
+            "error": "insufficient_approvals",
+            "message": message,
+            "got": got,
+            "need": need,
+            "details": reason if self._denial_detail == "full" else None,
+        }
 
     def _deny(
         self,

--- a/tenuo-python/tenuo/langgraph.py
+++ b/tenuo-python/tenuo/langgraph.py
@@ -90,7 +90,7 @@ from ._enforcement import enforce_tool_call, enforce_tool_call_async, filter_too
 from .bound_warrant import BoundWarrant
 from .config import resolve_trusted_roots
 from .approval import ApprovalDenied, ApprovalRequired, ApprovalVerificationError
-from .exceptions import ApprovalGateTriggered, ConfigurationError
+from .exceptions import ApprovalGateTriggered, ConfigurationError, InsufficientApprovals
 from .keys import KeyRegistry, load_signing_key_from_env
 
 check_langgraph_compat()
@@ -237,6 +237,13 @@ def _authorize_tool_request(
             logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
     if not result.allowed:
+        if result.error_type == "insufficient_approvals":
+            meta = result.approval_metadata or {}
+            raise InsufficientApprovals(
+                required=meta.get("need", 0),
+                received=meta.get("got", 0),
+                detail=result.denial_reason or "",
+            )
         logger.warning(f"[{request_id}] Tool '{tool_name}' denied: {result.denial_reason}")
         error_msg = (
             f"Authorization denied: {result.denial_reason}" if debug
@@ -312,6 +319,13 @@ async def _authorize_tool_request_async(
             logger.warning("Control plane emission failed for '%s'; audit event lost", tool_name, exc_info=True)
 
     if not result.allowed:
+        if result.error_type == "insufficient_approvals":
+            meta = result.approval_metadata or {}
+            raise InsufficientApprovals(
+                required=meta.get("need", 0),
+                received=meta.get("got", 0),
+                detail=result.denial_reason or "",
+            )
         logger.warning(f"[{request_id}] Tool '{tool_name}' denied: {result.denial_reason}")
         error_msg = (
             f"Authorization denied: {result.denial_reason}" if debug

--- a/tenuo-python/tenuo/mcp/fastmcp_middleware.py
+++ b/tenuo-python/tenuo/mcp/fastmcp_middleware.py
@@ -129,6 +129,12 @@ def _denial_tool_return(verification: MCPVerificationResult) -> _VerifierDenialT
     }
     if verification.request_hash:
         tenuo_block["request_hash"] = verification.request_hash
+    if verification.approval_metadata:
+        meta = verification.approval_metadata
+        if "got" in meta:
+            tenuo_block["got"] = meta["got"]
+        if "need" in meta:
+            tenuo_block["need"] = meta["need"]
     call = mt.CallToolResult(
         content=[TextContent(type="text", text=message)],
         isError=True,

--- a/tenuo-python/tenuo/mcp/server.py
+++ b/tenuo-python/tenuo/mcp/server.py
@@ -112,6 +112,7 @@ from ..exceptions import (
     ApprovalGateTriggered,
     ConstraintViolation,
     ExpiredError,
+    InsufficientApprovals,
     MissingSignature,
     SignatureInvalid,
     SignatureMismatch,
@@ -739,6 +740,34 @@ class MCPVerifier:
                 denial_reason=(
                     f"Approval required for '{tool_name}'. "
                     "Re-submit the call with approvals in _meta.tenuo.approvals."
+                ),
+                jsonrpc_error_code=-32002,
+            )
+        except InsufficientApprovals as insuf_exc:
+            # Multi-sig threshold not met — the warrant does authorise this tool
+            # but not enough approval signatures were supplied.  Use -32002 (same
+            # as ApprovalGateTriggered) so callers can build a single
+            # retry-with-approval branch for both approval-gate and multi-sig
+            # flows, rather than treating this as a flat access denial (-32001).
+            _got = insuf_exc.details.get("received", 0) if hasattr(insuf_exc, "details") else 0
+            _need = insuf_exc.details.get("required", 0) if hasattr(insuf_exc, "details") else 0
+            logger.info(
+                "Insufficient approvals for '%s' (warrant=%s): got %d, need %d",
+                tool_name,
+                warrant_id,
+                _got,
+                _need,
+            )
+            result = MCPVerificationResult(
+                allowed=False,
+                tool=tool_name,
+                clean_arguments=clean_arguments,
+                constraints=constraints,
+                warrant_id=warrant_id,
+                denial_reason=(
+                    f"Insufficient approvals for '{tool_name}': "
+                    f"got {_got}, need {_need}. "
+                    "Re-submit with additional approvals in _meta.tenuo.approvals."
                 ),
                 jsonrpc_error_code=-32002,
             )

--- a/tenuo-python/tenuo/mcp/server.py
+++ b/tenuo-python/tenuo/mcp/server.py
@@ -109,10 +109,12 @@ from typing import Any, Dict, List, Optional
 
 from .._pop_canonicalize import strip_none_values
 from ..exceptions import (
+    ApprovalExpired,
     ApprovalGateTriggered,
     ConstraintViolation,
     ExpiredError,
     InsufficientApprovals,
+    InvalidApproval,
     MissingSignature,
     SignatureInvalid,
     SignatureMismatch,
@@ -197,6 +199,9 @@ class MCPVerificationResult:
     re-deriving it from ``(warrant_id, tool, args, holder_key)``.
     """
 
+    approval_metadata: Optional[Dict[str, Any]] = field(default=None)
+    """Structured approval counts for ``-32002`` responses (``got`` / ``need``)."""
+
     @property
     def is_approval_required(self) -> bool:
         """``True`` when an approval gate fired and approvals must be supplied."""
@@ -227,8 +232,16 @@ class MCPVerificationResult:
             "code": self.jsonrpc_error_code or -32001,
             "message": self.denial_reason or "Authorization denied",
         }
+        data: Dict[str, Any] = {}
         if self.request_hash:
-            error["data"] = {"request_hash": self.request_hash}
+            data["request_hash"] = self.request_hash
+        if self.approval_metadata:
+            if "got" in self.approval_metadata:
+                data["got"] = self.approval_metadata["got"]
+            if "need" in self.approval_metadata:
+                data["need"] = self.approval_metadata["need"]
+        if data:
+            error["data"] = data
         return error
 
 
@@ -770,6 +783,23 @@ class MCPVerifier:
                     "Re-submit with additional approvals in _meta.tenuo.approvals."
                 ),
                 jsonrpc_error_code=-32002,
+                approval_metadata={"got": _got, "need": _need},
+            )
+        except (InvalidApproval, ApprovalExpired) as approval_exc:
+            logger.info(
+                "MCP call denied for '%s' (warrant=%s): %s",
+                tool_name,
+                warrant_id,
+                approval_exc,
+            )
+            result = MCPVerificationResult(
+                allowed=False,
+                tool=tool_name,
+                clean_arguments=clean_arguments,
+                constraints=constraints,
+                warrant_id=warrant_id,
+                denial_reason=_access_denial_reason(approval_exc),
+                jsonrpc_error_code=-32001,
             )
         except (
             ConstraintViolation,

--- a/tenuo-python/tenuo/openai.py
+++ b/tenuo-python/tenuo/openai.py
@@ -135,8 +135,29 @@ check_openai_compat()
 # Import shared enforcement logic (after version check)
 from tenuo._enforcement import DenialPolicy, EnforcementResult, enforce_tool_call, enforce_tool_call_async, handle_denial  # noqa: E402
 from tenuo.config import resolve_trusted_roots  # noqa: E402
+from tenuo.exceptions import InsufficientApprovals  # noqa: E402
 
 logger = logging.getLogger("tenuo.openai")
+
+
+def _raise_for_enforcement_denial(tool_name: str, result: EnforcementResult) -> None:
+    """Map an ``EnforcementResult`` denial to a typed OpenAI adapter exception."""
+    if result.error_type == "expired":
+        raise WarrantDenied(tool_name, "warrant expired")
+    if result.error_type == "insufficient_approvals":
+        meta = result.approval_metadata or {}
+        raise InsufficientApprovals(
+            required=meta.get("need", 0),
+            received=meta.get("got", 0),
+            detail=result.denial_reason or "",
+        )
+    if result.error_type == "constraint_violation":
+        raise WarrantDenied(tool_name, result.denial_reason or "constraint violation")
+    if result.error_type == "tool_not_allowed":
+        raise WarrantDenied(tool_name, result.denial_reason or "tool not in warrant")
+    if result.error_type == "invalid_pop":
+        raise WarrantDenied(tool_name, result.denial_reason or "invalid proof-of-possession")
+    raise WarrantDenied(tool_name, result.denial_reason or "not authorized by warrant")
 
 
 def enable_debug(handler: Optional[logging.Handler] = None) -> None:
@@ -536,10 +557,7 @@ def verify_tool_call(
 
         if not result.allowed:
             logger.debug(f"Tier 2: Authorization DENIED for '{tool_name}'")
-            if result.error_type == "expired":
-                raise WarrantDenied(tool_name, "warrant expired")
-            else:
-                raise WarrantDenied(tool_name, result.denial_reason or "not authorized by warrant")
+            _raise_for_enforcement_denial(tool_name, result)
         else:
             logger.debug(f"Tier 2: Authorization GRANTED for '{tool_name}'")
 
@@ -637,10 +655,7 @@ async def verify_tool_call_async(
         )
 
         if not result.allowed:
-            if result.error_type == "expired":
-                raise WarrantDenied(tool_name, "warrant expired")
-            else:
-                raise WarrantDenied(tool_name, result.denial_reason or "not authorized by warrant")
+            _raise_for_enforcement_denial(tool_name, result)
 
     if deny_tools and tool_name in deny_tools:
         raise ToolDenied(tool_name, "Tool is in denylist")

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -17,7 +17,15 @@ import threading
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from tenuo.exceptions import ApprovalGateTriggered, InsufficientApprovals, ToolNotAuthorized
+from tenuo.exceptions import (
+    ApprovalGateTriggered,
+    ApprovalExpired,
+    ConstraintViolation,
+    InsufficientApprovals,
+    InvalidApproval,
+    RevokedError,
+    ToolNotAuthorized,
+)
 from tenuo.temporal._constants import (
     TENUO_APPROVALS_HEADER,
     TENUO_ARG_KEYS_HEADER,
@@ -990,15 +998,15 @@ class TenuoActivityInboundInterceptor:
             ApprovalGateTriggered,
             InsufficientApprovals,
             ToolNotAuthorized,
+            ConstraintViolation,
+            InvalidApproval,
+            ApprovalExpired,
+            RevokedError,
         ) as auth_exc:
-            # ``ApprovalGateTriggered``, ``InsufficientApprovals``, and
-            # ``ToolNotAuthorized`` are listed explicitly so they reach the wire
-            # with their own ``ApplicationError.type`` (``approval_required`` /
-            # ``insufficient_approvals`` / ``tool_not_authorized`` via
-            # ``_error_type_for_wire``) rather than being collapsed into a
-            # generic ``TemporalConstraintViolation`` by the fallback branch
-            # below.  Clients can then distinguish "needs approval", "wrong
-            # tool", and "constraint violated" without string-matching.
+            # Approval, tool, constraint, and revocation errors are listed
+            # explicitly so they reach the wire with their own
+            # ``ApplicationError.type`` via ``_error_type_for_wire`` rather than
+            # being collapsed into a generic ``TemporalConstraintViolation``.
             if _active_span is not None:
                 _active_span.set_attribute("tenuo.decision", "deny")
                 _active_span.set_attribute("tenuo.constraint_violated", "")

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -17,7 +17,7 @@ import threading
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from tenuo.exceptions import ApprovalGateTriggered
+from tenuo.exceptions import ApprovalGateTriggered, InsufficientApprovals
 from tenuo.temporal._constants import (
     TENUO_APPROVALS_HEADER,
     TENUO_ARG_KEYS_HEADER,
@@ -988,13 +988,15 @@ class TenuoActivityInboundInterceptor:
             ChainValidationError,
             WarrantExpired,
             ApprovalGateTriggered,
+            InsufficientApprovals,
         ) as auth_exc:
-            # ``ApprovalGateTriggered`` is listed explicitly so it reaches the
-            # wire with its own ``ApplicationError.type`` (``approval_required``
-            # via ``_error_type_for_wire``) rather than being collapsed into a
-            # generic ``TemporalConstraintViolation`` by the fallback branch
-            # below. Clients can then distinguish "needs approval" from
-            # "denied" without string-matching the message.
+            # ``ApprovalGateTriggered`` and ``InsufficientApprovals`` are listed
+            # explicitly so they reach the wire with their own
+            # ``ApplicationError.type`` (``approval_required`` /
+            # ``insufficient_approvals`` via ``_error_type_for_wire``) rather
+            # than being collapsed into a generic ``TemporalConstraintViolation``
+            # by the fallback branch below.  Clients can then distinguish
+            # "needs approval" from "denied" without string-matching the message.
             if _active_span is not None:
                 _active_span.set_attribute("tenuo.decision", "deny")
                 _active_span.set_attribute("tenuo.constraint_violated", "")

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -1036,7 +1036,14 @@ class TenuoActivityInboundInterceptor:
                 if _span_ctx is not None:
                     _span_ctx.__exit__(None, None, None)
                     _span_ctx = None
-            raise self._wrap_as_non_retryable(auth_exc) from auth_exc
+            # Honor dry_run / on_denial like the generic branch below, but keep
+            # raising ``auth_exc`` itself so it reaches the wire with its own
+            # ``ApplicationError.type`` rather than a generic
+            # ``TemporalConstraintViolation``. In dry-run mode the activity still
+            # executes (shadow); in ``log`` mode it is denied without raising.
+            if self._config.on_denial == "raise" and not self._config.dry_run:
+                raise self._wrap_as_non_retryable(auth_exc) from auth_exc
+            return await _deny_or_continue(tool=tool_name, reason=str(auth_exc))
         except Exception as e:
             try:
                 from tenuo.exceptions import TenuoError as _TenuoError

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -17,7 +17,7 @@ import threading
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from tenuo.exceptions import ApprovalGateTriggered, InsufficientApprovals
+from tenuo.exceptions import ApprovalGateTriggered, InsufficientApprovals, ToolNotAuthorized
 from tenuo.temporal._constants import (
     TENUO_APPROVALS_HEADER,
     TENUO_ARG_KEYS_HEADER,
@@ -989,14 +989,16 @@ class TenuoActivityInboundInterceptor:
             WarrantExpired,
             ApprovalGateTriggered,
             InsufficientApprovals,
+            ToolNotAuthorized,
         ) as auth_exc:
-            # ``ApprovalGateTriggered`` and ``InsufficientApprovals`` are listed
-            # explicitly so they reach the wire with their own
-            # ``ApplicationError.type`` (``approval_required`` /
-            # ``insufficient_approvals`` via ``_error_type_for_wire``) rather
-            # than being collapsed into a generic ``TemporalConstraintViolation``
-            # by the fallback branch below.  Clients can then distinguish
-            # "needs approval" from "denied" without string-matching the message.
+            # ``ApprovalGateTriggered``, ``InsufficientApprovals``, and
+            # ``ToolNotAuthorized`` are listed explicitly so they reach the wire
+            # with their own ``ApplicationError.type`` (``approval_required`` /
+            # ``insufficient_approvals`` / ``tool_not_authorized`` via
+            # ``_error_type_for_wire``) rather than being collapsed into a
+            # generic ``TemporalConstraintViolation`` by the fallback branch
+            # below.  Clients can then distinguish "needs approval", "wrong
+            # tool", and "constraint violated" without string-matching.
             if _active_span is not None:
                 _active_span.set_attribute("tenuo.decision", "deny")
                 _active_span.set_attribute("tenuo.constraint_violated", "")

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -583,6 +583,20 @@ class TenuoWorkerInterceptor(_TemporalWorkerInterceptor):
 
 # ── Activity Inbound Interceptor ─────────────────────────────────────────
 
+
+def _constraint_label_from_auth_exc(auth_exc: Exception) -> Optional[str]:
+    """Extract a constraint label for denial metrics/audit from an auth exception."""
+    from tenuo.exceptions import ConstraintViolation as CoreConstraintViolation
+
+    if isinstance(auth_exc, TemporalConstraintViolation):
+        return auth_exc.constraint
+    if isinstance(auth_exc, CoreConstraintViolation):
+        from tenuo._enforcement import _constraint_field_from_exception
+
+        return _constraint_field_from_exception(auth_exc)
+    return None
+
+
 class TenuoActivityInboundInterceptor:
     """Activity-level interceptor that performs authorization checks."""
 
@@ -1007,6 +1021,15 @@ class TenuoActivityInboundInterceptor:
             # explicitly so they reach the wire with their own
             # ``ApplicationError.type`` via ``_error_type_for_wire`` rather than
             # being collapsed into a generic ``TemporalConstraintViolation``.
+            self._emit_denial_event(
+                info=info,
+                warrant=warrant,
+                tool=tool_name,
+                args=args,
+                reason=str(auth_exc),
+                constraint=_constraint_label_from_auth_exc(auth_exc),
+                start_ns=start_ns,
+            )
             if _active_span is not None:
                 _active_span.set_attribute("tenuo.decision", "deny")
                 _active_span.set_attribute("tenuo.constraint_violated", "")

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -966,7 +966,7 @@ class TenuoActivityInboundInterceptor:
                     ) from _e
 
             # -- 11. Multi-Sig Approval Resolution --
-            gate_approvals = self._resolve_approval_gate_approvals(
+            gate_approvals = await self._resolve_approval_gate_approvals(
                 warrant, tool_name, args, headers,
             )
 
@@ -1129,7 +1129,7 @@ class TenuoActivityInboundInterceptor:
 
         return await self._next.execute_activity(input)
 
-    def _resolve_approval_gate_approvals(
+    async def _resolve_approval_gate_approvals(
         self,
         warrant: Any,
         tool_name: str,
@@ -1152,51 +1152,39 @@ class TenuoActivityInboundInterceptor:
                     CoreSignedApproval.from_bytes(base64.b64decode(a))
                     for a in approvals_list
                 ]
-            except Exception as e:
-                logger.warning(f"Failed to decode approvals header: {e}")
+            except Exception as exc:
+                raise InvalidApproval(
+                    f"Malformed x-tenuo-approvals header: {exc}",
+                ) from exc
 
         handler = self._config.approval_handler if self._config else None
         if handler is not None:
-            try:
-                from tenuo_core import py_compute_request_hash as _compute_hash
-                from tenuo.approval import ApprovalRequest
+            from tenuo_core import py_compute_request_hash as _compute_hash
+            from tenuo.approval import ApprovalRequest
 
-                holder_key = getattr(warrant, "holder_key", None)
-                warrant_id = getattr(warrant, "id", "") or ""
-                request_hash = _compute_hash(warrant_id, tool_name, args, holder_key)
-                request = ApprovalRequest.for_warrant_gate(
-                    tool_name,
-                    args,
-                    warrant,
-                    request_hash,
-                    holder_key=holder_key,
-                )
+            holder_key = getattr(warrant, "holder_key", None)
+            warrant_id = getattr(warrant, "id", "") or ""
+            request_hash = _compute_hash(warrant_id, tool_name, args, holder_key)
+            request = ApprovalRequest.for_warrant_gate(
+                tool_name,
+                args,
+                warrant,
+                request_hash,
+                holder_key=holder_key,
+            )
 
-                result = handler(request)
-                if _inspect.isawaitable(result):
-                    import asyncio
-                    from typing import cast, Coroutine as _Coro
-                    coro = cast(_Coro[Any, Any, Any], result)
-                    try:
-                        loop = asyncio.get_running_loop()
-                    except RuntimeError:
-                        loop = None
-                    if loop and loop.is_running():
-                        future = asyncio.run_coroutine_threadsafe(coro, loop)
-                        result = future.result(timeout=300)
-                    else:
-                        result = asyncio.run(coro)
+            result = handler(request)
+            if _inspect.isawaitable(result):
+                result = await result
 
-                collected = result if isinstance(result, list) else [result]
+            collected = result if isinstance(result, list) else [result]
 
-                approvers = warrant.required_approvers()
-                threshold = warrant.approval_threshold()
-                from tenuo_core import verify_approvals as _verify
-                _verify(request_hash, collected, approvers, threshold)
+            approvers = warrant.required_approvers()
+            threshold = warrant.approval_threshold()
+            from tenuo_core import verify_approvals as _verify
+            _verify(request_hash, collected, approvers, threshold)
 
-                return collected
-            except Exception:
-                raise
+            return collected
 
         raise ApprovalGateTriggered(
             tool=tool_name,

--- a/tenuo-python/tests/adapters/test_a2a_approvals.py
+++ b/tenuo-python/tests/adapters/test_a2a_approvals.py
@@ -146,7 +146,7 @@ class TestApprovalErrors:
         rpc = err.to_jsonrpc_error()
         assert rpc["data"]["required"] == 3
         assert rpc["data"]["received"] == 1
-        assert rpc["data"]["tenuo_code"] == 1702
+        assert rpc["data"]["tenuo_code"] == 1700
 
     def test_invalid_approval_error_code(self):
         err = InvalidApprovalError("bad format")

--- a/tenuo-python/tests/adapters/test_a2a_approvals.py
+++ b/tenuo-python/tests/adapters/test_a2a_approvals.py
@@ -117,11 +117,12 @@ class TestDecodeApprovals:
         assert result is not None
         assert len(result) == 1
 
-    def test_returns_none_on_malformed_payload(self):
-        """Malformed approval data returns None (logged, not raised)."""
+    def test_raises_invalid_approval_on_malformed_payload(self):
+        """Malformed approval data raises InvalidApprovalError (-32021)."""
         wire_value = base64.b64encode(b"not valid json").decode()
         req = _make_request({APPROVALS_HEADER: wire_value})
-        assert A2AServer._decode_approvals(req, {}) is None
+        with pytest.raises(InvalidApprovalError):
+            A2AServer._decode_approvals(req, {})
 
 
 # =============================================================================

--- a/tenuo-python/tests/adapters/test_fastapi_integration.py
+++ b/tenuo-python/tests/adapters/test_fastapi_integration.py
@@ -27,6 +27,7 @@ try:
 
     from tenuo.fastapi import (  # type: ignore[no-redef]
         FASTAPI_AVAILABLE,
+        X_TENUO_APPROVALS,
         X_TENUO_POP,
         X_TENUO_WARRANT,
         SecurityContext,
@@ -87,6 +88,27 @@ class TestFastAPIIntegration:
         resp = client.get("/search?query=test", headers=headers)
         assert resp.status_code == 200
         assert resp.json()["query"] == "test"
+
+    def test_malformed_approvals_header_returns_400(self, app, client, key):
+        """Malformed X-Tenuo-Approvals must fail closed with 400, not be ignored."""
+        @app.get("/search")
+        def search(ctx: SecurityContext = Depends(TenuoGuard("search"))):
+            return {"status": "ok"}
+
+        warrant = Warrant.mint_builder().tool("search").mint(key)
+        args = {"query": "test"}
+        pop_sig = warrant.sign(key, "search", args, int(time.time()))
+        pop_b64 = base64.b64encode(pop_sig).decode("ascii")
+        bad_approvals = base64.b64encode(b"not-json").decode("ascii")
+
+        headers = {
+            X_TENUO_WARRANT: warrant.to_base64(),
+            X_TENUO_POP: pop_b64,
+            X_TENUO_APPROVALS: bad_approvals,
+        }
+        resp = client.get("/search?query=test", headers=headers)
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "invalid_approval"
 
     def test_invalid_pop_signature_returns_403(self, app, client, key):
         @app.get("/search")

--- a/tenuo-python/tests/adapters/test_langgraph.py
+++ b/tenuo-python/tests/adapters/test_langgraph.py
@@ -1055,7 +1055,10 @@ class TestPhilosophyAndDesign:
 
         assert not result.allowed
 
-        # Tool-scope denials log at DEBUG on tenuo.enforcement (not WARNING).
+        # The warrant is bound against an untrusted root, so this denies as a
+        # trust/signature failure (invalid_pop) which logs at WARNING. Assert at
+        # DEBUG+ so the test stays robust regardless of which denial path fires —
+        # the contract is only that denials are logged for security monitoring.
         denial_records = [
             r for r in caplog.records
             if r.levelno >= logging.DEBUG and "denied" in r.getMessage().lower()

--- a/tenuo-python/tests/adapters/test_langgraph.py
+++ b/tenuo-python/tests/adapters/test_langgraph.py
@@ -1047,23 +1047,23 @@ class TestPhilosophyAndDesign:
         key = SigningKey.generate()
         registry.register("audit-denial-key", key)
 
-        warrant, _ = Warrant.quick_mint(tools=["search"], ttl=3600)
-        bound = warrant.bind(key, trusted_roots=[key.public_key])
+        warrant, mint_key = Warrant.quick_mint(tools=["search"], ttl=3600)
+        bound = warrant.bind(mint_key, trusted_roots=[mint_key.public_key])
 
         with caplog.at_level(logging.DEBUG, logger="tenuo.enforcement"):
             result = enforce_tool_call("delete_file", {"path": "/"}, bound)
 
         assert not result.allowed
+        assert result.error_type == "constraint_violation"
 
-        # The warrant is bound against an untrusted root, so this denies as a
-        # trust/signature failure (invalid_pop) which logs at WARNING. Assert at
-        # DEBUG+ so the test stays robust regardless of which denial path fires —
-        # the contract is only that denials are logged for security monitoring.
+        # Tool not in warrant — expected denial logged at DEBUG on tenuo.enforcement.
         denial_records = [
             r for r in caplog.records
-            if r.levelno >= logging.DEBUG and "denied" in r.getMessage().lower()
+            if r.name == "tenuo.enforcement"
+            and r.levelno >= logging.DEBUG
+            and "denied" in r.getMessage().lower()
         ]
-        assert len(denial_records) >= 1, "Denied auth must be logged for security monitoring"
+        assert denial_records, "Denied auth must be logged for security monitoring"
 
     def test_opaque_errors_dont_leak_constraint_details(self, registry):
         """

--- a/tenuo-python/tests/adapters/test_langgraph.py
+++ b/tenuo-python/tests/adapters/test_langgraph.py
@@ -1050,14 +1050,17 @@ class TestPhilosophyAndDesign:
         warrant, _ = Warrant.quick_mint(tools=["search"], ttl=3600)
         bound = warrant.bind(key, trusted_roots=[key.public_key])
 
-        with caplog.at_level(logging.WARNING, logger="tenuo"):
+        with caplog.at_level(logging.DEBUG, logger="tenuo.enforcement"):
             result = enforce_tool_call("delete_file", {"path": "/"}, bound)
 
         assert not result.allowed
 
-        # Check for denial log
-        denial_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
-        assert len(denial_records) >= 1, "Denied auth must be logged at WARNING+"
+        # Tool-scope denials log at DEBUG on tenuo.enforcement (not WARNING).
+        denial_records = [
+            r for r in caplog.records
+            if r.levelno >= logging.DEBUG and "denied" in r.getMessage().lower()
+        ]
+        assert len(denial_records) >= 1, "Denied auth must be logged for security monitoring"
 
     def test_opaque_errors_dont_leak_constraint_details(self, registry):
         """

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -2884,6 +2884,66 @@ class TestApprovalGates:
         assert "approval" in msg.lower() or "gate" in msg.lower() or \
             isinstance(exc_info.value, ApprovalGateTriggered)
 
+    def test_malformed_approvals_header_raises_invalid_approval(self):
+        """Malformed x-tenuo-approvals must raise InvalidApproval, not be ignored."""
+        import time as _time
+
+        from tenuo import SigningKey
+        from tenuo.exceptions import InvalidApproval
+
+        control_key = SigningKey.generate()
+        agent_key = SigningKey.generate()
+        approver_key = SigningKey.generate()
+
+        warrant = self._mint_gated_warrant(
+            control_key, agent_key, approver_key=approver_key,
+        )
+        pop = warrant.sign(agent_key, "deploy", {}, int(_time.time()))
+
+        cfg = TenuoPluginConfig(
+            key_resolver=EnvKeyResolver(),
+            trusted_roots=[control_key.public_key],
+        )
+        plugin = TenuoWorkerInterceptor(cfg)
+        info, inp = self._build_activity_inputs(
+            warrant, pop, approvals_header=b"not-json",
+        )
+
+        with pytest.raises((InvalidApproval, Exception)) as exc_info:
+            self._run(plugin, info, inp)
+        msg = str(exc_info.value).lower()
+        assert isinstance(exc_info.value, InvalidApproval) or "invalid" in msg
+
+    def test_async_approval_handler_allows_gated_activity(self):
+        """Async approval_handler must be awaited, not deadlocked on the activity loop."""
+        import time as _time
+
+        from tenuo import SigningKey
+
+        control_key = SigningKey.generate()
+        agent_key = SigningKey.generate()
+        approver_key = SigningKey.generate()
+
+        warrant = self._mint_gated_warrant(
+            control_key, agent_key, approver_key=approver_key,
+        )
+        signed = self._sign_approval(warrant, approver_key, "deploy", {})
+        pop = warrant.sign(agent_key, "deploy", {}, int(_time.time()))
+
+        async def handler(request):
+            return signed
+
+        cfg = TenuoPluginConfig(
+            key_resolver=EnvKeyResolver(),
+            trusted_roots=[control_key.public_key],
+            approval_handler=handler,
+        )
+        plugin = TenuoWorkerInterceptor(cfg)
+        info, inp = self._build_activity_inputs(warrant, pop)
+
+        result = self._run(plugin, info, inp)
+        assert result == "ok"
+
 
 # =============================================================================
 # block_local_activities

--- a/tenuo-python/tests/contracts/__init__.py
+++ b/tenuo-python/tests/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-integration contract tests for enforcement error propagation."""

--- a/tenuo-python/tests/contracts/error_type_contract.py
+++ b/tenuo-python/tests/contracts/error_type_contract.py
@@ -1,0 +1,226 @@
+"""Canonical enforcement error_type → integration signal contract.
+
+Each row defines how a single ``EnforcementResult.error_type`` must surface
+to callers through adapter-specific mapping surfaces.  Parametric tests in
+``test_integration_error_contract.py`` assert production code matches this
+table so integrations cannot silently drift apart.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, FrozenSet, Optional, Type
+
+from tenuo._enforcement import EnforcementResult
+
+# Every value ``enforce_tool_call`` may assign to ``EnforcementResult.error_type``.
+# Property tests import this set — add new error types here first.
+CANONICAL_ERROR_TYPES: FrozenSet[Optional[str]] = frozenset(
+    {
+        None,
+        "tool_not_allowed",
+        "policy_violation",
+        "authorization_failed",
+        "expired",
+        "constraint_violation",
+        "tenuo_error",
+        "internal_error",
+        "invalid_pop",
+        "approval_gate_misconfigured",
+        "insufficient_approvals",
+        "revoked",
+    }
+)
+
+
+def make_denial(
+    error_type: str,
+    *,
+    tool: str = "transfer",
+    arguments: Optional[Dict[str, Any]] = None,
+    denial_reason: Optional[str] = None,
+    constraint_violated: Optional[str] = None,
+    approval_metadata: Optional[Dict[str, Any]] = None,
+) -> EnforcementResult:
+    """Build a synthetic denied ``EnforcementResult`` for contract tests."""
+    return EnforcementResult(
+        allowed=False,
+        tool=tool,
+        arguments=arguments if arguments is not None else {"amount": 100},
+        denial_reason=denial_reason or f"test denial ({error_type})",
+        constraint_violated=constraint_violated,
+        error_type=error_type,
+        approval_metadata=approval_metadata,
+    )
+
+
+@dataclass(frozen=True)
+class IntegrationExpectation:
+    """Expected caller-visible signal for one adapter."""
+
+    raises: Optional[Type[Exception]] = None
+    http_status: Optional[int] = None
+    http_error: Optional[str] = None
+    jsonrpc_code: Optional[int] = None
+    wire_type: Optional[str] = None
+    tenuo_wire_code: Optional[int] = None
+    got_need_in_payload: bool = False
+    returns_tool_message: bool = False
+
+
+@dataclass(frozen=True)
+class ErrorTypeContract:
+    """One row of the cross-integration error contract."""
+
+    error_type: str
+    core_exception: Type[Exception]
+    result_factory: Callable[[], EnforcementResult]
+    integrations: Dict[str, IntegrationExpectation] = field(default_factory=dict)
+
+
+def _rows() -> list[ErrorTypeContract]:
+    return [
+        ErrorTypeContract(
+            error_type="insufficient_approvals",
+            core_exception=_exc("InsufficientApprovals"),
+            result_factory=lambda: make_denial(
+                "insufficient_approvals",
+                approval_metadata={"got": 1, "need": 2},
+            ),
+            integrations={
+                "core": IntegrationExpectation(raises=_exc("InsufficientApprovals")),
+                "openai": IntegrationExpectation(raises=_exc("InsufficientApprovals")),
+                "crewai": IntegrationExpectation(raises=_exc("InsufficientApprovalsDenied", "crewai")),
+                "langgraph": IntegrationExpectation(raises=_exc("InsufficientApprovals")),
+                "fastapi": IntegrationExpectation(
+                    http_status=409,
+                    http_error="insufficient_approvals",
+                    got_need_in_payload=True,
+                ),
+                "mcp": IntegrationExpectation(
+                    jsonrpc_code=-32002,
+                    got_need_in_payload=True,
+                ),
+                "a2a": IntegrationExpectation(
+                    raises=_exc("InsufficientApprovalsError", "a2a"),
+                    tenuo_wire_code=1700,
+                    got_need_in_payload=True,
+                ),
+                "temporal": IntegrationExpectation(wire_type="insufficient_approvals"),
+            },
+        ),
+        ErrorTypeContract(
+            error_type="expired",
+            core_exception=_exc("ExpiredError"),
+            result_factory=lambda: make_denial("expired", denial_reason="Warrant expired"),
+            integrations={
+                "core": IntegrationExpectation(raises=_exc("ExpiredError")),
+                "openai": IntegrationExpectation(raises=_exc("WarrantDenied", "openai")),
+                "crewai": IntegrationExpectation(raises=_exc("WarrantExpired", "crewai")),
+                "langgraph": IntegrationExpectation(returns_tool_message=True),
+                "fastapi": IntegrationExpectation(http_status=401, http_error="warrant_expired"),
+                "temporal": IntegrationExpectation(wire_type="expired"),
+            },
+        ),
+        ErrorTypeContract(
+            error_type="tool_not_allowed",
+            core_exception=_exc("ToolNotAuthorized"),
+            result_factory=lambda: make_denial(
+                "constraint_violation",
+                constraint_violated="tool",
+                denial_reason="warrant does not authorize tool 'read_file'",
+                tool="read_file",
+            ),
+            integrations={
+                "core": IntegrationExpectation(raises=_exc("ToolNotAuthorized")),
+                "openai": IntegrationExpectation(raises=_exc("WarrantDenied", "openai")),
+                "crewai": IntegrationExpectation(raises=_exc("WarrantToolDenied", "crewai")),
+                "langgraph": IntegrationExpectation(returns_tool_message=True),
+                "fastapi": IntegrationExpectation(http_status=403, http_error="authorization_denied"),
+                "mcp": IntegrationExpectation(jsonrpc_code=-32001),
+                "temporal": IntegrationExpectation(wire_type="tool_not_authorized"),
+            },
+        ),
+        ErrorTypeContract(
+            error_type="constraint_violation",
+            core_exception=_exc("ConstraintViolation"),
+            result_factory=lambda: make_denial(
+                "constraint_violation",
+                constraint_violated="amount",
+            ),
+            integrations={
+                "core": IntegrationExpectation(raises=_exc("ConstraintViolation")),
+                "openai": IntegrationExpectation(raises=_exc("WarrantDenied", "openai")),
+                "crewai": IntegrationExpectation(
+                    raises=_exc("CrewAIConstraintViolation", "crewai")
+                ),
+                "langgraph": IntegrationExpectation(returns_tool_message=True),
+                "fastapi": IntegrationExpectation(http_status=403, http_error="authorization_denied"),
+                "temporal": IntegrationExpectation(wire_type="constraint_violation"),
+            },
+        ),
+        ErrorTypeContract(
+            error_type="invalid_pop",
+            core_exception=_exc("SignatureInvalid"),
+            result_factory=lambda: make_denial("invalid_pop", denial_reason="bad signature"),
+            integrations={
+                "core": IntegrationExpectation(raises=_exc("SignatureInvalid")),
+                "openai": IntegrationExpectation(raises=_exc("WarrantDenied", "openai")),
+                "crewai": IntegrationExpectation(raises=_exc("InvalidPoP", "crewai")),
+                "langgraph": IntegrationExpectation(returns_tool_message=True),
+                "fastapi": IntegrationExpectation(http_status=403, http_error="authorization_denied"),
+                "temporal": IntegrationExpectation(wire_type="signature_invalid"),
+            },
+        ),
+    ]
+
+
+def _exc(name: str, module: str = "tenuo.exceptions") -> Type[Exception]:
+    if module == "tenuo.exceptions":
+        from tenuo import exceptions as mod
+    elif module == "crewai":
+        from tenuo import crewai as mod
+    elif module == "openai":
+        from tenuo import openai as mod
+    elif module == "a2a":
+        from tenuo.a2a import errors as mod
+    else:
+        raise ValueError(f"unknown module {module!r}")
+    return getattr(mod, name)
+
+
+CONTRACT_ROWS: list[ErrorTypeContract] = _rows()
+
+INTEGRATION_SURFACES = frozenset(
+    {
+        "core",
+        "openai",
+        "crewai",
+        "langgraph",
+        "fastapi",
+        "mcp",
+        "a2a",
+        "temporal",
+    }
+)
+
+# Modules that must catch auth-family exceptions explicitly (not generic fallthrough).
+AUTH_CATCH_GUARD_MODULES: Dict[str, tuple[str, ...]] = {
+    "tenuo.temporal._interceptors": (
+        "InsufficientApprovals",
+        "ApprovalGateTriggered",
+        "ToolNotAuthorized",
+        "ConstraintViolation",
+    ),
+    "tenuo.mcp.server": (
+        "InsufficientApprovals",
+        "ApprovalGateTriggered",
+        "InvalidApproval",
+        "ApprovalExpired",
+    ),
+    "tenuo.fastapi": (
+        "InsufficientApprovals",
+        "ApprovalRequired",
+        "ApprovalGateTriggered",
+    ),
+}

--- a/tenuo-python/tests/contracts/test_integration_error_contract.py
+++ b/tenuo-python/tests/contracts/test_integration_error_contract.py
@@ -337,7 +337,9 @@ class TestEnforcementObservability:
                 records.append(record)
 
         log = logging.getLogger("tenuo.enforcement")
-        log.addHandler(_H())
+        handler = _H()
+        prev_level = log.level
+        log.addHandler(handler)
         log.setLevel(logging.DEBUG)
         try:
             result = enforce_tool_call(
@@ -347,7 +349,8 @@ class TestEnforcementObservability:
                 trusted_roots=[untrusted.public_key],
             )
         finally:
-            log.removeHandler(_H())
+            log.removeHandler(handler)
+            log.setLevel(prev_level)
 
         assert not result.allowed
         assert result.error_type == "invalid_pop"

--- a/tenuo-python/tests/contracts/test_integration_error_contract.py
+++ b/tenuo-python/tests/contracts/test_integration_error_contract.py
@@ -308,3 +308,49 @@ def test_contract_covers_all_distinct_error_types() -> None:
 def test_canonical_error_types_include_contract_rows() -> None:
     contract_types = {row.error_type for row in CONTRACT_ROWS}
     assert contract_types <= set(CANONICAL_ERROR_TYPES)
+
+
+class TestEnforcementObservability:
+    def test_signature_trust_denial_logs_warning_and_invalid_pop(self):
+        """Trust/signature failures stay typed as invalid_pop and log at WARNING."""
+        import logging
+
+        from tenuo import SigningKey, Warrant
+        from tenuo._enforcement import enforce_tool_call
+
+        issuer = SigningKey.generate()
+        holder = SigningKey.generate()
+        untrusted = SigningKey.generate()
+        warrant = (
+            Warrant.mint_builder()
+            .capability("search")
+            .holder(holder.public_key)
+            .ttl(3600)
+            .mint(issuer)
+        )
+        bound = warrant.bind(holder)
+
+        records: list[logging.LogRecord] = []
+
+        class _H(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        log = logging.getLogger("tenuo.enforcement")
+        log.addHandler(_H())
+        log.setLevel(logging.DEBUG)
+        try:
+            result = enforce_tool_call(
+                "search",
+                {},
+                bound,
+                trusted_roots=[untrusted.public_key],
+            )
+        finally:
+            log.removeHandler(_H())
+
+        assert not result.allowed
+        assert result.error_type == "invalid_pop"
+        assert any(r.levelno >= logging.WARNING for r in records), (
+            "Signature/trust denials must log at WARNING for operator visibility"
+        )

--- a/tenuo-python/tests/contracts/test_integration_error_contract.py
+++ b/tenuo-python/tests/contracts/test_integration_error_contract.py
@@ -357,3 +357,265 @@ class TestEnforcementObservability:
         assert any(r.levelno >= logging.WARNING for r in records), (
             "Signature/trust denials must log at WARNING for operator visibility"
         )
+
+
+# ---------------------------------------------------------------------------
+# Temporal: typed auth branch observability + denial modes
+# ---------------------------------------------------------------------------
+
+
+class TestTemporalExplicitDenialContract:
+    """Guard the explicit auth-denial path added for typed wire errors."""
+
+    def test_typed_auth_branch_emits_before_wrap_or_continue(self) -> None:
+        import inspect
+
+        from tenuo.temporal._interceptors import TenuoActivityInboundInterceptor
+
+        source = inspect.getsource(TenuoActivityInboundInterceptor.execute_activity)
+        anchor = source.index(") as auth_exc:")
+        block = source[anchor : anchor + 2500]
+        emit_at = block.index("_emit_denial_event")
+        next_action = min(
+            i for i in (
+                block.find("_wrap_as_non_retryable(auth_exc)"),
+                block.find("_deny_or_continue"),
+            )
+            if i >= 0
+        )
+        assert emit_at < next_action, (
+            "Typed auth denials must emit metrics/audit before wrap or continue"
+        )
+
+    def test_typed_auth_branch_honors_dry_run_and_log_mode(self) -> None:
+        import inspect
+
+        from tenuo.temporal._interceptors import TenuoActivityInboundInterceptor
+
+        source = inspect.getsource(TenuoActivityInboundInterceptor.execute_activity)
+        anchor = source.index(") as auth_exc:")
+        block = source[anchor : anchor + 2500]
+        assert 'on_denial == "raise"' in block and "dry_run" in block
+        assert "_deny_or_continue" in block
+
+    @pytest.mark.asyncio
+    async def test_typed_constraint_denial_records_metrics(self) -> None:
+        pytest.importorskip("temporalio")
+        import base64
+        import time as _time
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from tenuo import SigningKey, Warrant
+        from tenuo_core import Subpath
+        from tenuo.temporal._config import TenuoPluginConfig
+        from tenuo.temporal._constants import TENUO_ARG_KEYS_HEADER, TENUO_POP_HEADER
+        from tenuo.temporal._headers import tenuo_headers
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
+        from tenuo.temporal._observability import TenuoMetrics
+        from tenuo.temporal._resolvers import EnvKeyResolver
+
+        control_key = SigningKey.generate()
+        agent_key = SigningKey.generate()
+        warrant = (
+            Warrant.mint_builder()
+            .holder(agent_key.public_key)
+            .capability("read_file", path=Subpath("/tmp/safe"))
+            .ttl(3600)
+            .mint(control_key)
+        )
+        metrics = TenuoMetrics()
+        cfg = TenuoPluginConfig(
+            key_resolver=EnvKeyResolver(),
+            trusted_roots=[control_key.public_key],
+            metrics=metrics,
+        )
+        plugin = TenuoWorkerInterceptor(cfg)
+        nxt = MagicMock()
+        nxt.execute_activity = AsyncMock(return_value="ok")
+        nxt.init = MagicMock()
+        ai = plugin.intercept_activity(nxt)
+
+        h = tenuo_headers(warrant, "agent1")
+        pop = warrant.sign(
+            agent_key, "read_file", {"path": "/etc/passwd"}, int(_time.time())
+        )
+        act_headers = {
+            k: (v if isinstance(v, bytes) else str(v).encode("utf-8"))
+            for k, v in h.items()
+            if k.startswith("x-tenuo-")
+        }
+        act_headers[TENUO_POP_HEADER] = base64.b64encode(bytes(pop))
+        act_headers[TENUO_ARG_KEYS_HEADER] = b"path"
+
+        class FakePayload:
+            def __init__(self, data: bytes) -> None:
+                self.data = data
+
+        info = MagicMock(
+            activity_type="read_file",
+            activity_id="1",
+            workflow_id="wf-contract-deny",
+            workflow_run_id="run-1",
+            workflow_type="ContractDenyWF",
+            task_queue="test-q",
+            attempt=1,
+            is_local=False,
+        )
+        inp = MagicMock(
+            fn=None,
+            args=("/etc/passwd",),
+            headers={k: FakePayload(v) for k, v in act_headers.items()},
+        )
+
+        with patch("temporalio.activity.info", return_value=info):
+            with pytest.raises(Exception):
+                await ai.execute_activity(inp)
+
+        assert metrics.get_stats()["latency_count"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_typed_denial_dry_run_executes_activity(self) -> None:
+        pytest.importorskip("temporalio")
+        import base64
+        import time as _time
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from tenuo import SigningKey, Warrant
+        from tenuo_core import Subpath
+        from tenuo.temporal._config import TenuoPluginConfig
+        from tenuo.temporal._constants import TENUO_ARG_KEYS_HEADER, TENUO_POP_HEADER
+        from tenuo.temporal._headers import tenuo_headers
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
+        from tenuo.temporal._resolvers import EnvKeyResolver
+
+        control_key = SigningKey.generate()
+        agent_key = SigningKey.generate()
+        warrant = (
+            Warrant.mint_builder()
+            .holder(agent_key.public_key)
+            .capability("read_file", path=Subpath("/tmp/safe"))
+            .ttl(3600)
+            .mint(control_key)
+        )
+        cfg = TenuoPluginConfig(
+            key_resolver=EnvKeyResolver(),
+            trusted_roots=[control_key.public_key],
+            on_denial="raise",
+            dry_run=True,
+        )
+        plugin = TenuoWorkerInterceptor(cfg)
+        nxt = MagicMock()
+        nxt.execute_activity = AsyncMock(return_value="executed")
+        nxt.init = MagicMock()
+        ai = plugin.intercept_activity(nxt)
+
+        h = tenuo_headers(warrant, "agent1")
+        pop = warrant.sign(
+            agent_key, "read_file", {"path": "/etc/passwd"}, int(_time.time())
+        )
+        act_headers = {
+            k: (v if isinstance(v, bytes) else str(v).encode("utf-8"))
+            for k, v in h.items()
+            if k.startswith("x-tenuo-")
+        }
+        act_headers[TENUO_POP_HEADER] = base64.b64encode(bytes(pop))
+        act_headers[TENUO_ARG_KEYS_HEADER] = b"path"
+
+        class FakePayload:
+            def __init__(self, data: bytes) -> None:
+                self.data = data
+
+        info = MagicMock(
+            activity_type="read_file",
+            activity_id="1",
+            workflow_id="wf-dry",
+            workflow_run_id="run-1",
+            workflow_type="DryWF",
+            task_queue="test-q",
+            attempt=1,
+            is_local=False,
+        )
+        inp = MagicMock(
+            fn=None,
+            args=("/etc/passwd",),
+            headers={k: FakePayload(v) for k, v in act_headers.items()},
+        )
+
+        with patch("temporalio.activity.info", return_value=info):
+            result = await ai.execute_activity(inp)
+
+        assert result == "executed"
+        nxt.execute_activity.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_typed_denial_log_mode_skips_activity(self) -> None:
+        pytest.importorskip("temporalio")
+        import base64
+        import time as _time
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from tenuo import SigningKey, Warrant
+        from tenuo_core import Subpath
+        from tenuo.temporal._config import TenuoPluginConfig
+        from tenuo.temporal._constants import TENUO_ARG_KEYS_HEADER, TENUO_POP_HEADER
+        from tenuo.temporal._headers import tenuo_headers
+        from tenuo.temporal._interceptors import TenuoWorkerInterceptor
+        from tenuo.temporal._resolvers import EnvKeyResolver
+
+        control_key = SigningKey.generate()
+        agent_key = SigningKey.generate()
+        warrant = (
+            Warrant.mint_builder()
+            .holder(agent_key.public_key)
+            .capability("read_file", path=Subpath("/tmp/safe"))
+            .ttl(3600)
+            .mint(control_key)
+        )
+        cfg = TenuoPluginConfig(
+            key_resolver=EnvKeyResolver(),
+            trusted_roots=[control_key.public_key],
+            on_denial="log",
+        )
+        plugin = TenuoWorkerInterceptor(cfg)
+        nxt = MagicMock()
+        nxt.execute_activity = AsyncMock(return_value="real")
+        nxt.init = MagicMock()
+        ai = plugin.intercept_activity(nxt)
+
+        h = tenuo_headers(warrant, "agent1")
+        pop = warrant.sign(
+            agent_key, "read_file", {"path": "/etc/passwd"}, int(_time.time())
+        )
+        act_headers = {
+            k: (v if isinstance(v, bytes) else str(v).encode("utf-8"))
+            for k, v in h.items()
+            if k.startswith("x-tenuo-")
+        }
+        act_headers[TENUO_POP_HEADER] = base64.b64encode(bytes(pop))
+        act_headers[TENUO_ARG_KEYS_HEADER] = b"path"
+
+        class FakePayload:
+            def __init__(self, data: bytes) -> None:
+                self.data = data
+
+        info = MagicMock(
+            activity_type="read_file",
+            activity_id="1",
+            workflow_id="wf-log",
+            workflow_run_id="run-1",
+            workflow_type="LogWF",
+            task_queue="test-q",
+            attempt=1,
+            is_local=False,
+        )
+        inp = MagicMock(
+            fn=None,
+            args=("/etc/passwd",),
+            headers={k: FakePayload(v) for k, v in act_headers.items()},
+        )
+
+        with patch("temporalio.activity.info", return_value=info):
+            result = await ai.execute_activity(inp)
+
+        nxt.execute_activity.assert_not_called()
+        assert result != "real"

--- a/tenuo-python/tests/contracts/test_integration_error_contract.py
+++ b/tenuo-python/tests/contracts/test_integration_error_contract.py
@@ -1,0 +1,310 @@
+"""Parametric contract tests: one enforcement error_type, many integrations."""
+
+from __future__ import annotations
+
+import ast
+import base64
+import inspect
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.contracts.error_type_contract import (
+    AUTH_CATCH_GUARD_MODULES,
+    CANONICAL_ERROR_TYPES,
+    CONTRACT_ROWS,
+    ErrorTypeContract,
+)
+
+
+def _row_ids(row: ErrorTypeContract) -> str:
+    return row.error_type
+
+
+def _integration_rows(integration: str) -> list[ErrorTypeContract]:
+    return [row for row in CONTRACT_ROWS if integration in row.integrations]
+
+
+# ---------------------------------------------------------------------------
+# Core: EnforcementResult.raise_if_denied
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=_row_ids)
+def test_core_raise_if_denied_matches_contract(row: ErrorTypeContract) -> None:
+    exp = row.integrations["core"]
+    assert exp.raises is not None
+    with pytest.raises(exp.raises):
+        row.result_factory().raise_if_denied()
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("openai"), ids=_row_ids)
+def test_openai_mapper_matches_contract(row: ErrorTypeContract) -> None:
+    from tenuo.openai import _raise_for_enforcement_denial
+
+    exp = row.integrations["openai"]
+    assert exp.raises is not None
+    with pytest.raises(exp.raises):
+        _raise_for_enforcement_denial("transfer", row.result_factory())
+
+
+# ---------------------------------------------------------------------------
+# CrewAI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("crewai"), ids=_row_ids)
+def test_crewai_mapper_matches_contract(row: ErrorTypeContract) -> None:
+    from tenuo.crewai import CrewAIGuard
+
+    exp = row.integrations["crewai"]
+    assert exp.raises is not None
+    guard = CrewAIGuard.__new__(CrewAIGuard)
+    guard._warrant = None
+    guard._signing_key = None
+    result = row.result_factory()
+    err = guard._map_enforcement_error(result, "transfer", result.arguments, result.denial_reason or "")
+    assert isinstance(err, exp.raises)
+
+
+# ---------------------------------------------------------------------------
+# LangGraph
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("langgraph"), ids=_row_ids)
+def test_langgraph_denial_matches_contract(row: ErrorTypeContract) -> None:
+    from langchain_core.messages import ToolMessage
+
+    from tenuo.langgraph import _authorize_tool_request
+
+    exp = row.integrations["langgraph"]
+    result = row.result_factory()
+    request = MagicMock()
+    request.tool_call = {"name": "transfer", "args": result.arguments, "id": "call-1"}
+    handler = MagicMock(return_value="ok")
+    bw = MagicMock()
+
+    with patch("tenuo.langgraph.enforce_tool_call", return_value=result):
+        if exp.raises is not None:
+            with pytest.raises(exp.raises):
+                _authorize_tool_request(
+                    request,
+                    handler,
+                    bw_factory=lambda _req: bw,
+                )
+        elif exp.returns_tool_message:
+            out = _authorize_tool_request(
+                request,
+                handler,
+                bw_factory=lambda _req: bw,
+            )
+            assert isinstance(out, ToolMessage)
+            assert out.status == "error"
+            handler.assert_not_called()
+        else:
+            pytest.fail(f"langgraph contract for {row.error_type} has no signal")
+
+
+# ---------------------------------------------------------------------------
+# FastAPI (TenuoGuard enforcement result path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("fastapi"), ids=_row_ids)
+def test_fastapi_enforcement_path_matches_contract(row: ErrorTypeContract) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi import Depends, FastAPI
+    from fastapi.testclient import TestClient
+
+    from tenuo import SigningKey, Warrant
+    from tenuo.fastapi import TenuoGuard, X_TENUO_POP, X_TENUO_WARRANT, configure_tenuo
+
+    exp = row.integrations["fastapi"]
+    assert exp.http_status is not None
+    assert exp.http_error is not None
+
+    key = SigningKey.generate()
+    app = FastAPI()
+    configure_tenuo(app, trusted_issuers=[key.public_key])
+
+    @app.get("/transfer")
+    def transfer(ctx=Depends(TenuoGuard("transfer"))):
+        return {"ok": True}
+
+    warrant = Warrant.mint_builder().tool("transfer").mint(key)
+    args = row.result_factory().arguments
+    pop_sig = warrant.sign(key, "transfer", args, int(time.time()))
+    pop_b64 = base64.b64encode(pop_sig).decode("ascii")
+    headers = {X_TENUO_WARRANT: warrant.to_base64(), X_TENUO_POP: pop_b64}
+
+    with patch.object(
+        TenuoGuard,
+        "_enforce_with_pop_signature",
+        return_value=row.result_factory(),
+    ):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/transfer", params=args, headers=headers)
+
+    assert resp.status_code == exp.http_status, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error"] == exp.http_error
+    if exp.got_need_in_payload:
+        assert detail["got"] == 1
+        assert detail["need"] == 2
+
+
+# ---------------------------------------------------------------------------
+# MCP (JSON-RPC payload contract)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("mcp"), ids=_row_ids)
+def test_mcp_jsonrpc_payload_matches_contract(row: ErrorTypeContract) -> None:
+    from tenuo.exceptions import InsufficientApprovals
+    from tenuo.mcp.server import MCPVerificationResult
+
+    exp = row.integrations["mcp"]
+    assert exp.jsonrpc_code is not None
+
+    if row.error_type == "insufficient_approvals":
+        exc = InsufficientApprovals(required=2, received=1)
+        meta = {"got": exc.details["received"], "need": exc.details["required"]}
+        mcp_result = MCPVerificationResult(
+            allowed=False,
+            tool="transfer",
+            clean_arguments={},
+            constraints={},
+            denial_reason=str(exc),
+            jsonrpc_error_code=-32002,
+            approval_metadata=meta,
+        )
+    else:
+        mcp_result = MCPVerificationResult(
+            allowed=False,
+            tool="transfer",
+            clean_arguments={},
+            constraints={},
+            denial_reason=row.result_factory().denial_reason or "",
+            jsonrpc_error_code=exp.jsonrpc_code,
+        )
+
+    err = mcp_result.to_jsonrpc_error()
+    assert err["code"] == exp.jsonrpc_code
+    if exp.got_need_in_payload:
+        assert err["data"]["got"] == 1
+        assert err["data"]["need"] == 2
+
+
+# ---------------------------------------------------------------------------
+# A2A
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("a2a"), ids=_row_ids)
+def test_a2a_error_payload_matches_contract(row: ErrorTypeContract) -> None:
+    from tenuo.a2a.errors import InsufficientApprovalsError
+    from tenuo.exceptions import InsufficientApprovals
+
+    exp = row.integrations["a2a"]
+    assert exp.raises is not None
+
+    core_exc = InsufficientApprovals(required=2, received=1)
+    a2a_exc = InsufficientApprovalsError(
+        str(core_exc),
+        required=core_exc.details["required"],
+        received=core_exc.details["received"],
+    )
+    assert isinstance(a2a_exc, exp.raises)
+    rpc = a2a_exc.to_jsonrpc_error()
+    if exp.tenuo_wire_code is not None:
+        assert rpc["data"]["tenuo_code"] == exp.tenuo_wire_code
+    if exp.got_need_in_payload:
+        assert rpc["data"]["required"] == 2
+        assert rpc["data"]["received"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Temporal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("temporal"), ids=_row_ids)
+def test_temporal_wire_type_matches_contract(row: ErrorTypeContract) -> None:
+    from tenuo.temporal._interceptors import _error_type_for_wire
+
+    exp = row.integrations["temporal"]
+    assert exp.wire_type is not None
+    exc = row.core_exception
+    if row.error_type == "insufficient_approvals":
+        instance = exc(required=2, received=1)
+    elif row.error_type == "tool_not_allowed":
+        instance = exc(tool="transfer")
+    elif row.error_type == "constraint_violation":
+        instance = exc(field="amount", reason="bad", value=999)
+    elif row.error_type == "expired":
+        instance = exc("warrant expired")
+    elif row.error_type == "invalid_pop":
+        instance = exc("bad signature")
+    else:
+        instance = exc("contract sweep")
+    assert _error_type_for_wire(instance) == exp.wire_type
+
+
+# ---------------------------------------------------------------------------
+# Structural: explicit auth exception catch lists
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module_path,required_names",
+    list(AUTH_CATCH_GUARD_MODULES.items()),
+)
+def test_auth_exceptions_in_explicit_catch_list(
+    module_path: str,
+    required_names: tuple[str, ...],
+) -> None:
+    """Each auth-family exception must have its own explicit except handler."""
+    mod = __import__(module_path, fromlist=[module_path.split(".")[-1]])
+    source = inspect.getsource(mod)
+    tree = ast.parse(source)
+
+    caught: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler) or node.type is None:
+            continue
+        if isinstance(node.type, ast.Tuple):
+            names = [ast.unparse(elt) for elt in node.type.elts]
+        else:
+            names = [ast.unparse(node.type)]
+        for req in required_names:
+            if any(req in n for n in names):
+                caught.add(req)
+
+    missing = set(required_names) - caught
+    assert not missing, (
+        f"{module_path} is missing explicit except handlers for {sorted(missing)} — "
+        f"generic fallthrough causes integration drift"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy sync: property tests use CANONICAL_ERROR_TYPES
+# ---------------------------------------------------------------------------
+
+
+def test_contract_covers_all_distinct_error_types() -> None:
+    """Every contract row error_type is in the canonical taxonomy."""
+    for row in CONTRACT_ROWS:
+        assert row.error_type in CANONICAL_ERROR_TYPES
+
+
+def test_canonical_error_types_include_contract_rows() -> None:
+    contract_types = {row.error_type for row in CONTRACT_ROWS}
+    assert contract_types <= set(CANONICAL_ERROR_TYPES)

--- a/tenuo-python/tests/property/test_cross_adapter_consistency.py
+++ b/tenuo-python/tests/property/test_cross_adapter_consistency.py
@@ -17,6 +17,8 @@ from hypothesis import given, settings
 from tenuo import SigningKey
 from tenuo._enforcement import enforce_tool_call
 
+from tests.contracts.error_type_contract import CANONICAL_ERROR_TYPES
+
 from .strategies import st_bound_warrant_bundle, st_tool_name
 
 
@@ -46,18 +48,7 @@ class TestEnforceDeterminism:
 # ---------------------------------------------------------------------------
 
 
-KNOWN_ERROR_TYPES = {
-    None,  # allowed=True
-    "tool_not_allowed",
-    "policy_violation",
-    "authorization_failed",
-    "expired",
-    "constraint_violation",
-    "tenuo_error",
-    "internal_error",
-    "invalid_pop",
-    "approval_gate_misconfigured",
-}
+KNOWN_ERROR_TYPES = CANONICAL_ERROR_TYPES
 
 
 class TestDenialTaxonomy:

--- a/tenuo-python/tests/security/test_integration_invariants.py
+++ b/tenuo-python/tests/security/test_integration_invariants.py
@@ -1899,7 +1899,11 @@ class TestLangChainInvariants:
         )
         bw = BoundWarrant(warrant=w, key=root_key)
 
-        tool = TenuoTool(self._make_mock_lc_tool("delete_file"), bound_warrant=bw)
+        tool = TenuoTool(
+            self._make_mock_lc_tool("delete_file"),
+            bound_warrant=bw,
+            trusted_roots=[root_key.public_key],
+        )
         with pytest.raises(ToolNotAuthorized):
             tool._check_authorization({})
 
@@ -1924,7 +1928,11 @@ class TestLangChainInvariants:
         time.sleep(2)
         bw = BoundWarrant(warrant=w, key=root_key)
 
-        tool = TenuoTool(self._make_mock_lc_tool("search"), bound_warrant=bw)
+        tool = TenuoTool(
+            self._make_mock_lc_tool("search"),
+            bound_warrant=bw,
+            trusted_roots=[root_key.public_key],
+        )
         with pytest.raises(Exception) as exc_info:
             tool._check_authorization({})
         assert exc_info.type.__name__ not in ("AttributeError", "TypeError")

--- a/tenuo-python/tests/unit/test_approval.py
+++ b/tenuo-python/tests/unit/test_approval.py
@@ -23,6 +23,7 @@ from tenuo import (
 )
 from tenuo.constraints import Constraints
 from tenuo._enforcement import enforce_tool_call
+from tenuo.exceptions import InvalidApproval
 from tenuo.approval import (
     ApprovalDenied,
     ApprovalRequest,
@@ -344,7 +345,7 @@ class TestTamperResistance:
             )
             return SignedApproval.create(payload, approver_key)
 
-        with pytest.raises(ApprovalVerificationError, match="request hash mismatch"):
+        with pytest.raises(InvalidApproval, match="request hash mismatch"):
             enforce_tool_call(
                 "transfer",
                 {"amount": 50_000},
@@ -355,7 +356,7 @@ class TestTamperResistance:
     def test_untrusted_key_rejected(self, agent_key, approver_key):
         bound = _bound_gated(agent_key, approver_key, gates={"transfer": None})
         rogue = SigningKey.generate()
-        with pytest.raises(ApprovalVerificationError, match="approver not in trusted set"):
+        with pytest.raises(InvalidApproval, match="approver not in trusted set"):
             enforce_tool_call(
                 "transfer",
                 {"amount": 50_000},
@@ -418,7 +419,7 @@ class TestMultiApprover:
             approval_gates={"transfer": None},
         )
         bound = w.bind(agent_key, trusted_roots=[agent_key.public_key])
-        with pytest.raises(ApprovalVerificationError, match="approver not in trusted set"):
+        with pytest.raises(InvalidApproval, match="approver not in trusted set"):
             enforce_tool_call(
                 "transfer",
                 {"amount": 100},
@@ -467,7 +468,7 @@ class TestRequestHashBinding:
         def replay_handler(_request):
             return captured[0]
 
-        with pytest.raises(ApprovalVerificationError, match="request hash mismatch"):
+        with pytest.raises(InvalidApproval, match="request hash mismatch"):
             enforce_tool_call(
                 "transfer",
                 {"amount": 100},

--- a/tenuo-python/tests/unit/test_approval.py
+++ b/tenuo-python/tests/unit/test_approval.py
@@ -614,8 +614,6 @@ class TestMofN:
         assert result.allowed
 
     def test_two_of_three_insufficient(self):
-        from tenuo.exceptions import InsufficientApprovals
-        from tenuo._enforcement import EnforcementResult
 
         agent_key = SigningKey.generate()
         k1, k2, k3 = SigningKey.generate(), SigningKey.generate(), SigningKey.generate()

--- a/tenuo-python/tests/unit/test_approval.py
+++ b/tenuo-python/tests/unit/test_approval.py
@@ -613,14 +613,24 @@ class TestMofN:
         assert result.allowed
 
     def test_two_of_three_insufficient(self):
+        from tenuo.exceptions import InsufficientApprovals
+        from tenuo._enforcement import EnforcementResult
+
         agent_key = SigningKey.generate()
         k1, k2, k3 = SigningKey.generate(), SigningKey.generate(), SigningKey.generate()
         bound = self._bound_mn(agent_key, [k1, k2, k3], m=2)
         warrant_id = bound.id or ""
         rh = compute_request_hash(warrant_id, "deploy", {}, agent_key.public_key)
         a1 = self._sign_for_request(k1, rh)
-        with pytest.raises(ApprovalVerificationError, match="Insufficient approvals"):
-            enforce_tool_call("deploy", {}, bound, approvals=[a1])
+        # InsufficientApprovals is now surfaced as a distinct EnforcementResult
+        # (error_type="insufficient_approvals") rather than being wrapped in
+        # ApprovalVerificationError — callers can build retry-with-approval loops.
+        result = enforce_tool_call("deploy", {}, bound, approvals=[a1])
+        assert not result.allowed
+        assert result.error_type == "insufficient_approvals"
+        assert result.approval_metadata is not None
+        assert result.approval_metadata["need"] == 2
+        assert result.approval_metadata["got"] == 1
 
 
 class TestCrewAIApproval:

--- a/tenuo-python/tests/unit/test_enforcement.py
+++ b/tenuo-python/tests/unit/test_enforcement.py
@@ -897,4 +897,5 @@ class TestEnforceToolCallWithAuthorizer:
             authorizer=authorizer,
         )
         assert result.allowed is False
-        assert result.error_type == "authorization_failed"
+        assert result.error_type == "constraint_violation"
+        assert result.constraint_violated == "tool"

--- a/tenuo-python/tests/unit/test_enforcement.py
+++ b/tenuo-python/tests/unit/test_enforcement.py
@@ -854,7 +854,7 @@ class TestEnforceToolCallWithAuthorizer:
             authorizer=auth,
         )
         assert result.allowed is False
-        assert result.error_type == "authorization_failed"
+        assert result.error_type == "invalid_pop"
         assert "trusted" in result.denial_reason.lower() or "issuer" in result.denial_reason.lower()
 
     def test_authorizer_verify_mode_expired_warrant(self, keypair, authorizer):

--- a/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
+++ b/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
@@ -1,0 +1,472 @@
+"""
+Regression tests for the InsufficientApprovals signal bug.
+
+Before this fix, InsufficientApprovals (multi-sig threshold not met) was
+indistinguishable from a scope denial (tool not in warrant, constraint
+violated) across MCP, FastAPI, and Temporal.  Callers could not tell whether
+to retry with more approvals or give up.
+
+These tests assert that each integration emits its own distinct "approval
+required" signal — the same one used for ApprovalGateTriggered — rather than
+the generic access-denied signal.
+
+Coverage:
+  _enforcement.py   — EnforcementResult.error_type + approval_metadata
+  mcp/server.py     — jsonrpc_error_code == -32002
+  fastapi.py        — HTTP 409 Conflict with error="insufficient_approvals"
+  temporal          — _error_type_for_wire returns "insufficient_approvals"
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tenuo import SigningKey, Warrant
+from tenuo.exceptions import InsufficientApprovals
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_multi_sig_warrant(
+    issuer_key: SigningKey,
+    holder_key: SigningKey,
+    approver_keys: list,
+    min_approvals: int = 2,
+) -> Warrant:
+    """Issue a warrant that requires multi-sig approval for 'transfer'."""
+    return Warrant.issue(
+        issuer_key,
+        capabilities={"transfer": {}},
+        holder=holder_key.public_key,
+        approval_gates={"transfer": None},
+        required_approvers=[k.public_key for k in approver_keys],
+        min_approvals=min_approvals,
+    )
+
+
+def _make_signed_approval(warrant: Warrant, tool: str, tool_args: dict, holder_key, approver_key):
+    """Build a real SignedApproval for the given call."""
+    from tenuo_core import ApprovalPayload, SignedApproval
+    from tenuo_core import py_compute_request_hash as compute_request_hash
+
+    request_hash = compute_request_hash(
+        warrant.id, tool, tool_args, holder_key.public_key
+    )
+    now = int(time.time())
+    payload = ApprovalPayload(
+        request_hash=request_hash,
+        nonce=os.urandom(16),
+        external_id="test-approver",
+        approved_at=now,
+        expires_at=now + 300,
+    )
+    return SignedApproval.create(payload, approver_key)
+
+
+# ---------------------------------------------------------------------------
+# _enforcement.py
+# ---------------------------------------------------------------------------
+
+
+class TestEnforcementResult:
+    """InsufficientApprovals must surface as error_type='insufficient_approvals'
+    with structured approval_metadata, not as generic 'authorization_failed'."""
+
+    def test_insufficient_approvals_sets_correct_error_type(self):
+        from tenuo import Authorizer
+        from tenuo._enforcement import enforce_tool_call
+
+        issuer = SigningKey.generate()
+        holder = SigningKey.generate()
+        approver1 = SigningKey.generate()
+        approver2 = SigningKey.generate()
+
+        warrant = _make_multi_sig_warrant(
+            issuer, holder, [approver1, approver2], min_approvals=2
+        )
+        bound = warrant.bind(holder)
+        authorizer = Authorizer(trusted_roots=[issuer.public_key])
+
+        tool_args = {"amount": 100}
+        # Provide only one approval — threshold is 2
+        approval = _make_signed_approval(warrant, "transfer", tool_args, holder, approver1)
+
+        result = enforce_tool_call(
+            "transfer",
+            tool_args,
+            bound,
+            trusted_roots=[issuer.public_key],
+            approvals=[approval],
+        )
+
+        assert not result.allowed
+        assert result.error_type == "insufficient_approvals", (
+            f"Expected 'insufficient_approvals', got '{result.error_type}' — "
+            "InsufficientApprovals is being swallowed as a generic denial"
+        )
+
+    def test_insufficient_approvals_populates_approval_metadata(self):
+        from tenuo import Authorizer
+        from tenuo._enforcement import enforce_tool_call
+
+        issuer = SigningKey.generate()
+        holder = SigningKey.generate()
+        approver1 = SigningKey.generate()
+        approver2 = SigningKey.generate()
+
+        warrant = _make_multi_sig_warrant(
+            issuer, holder, [approver1, approver2], min_approvals=2
+        )
+        bound = warrant.bind(holder)
+
+        tool_args = {"amount": 100}
+        approval = _make_signed_approval(warrant, "transfer", tool_args, holder, approver1)
+
+        result = enforce_tool_call(
+            "transfer",
+            tool_args,
+            bound,
+            trusted_roots=[issuer.public_key],
+            approvals=[approval],
+        )
+
+        assert result.approval_metadata is not None, (
+            "approval_metadata must be populated for insufficient_approvals"
+        )
+        assert "got" in result.approval_metadata
+        assert "need" in result.approval_metadata
+        assert result.approval_metadata["need"] == 2
+        assert result.approval_metadata["got"] == 1
+
+    def test_scope_denial_does_not_set_approval_metadata(self):
+        """A plain scope denial must never carry approval_metadata."""
+        from tenuo._enforcement import enforce_tool_call
+
+        issuer = SigningKey.generate()
+        holder = SigningKey.generate()
+        warrant = Warrant.issue(
+            issuer,
+            capabilities={"read_file": {}},
+            holder=holder.public_key,
+        )
+        bound = warrant.bind(holder)
+
+        result = enforce_tool_call(
+            "delete_file",  # not in warrant
+            {},
+            bound,
+            trusted_roots=[issuer.public_key],
+        )
+
+        assert not result.allowed
+        assert result.error_type != "insufficient_approvals"
+        assert result.approval_metadata is None
+
+    def test_outer_catch_handles_insufficient_approvals(self):
+        """The outer InsufficientApprovals except block in enforce_tool_call
+        produces the correct EnforcementResult even when the exception escapes
+        the inner handlers.  We simulate this by patching the Rust authorizer
+        to raise InsufficientApprovals on a warrant with no approval gates
+        (so the gate branch is skipped and the exception comes from the inner
+        authorize_one call)."""
+        from tenuo._enforcement import enforce_tool_call
+        from tenuo.exceptions import InsufficientApprovals
+        from tenuo import Authorizer
+
+        issuer = SigningKey.generate()
+        holder = SigningKey.generate()
+        warrant = Warrant.issue(
+            issuer,
+            capabilities={"transfer": {}},
+            holder=holder.public_key,
+        )
+        bound = warrant.bind(holder)
+
+        exc = InsufficientApprovals(required=3, received=1)
+
+        with patch.object(Authorizer, "authorize_one", side_effect=exc), \
+             patch.object(Authorizer, "authorize_one_with_pop_args", side_effect=exc):
+            result = enforce_tool_call(
+                "transfer",
+                {},
+                bound,
+                trusted_roots=[issuer.public_key],
+            )
+
+        assert not result.allowed
+        assert result.error_type == "insufficient_approvals"
+        assert result.approval_metadata is not None
+        assert result.approval_metadata["got"] == 1
+        assert result.approval_metadata["need"] == 3
+
+
+# ---------------------------------------------------------------------------
+# mcp/server.py
+# ---------------------------------------------------------------------------
+
+
+class TestMCPInsufficientApprovals:
+    """MCPVerifier must return jsonrpc_error_code=-32002 for InsufficientApprovals,
+    not -32001 (the generic access denied code)."""
+
+    @pytest.fixture
+    def issuer_key(self):
+        return SigningKey.generate()
+
+    @pytest.fixture
+    def agent_key(self):
+        return SigningKey.generate()
+
+    @staticmethod
+    def _make_meta(warrant: Warrant, agent_key: SigningKey, tool: str, tool_args: dict, approvals=None):
+        import base64, time as _time
+
+        sig = bytes(warrant.sign(agent_key, tool, tool_args, int(_time.time())))
+        entry: dict = {
+            "warrant": warrant.to_base64(),
+            "signature": base64.b64encode(sig).decode(),
+        }
+        if approvals:
+            entry["approvals"] = [
+                base64.b64encode(bytes(a.to_bytes())).decode() for a in approvals
+            ]
+        return {"tenuo": entry}
+
+    def test_insufficient_approvals_returns_minus_32002(self, issuer_key, agent_key):
+        from tenuo_core import Authorizer
+        from tenuo.mcp.server import MCPVerifier
+
+        approver1 = SigningKey.generate()
+        approver2 = SigningKey.generate()
+        authorizer = Authorizer(trusted_roots=[issuer_key.public_key])
+
+        warrant = _make_multi_sig_warrant(
+            issuer_key, agent_key, [approver1, approver2], min_approvals=2
+        )
+        tool_args = {"amount": 500}
+
+        # Provide only one valid approval
+        approval = _make_signed_approval(warrant, "transfer", tool_args, agent_key, approver1)
+        meta = self._make_meta(warrant, agent_key, "transfer", tool_args, approvals=[approval])
+
+        result = MCPVerifier(authorizer=authorizer).verify("transfer", tool_args, meta=meta)
+
+        assert not result.allowed
+        assert result.jsonrpc_error_code == -32002, (
+            f"Expected -32002 (approval required), got {result.jsonrpc_error_code} — "
+            "InsufficientApprovals is being treated as a flat access denial"
+        )
+        assert result.is_approval_required
+
+    def test_insufficient_approvals_denial_reason_includes_counts(self, issuer_key, agent_key):
+        from tenuo_core import Authorizer
+        from tenuo.mcp.server import MCPVerifier
+
+        approver1 = SigningKey.generate()
+        approver2 = SigningKey.generate()
+        authorizer = Authorizer(trusted_roots=[issuer_key.public_key])
+
+        warrant = _make_multi_sig_warrant(
+            issuer_key, agent_key, [approver1, approver2], min_approvals=2
+        )
+        tool_args = {"amount": 500}
+        approval = _make_signed_approval(warrant, "transfer", tool_args, agent_key, approver1)
+        meta = self._make_meta(warrant, agent_key, "transfer", tool_args, approvals=[approval])
+
+        result = MCPVerifier(authorizer=authorizer).verify("transfer", tool_args, meta=meta)
+
+        # Denial reason should be self-explanatory for the retry loop
+        assert result.denial_reason is not None
+        reason = result.denial_reason.lower()
+        assert "approval" in reason
+
+    def test_scope_denial_still_returns_minus_32001(self, issuer_key, agent_key):
+        """Regression guard: plain tool-not-allowed must stay -32001."""
+        import base64, time as _time
+        from tenuo_core import Authorizer
+        from tenuo.mcp.server import MCPVerifier
+
+        warrant = Warrant.issue(
+            issuer_key,
+            capabilities={"read_file": {}},
+            holder=agent_key.public_key,
+        )
+        authorizer = Authorizer(trusted_roots=[issuer_key.public_key])
+
+        tool_args = {}
+        sig = bytes(warrant.sign(agent_key, "delete_file", tool_args, int(_time.time())))
+        meta = {
+            "tenuo": {
+                "warrant": warrant.to_base64(),
+                "signature": base64.b64encode(sig).decode(),
+            }
+        }
+
+        result = MCPVerifier(authorizer=authorizer).verify("delete_file", tool_args, meta=meta)
+
+        assert not result.allowed
+        assert result.jsonrpc_error_code == -32001
+        assert not result.is_approval_required
+
+    def test_insufficient_approvals_catch_block_emits_minus_32002(self, issuer_key, agent_key):
+        """Inject InsufficientApprovals at the Rust authorizer boundary and confirm
+        the MCP catch block maps it to -32002, not -32001."""
+        import base64, time as _time
+        from tenuo_core import Authorizer
+        from tenuo.mcp.server import MCPVerifier
+
+        warrant = Warrant.issue(
+            issuer_key,
+            capabilities={"transfer": {}},
+            holder=agent_key.public_key,
+        )
+        authorizer = Authorizer(trusted_roots=[issuer_key.public_key])
+
+        tool_args = {}
+        sig = bytes(warrant.sign(agent_key, "transfer", tool_args, int(_time.time())))
+        meta = {
+            "tenuo": {
+                "warrant": warrant.to_base64(),
+                "signature": base64.b64encode(sig).decode(),
+            }
+        }
+
+        exc = InsufficientApprovals(required=2, received=1)
+        # Patch all the verify paths the MCPVerifier may call so the exception
+        # reaches the catch block regardless of which internal path is taken.
+        with patch.object(Authorizer, "authorize_one", side_effect=exc), \
+             patch.object(Authorizer, "authorize_one_with_pop_args", side_effect=exc), \
+             patch.object(Authorizer, "check_chain", side_effect=exc), \
+             patch.object(Authorizer, "check_chain_with_pop_args", side_effect=exc):
+            result = MCPVerifier(authorizer=authorizer).verify("transfer", tool_args, meta=meta)
+
+        assert not result.allowed
+        assert result.jsonrpc_error_code == -32002, (
+            f"Expected -32002, got {result.jsonrpc_error_code}"
+        )
+        assert result.is_approval_required
+
+
+# ---------------------------------------------------------------------------
+# fastapi.py
+# ---------------------------------------------------------------------------
+
+
+class TestFastAPIInsufficientApprovals:
+    """FastAPI dependency must raise HTTP 409 with error='insufficient_approvals',
+    not 403 or a generic TenuoError."""
+
+    def test_http_409_on_insufficient_approvals(self):
+        """InsufficientApprovals must produce 409, not 403."""
+        pytest.importorskip("fastapi")
+        from fastapi import FastAPI, Request
+        from fastapi.responses import JSONResponse
+        from fastapi.testclient import TestClient
+        from tenuo.exceptions import InsufficientApprovals as IA
+
+        # Directly register the same handler that fastapi.py adds and verify
+        # the exception shape leads to the right HTTP response.
+        app = FastAPI()
+
+        @app.exception_handler(IA)
+        async def _handler(request: Request, exc: IA):
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": "insufficient_approvals",
+                    "got": exc.details.get("received", 0) if hasattr(exc, "details") else 0,
+                    "need": exc.details.get("required", 0) if hasattr(exc, "details") else 0,
+                },
+            )
+
+        @app.get("/test")
+        async def _route():
+            raise IA(required=2, received=1)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/test")
+
+        assert response.status_code == 409
+        body = response.json()
+        assert body["error"] == "insufficient_approvals"
+        assert body["need"] == 2
+        assert body["got"] == 1
+
+    def test_insufficient_approvals_details_attributes(self):
+        """InsufficientApprovals.details carries got/need for the fastapi handler."""
+        from tenuo.exceptions import InsufficientApprovals as IA
+
+        exc = IA(required=3, received=1)
+        assert exc.details["required"] == 3
+        assert exc.details["received"] == 1
+
+
+# ---------------------------------------------------------------------------
+# temporal/exceptions.py  (_error_type_for_wire)
+# ---------------------------------------------------------------------------
+
+
+class TestTemporalErrorTypeForWire:
+    """_error_type_for_wire must return 'insufficient_approvals' for
+    InsufficientApprovals, not the class name or a generic string."""
+
+    def test_error_type_for_wire_insufficient_approvals(self):
+        from tenuo.temporal.exceptions import _error_type_for_wire
+
+        exc = InsufficientApprovals(required=2, received=1)
+        wire_type = _error_type_for_wire(exc)
+
+        assert wire_type == "insufficient_approvals", (
+            f"Expected 'insufficient_approvals', got '{wire_type}'"
+        )
+
+    def test_error_type_for_wire_approval_gate_triggered(self):
+        """Sanity check: ApprovalGateTriggered keeps its wire type."""
+        from tenuo.temporal.exceptions import _error_type_for_wire
+        from tenuo.exceptions import ApprovalGateTriggered
+
+        exc = ApprovalGateTriggered(tool="transfer")
+        wire_type = _error_type_for_wire(exc)
+
+        assert wire_type == "approval_required"
+
+    def test_insufficient_approvals_in_interceptor_catch_list(self):
+        """InsufficientApprovals must be caught in the explicit auth_exc block,
+        not fall through to the generic Exception handler."""
+        import ast
+        import inspect
+        from tenuo.temporal import _interceptors
+
+        source = inspect.getsource(_interceptors)
+        tree = ast.parse(source)
+
+        # Find the except clause that includes ApprovalGateTriggered
+        found_in_same_clause = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler):
+                if node.type is None:
+                    continue
+                names = []
+                if isinstance(node.type, ast.Tuple):
+                    for elt in node.type.elts:
+                        names.append(ast.unparse(elt) if hasattr(ast, "unparse") else getattr(elt, "id", ""))
+                else:
+                    names.append(ast.unparse(node.type) if hasattr(ast, "unparse") else getattr(node.type, "id", ""))
+
+                has_gate = any("ApprovalGateTriggered" in n for n in names)
+                has_insuf = any("InsufficientApprovals" in n for n in names)
+                if has_gate and has_insuf:
+                    found_in_same_clause = True
+                    break
+
+        assert found_in_same_clause, (
+            "InsufficientApprovals must be in the same except clause as "
+            "ApprovalGateTriggered in temporal/_interceptors.py"
+        )

--- a/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
+++ b/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
@@ -642,3 +642,134 @@ class TestTemporalErrorTypeForWire:
 
         exc = ToolNotAuthorized(tool="delete_file")
         assert _error_type_for_wire(exc) == "tool_not_authorized"
+
+
+# ---------------------------------------------------------------------------
+# mcp/fastmcp_middleware.py
+# ---------------------------------------------------------------------------
+
+
+class TestFastMCPMiddlewareDenialPayload:
+    def test_structured_content_includes_got_and_need(self):
+        pytest.importorskip("fastmcp")
+        from tenuo.mcp.fastmcp_middleware import _denial_tool_return
+        from tenuo.mcp.server import MCPVerificationResult
+
+        result = MCPVerificationResult(
+            allowed=False,
+            tool="transfer",
+            clean_arguments={},
+            constraints={},
+            denial_reason="Insufficient approvals for 'transfer': got 1, need 2",
+            jsonrpc_error_code=-32002,
+            approval_metadata={"got": 1, "need": 2},
+        )
+        mcp_result = _denial_tool_return(result).to_mcp_result()
+        tenuo = mcp_result.structuredContent["tenuo"]
+        assert tenuo["code"] == -32002
+        assert tenuo["got"] == 1
+        assert tenuo["need"] == 2
+
+
+# ---------------------------------------------------------------------------
+# autogen.py
+# ---------------------------------------------------------------------------
+
+
+class TestAutoGenInsufficientApprovals:
+    def test_guard_raises_insufficient_approvals(self):
+        issuer = SigningKey.generate()
+        agent = SigningKey.generate()
+        approver1 = SigningKey.generate()
+        approver2 = SigningKey.generate()
+        warrant = _make_multi_sig_warrant(issuer, agent, [approver1, approver2], 2)
+        tool_args = {"amount": 500}
+        approval = _make_signed_approval(warrant, "transfer", tool_args, agent, approver1)
+
+        from tenuo.autogen import GuardBuilder
+
+        def transfer(amount: int) -> str:
+            return str(amount)
+
+        guard = (
+            GuardBuilder()
+            .with_warrant(warrant, agent)
+            .with_trusted_roots([issuer.public_key])
+            .with_approvals([approval])
+            .build()
+        )
+        guarded = guard.guard_tool(transfer, tool_name="transfer")
+
+        with pytest.raises(InsufficientApprovals) as exc_info:
+            guarded(amount=500)
+
+        assert exc_info.value.details["required"] == 2
+        assert exc_info.value.details["received"] == 1
+
+
+# ---------------------------------------------------------------------------
+# google_adk/guard.py
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleADKInsufficientApprovals:
+    def test_before_tool_returns_structured_insufficient_approvals(self):
+        pytest.importorskip("google.adk")
+        issuer = SigningKey.generate()
+        agent = SigningKey.generate()
+        approver1 = SigningKey.generate()
+        approver2 = SigningKey.generate()
+        warrant = _make_multi_sig_warrant(issuer, agent, [approver1, approver2], 2)
+        tool_args = {"amount": 500}
+        approval = _make_signed_approval(warrant, "transfer", tool_args, agent, approver1)
+
+        from unittest.mock import MagicMock
+
+        from tenuo.google_adk.guard import TenuoGuard
+
+        guard = TenuoGuard(
+            warrant=warrant,
+            signing_key=agent,
+            trusted_roots=[issuer.public_key],
+            require_pop=True,
+            approvals=[approval],
+        )
+        tool = MagicMock()
+        tool.name = "transfer"
+        context = MagicMock()
+
+        result = guard.before_tool(tool, tool_args, context)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "insufficient_approvals"
+        assert result["got"] == 1
+        assert result["need"] == 2
+
+    def test_before_tool_raises_insufficient_approvals_when_configured(self):
+        pytest.importorskip("google.adk")
+        issuer = SigningKey.generate()
+        agent = SigningKey.generate()
+        approver1 = SigningKey.generate()
+        approver2 = SigningKey.generate()
+        warrant = _make_multi_sig_warrant(issuer, agent, [approver1, approver2], 2)
+        tool_args = {"amount": 500}
+        approval = _make_signed_approval(warrant, "transfer", tool_args, agent, approver1)
+
+        from unittest.mock import MagicMock
+
+        from tenuo.google_adk.guard import TenuoGuard
+
+        guard = TenuoGuard(
+            warrant=warrant,
+            signing_key=agent,
+            trusted_roots=[issuer.public_key],
+            require_pop=True,
+            approvals=[approval],
+            on_denial="raise",
+        )
+        tool = MagicMock()
+        tool.name = "transfer"
+        context = MagicMock()
+
+        with pytest.raises(InsufficientApprovals):
+            guard.before_tool(tool, tool_args, context)

--- a/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
+++ b/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import os
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -92,7 +92,7 @@ class TestEnforcementResult:
             issuer, holder, [approver1, approver2], min_approvals=2
         )
         bound = warrant.bind(holder)
-        authorizer = Authorizer(trusted_roots=[issuer.public_key])
+        Authorizer(trusted_roots=[issuer.public_key])
 
         tool_args = {"amount": 100}
         # Provide only one approval — threshold is 2
@@ -113,7 +113,6 @@ class TestEnforcementResult:
         )
 
     def test_insufficient_approvals_populates_approval_metadata(self):
-        from tenuo import Authorizer
         from tenuo._enforcement import enforce_tool_call
 
         issuer = SigningKey.generate()
@@ -281,7 +280,8 @@ class TestMCPInsufficientApprovals:
 
     @staticmethod
     def _make_meta(warrant: Warrant, agent_key: SigningKey, tool: str, tool_args: dict, approvals=None):
-        import base64, time as _time
+        import base64
+        import time as _time
 
         sig = bytes(warrant.sign(agent_key, tool, tool_args, int(_time.time())))
         entry: dict = {
@@ -344,7 +344,8 @@ class TestMCPInsufficientApprovals:
 
     def test_scope_denial_still_returns_minus_32001(self, issuer_key, agent_key):
         """Regression guard: plain tool-not-allowed must stay -32001."""
-        import base64, time as _time
+        import base64
+        import time as _time
         from tenuo_core import Authorizer
         from tenuo.mcp.server import MCPVerifier
 
@@ -373,7 +374,8 @@ class TestMCPInsufficientApprovals:
     def test_insufficient_approvals_catch_block_emits_minus_32002(self, issuer_key, agent_key):
         """Inject InsufficientApprovals at the Rust authorizer boundary and confirm
         the MCP catch block maps it to -32002, not -32001."""
-        import base64, time as _time
+        import base64
+        import time as _time
         from tenuo_core import Authorizer
         from tenuo.mcp.server import MCPVerifier
 

--- a/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
+++ b/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
@@ -477,6 +477,97 @@ class TestA2AInsufficientApprovalsMapping:
         rpc = a2a_exc.to_jsonrpc_error()
         assert rpc["data"]["required"] == 3
         assert rpc["data"]["received"] == 1
+        assert rpc["data"]["tenuo_code"] == 1700
+
+
+class TestRaiseIfDenied:
+    def test_insufficient_approvals_raises_typed_exception(self):
+        from tenuo._enforcement import EnforcementResult
+        from tenuo.exceptions import InsufficientApprovals
+
+        result = EnforcementResult(
+            allowed=False,
+            tool="transfer",
+            arguments={},
+            error_type="insufficient_approvals",
+            approval_metadata={"got": 1, "need": 2},
+        )
+        with pytest.raises(InsufficientApprovals) as exc_info:
+            result.raise_if_denied()
+        assert exc_info.value.details["required"] == 2
+        assert exc_info.value.details["received"] == 1
+
+    def test_invalid_pop_raises_signature_invalid(self):
+        from tenuo._enforcement import EnforcementResult
+        from tenuo.exceptions import SignatureInvalid
+
+        result = EnforcementResult(
+            allowed=False,
+            tool="transfer",
+            arguments={},
+            error_type="invalid_pop",
+            denial_reason="bad signature",
+        )
+        with pytest.raises(SignatureInvalid):
+            result.raise_if_denied()
+
+
+class TestOpenAIEnforcementMapping:
+    def test_insufficient_approvals_raises_typed_exception(self):
+        from tenuo._enforcement import EnforcementResult
+        from tenuo.exceptions import InsufficientApprovals
+        from tenuo.openai import _raise_for_enforcement_denial
+
+        result = EnforcementResult(
+            allowed=False,
+            tool="transfer",
+            arguments={},
+            error_type="insufficient_approvals",
+            approval_metadata={"got": 0, "need": 2},
+        )
+        with pytest.raises(InsufficientApprovals):
+            _raise_for_enforcement_denial("transfer", result)
+
+
+class TestCrewAIEnforcementMapping:
+    def test_insufficient_approvals_maps_to_dedicated_exception(self):
+        from tenuo._enforcement import EnforcementResult
+        from tenuo.crewai import CrewAIGuard, InsufficientApprovalsDenied
+
+        guard = CrewAIGuard.__new__(CrewAIGuard)
+        guard._warrant = None
+        guard._signing_key = None
+        result = EnforcementResult(
+            allowed=False,
+            tool="transfer",
+            arguments={},
+            error_type="insufficient_approvals",
+            approval_metadata={"got": 1, "need": 3},
+            denial_reason="need more",
+        )
+        err = guard._map_enforcement_error(result, "transfer", {}, "need more")
+        assert isinstance(err, InsufficientApprovalsDenied)
+        assert err.got == 1
+        assert err.need == 3
+
+
+class TestMCPJsonRpcPayload:
+    def test_minus_32002_includes_got_and_need(self):
+        from tenuo.mcp.server import MCPVerificationResult
+
+        result = MCPVerificationResult(
+            allowed=False,
+            tool="transfer",
+            clean_arguments={},
+            constraints={},
+            denial_reason="need more approvals",
+            jsonrpc_error_code=-32002,
+            approval_metadata={"got": 1, "need": 2},
+        )
+        err = result.to_jsonrpc_error()
+        assert err["code"] == -32002
+        assert err["data"]["got"] == 1
+        assert err["data"]["need"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -533,13 +624,14 @@ class TestTemporalErrorTypeForWire:
                 has_gate = any("ApprovalGateTriggered" in n for n in names)
                 has_insuf = any("InsufficientApprovals" in n for n in names)
                 has_tool = any("ToolNotAuthorized" in n for n in names)
-                if has_gate and has_insuf and has_tool:
+                has_constraint = any("ConstraintViolation" in n for n in names)
+                if has_gate and has_insuf and has_tool and has_constraint:
                     found_in_same_clause = True
                     break
 
         assert found_in_same_clause, (
-            "InsufficientApprovals and ToolNotAuthorized must be in the same "
-            "except clause as ApprovalGateTriggered in temporal/_interceptors.py"
+            "Approval, tool, and constraint errors must be in the explicit "
+            "auth catch list in temporal/_interceptors.py"
         )
 
     def test_error_type_for_wire_tool_not_authorized(self):

--- a/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
+++ b/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
@@ -169,6 +169,61 @@ class TestEnforcementResult:
         assert result.error_type != "insufficient_approvals"
         assert result.approval_metadata is None
 
+    def test_constraint_violation_populates_constraint_field(self):
+        """ConstraintViolation.field lives in details — must surface in result."""
+        from tenuo._enforcement import enforce_tool_call
+        from tenuo import Pattern
+
+        issuer = SigningKey.generate()
+        holder = SigningKey.generate()
+        warrant = Warrant.issue(
+            issuer,
+            capabilities={"read_file": {"path": Pattern("/data/*")}},
+            holder=holder.public_key,
+        )
+        bound = warrant.bind(holder)
+
+        result = enforce_tool_call(
+            "read_file",
+            {"path": "/etc/passwd"},
+            bound,
+            trusted_roots=[issuer.public_key],
+        )
+
+        assert not result.allowed
+        assert result.error_type == "constraint_violation"
+        assert result.constraint_violated == "path"
+
+    def test_verify_path_maps_insufficient_approvals(self):
+        """verify_mode='verify' must preserve insufficient_approvals error_type."""
+        from tenuo._enforcement import enforce_tool_call
+        from tenuo import Authorizer
+
+        issuer = SigningKey.generate()
+        holder = SigningKey.generate()
+        warrant = Warrant.issue(
+            issuer,
+            capabilities={"transfer": {}},
+            holder=holder.public_key,
+        )
+        bound = warrant.bind(holder)
+        authorizer = Authorizer(trusted_roots=[issuer.public_key])
+
+        exc = InsufficientApprovals(required=2, received=1)
+        with patch.object(Authorizer, "check_chain", side_effect=exc):
+            result = enforce_tool_call(
+                "transfer",
+                {},
+                bound,
+                verify_mode="verify",
+                precomputed_signature=b"\x00" * 64,
+                authorizer=authorizer,
+            )
+
+        assert not result.allowed
+        assert result.error_type == "insufficient_approvals"
+        assert result.approval_metadata == {"got": 1, "need": 2}
+
     def test_outer_catch_handles_insufficient_approvals(self):
         """The outer InsufficientApprovals except block in enforce_tool_call
         produces the correct EnforcementResult even when the exception escapes
@@ -408,6 +463,22 @@ class TestFastAPIInsufficientApprovals:
         assert exc.details["received"] == 1
 
 
+class TestA2AInsufficientApprovalsMapping:
+    def test_insufficient_approvals_maps_details_to_a2a_error(self):
+        from tenuo.exceptions import InsufficientApprovals
+        from tenuo.a2a.errors import InsufficientApprovalsError
+
+        core_exc = InsufficientApprovals(required=3, received=1)
+        a2a_exc = InsufficientApprovalsError(
+            str(core_exc),
+            required=core_exc.details.get("required", 0),
+            received=core_exc.details.get("received", 0),
+        )
+        rpc = a2a_exc.to_jsonrpc_error()
+        assert rpc["data"]["required"] == 3
+        assert rpc["data"]["received"] == 1
+
+
 # ---------------------------------------------------------------------------
 # temporal/exceptions.py  (_error_type_for_wire)
 # ---------------------------------------------------------------------------
@@ -447,7 +518,6 @@ class TestTemporalErrorTypeForWire:
         source = inspect.getsource(_interceptors)
         tree = ast.parse(source)
 
-        # Find the except clause that includes ApprovalGateTriggered
         found_in_same_clause = False
         for node in ast.walk(tree):
             if isinstance(node, ast.ExceptHandler):
@@ -462,11 +532,19 @@ class TestTemporalErrorTypeForWire:
 
                 has_gate = any("ApprovalGateTriggered" in n for n in names)
                 has_insuf = any("InsufficientApprovals" in n for n in names)
-                if has_gate and has_insuf:
+                has_tool = any("ToolNotAuthorized" in n for n in names)
+                if has_gate and has_insuf and has_tool:
                     found_in_same_clause = True
                     break
 
         assert found_in_same_clause, (
-            "InsufficientApprovals must be in the same except clause as "
-            "ApprovalGateTriggered in temporal/_interceptors.py"
+            "InsufficientApprovals and ToolNotAuthorized must be in the same "
+            "except clause as ApprovalGateTriggered in temporal/_interceptors.py"
         )
+
+    def test_error_type_for_wire_tool_not_authorized(self):
+        from tenuo.temporal.exceptions import _error_type_for_wire
+        from tenuo.exceptions import ToolNotAuthorized
+
+        exc = ToolNotAuthorized(tool="delete_file")
+        assert _error_type_for_wire(exc) == "tool_not_authorized"


### PR DESCRIPTION
## Summary
- Surface `InsufficientApprovals` as a typed, retryable signal (`got`/`need`) across MCP, FastAPI, Temporal, A2A, LangGraph, OpenAI, and CrewAI instead of collapsing to generic access denied
- Add cross-adapter error contract tests to prevent integration drift on `EnforcementResult.error_type`
- Restore Temporal denial metrics/audit and enforcement WARNING logs without losing typed wire errors

## Test plan
- [x] `pytest tests/unit/ tests/contracts/ tests/adapters/test_mcp_server.py tests/adapters/test_a2a_approvals.py`
- [x] Temporal metrics, dry_run, and log-mode contract tests pass