### PR TITLE
fix: propagate insufficient_approvals in remaining adapters

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1312,7 +1312,29 @@ Returns `MCPVerificationResult` with:
 - `clean_arguments` - Tool arguments safe to pass to the handler
 - `is_approval_required` - Whether an approval gate requires approval
 - `jsonrpc_error_code` - `-32001` (denied), `-32002` (approval required), or `-32602` (invalid params)
+- `approval_metadata` - When present on `-32002`, carries `got` and `need` for partial multi-sig retry
 - `to_jsonrpc_error()` - Format as JSON-RPC error response
+
+### Human approvals and retry signals
+
+Multi-sig warrants and approval gates can require callers to collect signed approvals and retry. The distinct **`InsufficientApprovals`** signal (partial multi-sig: some approvals supplied, threshold not met) must be handled separately from scope denials.
+
+| Integration | Retry signal | Key fields |
+|-------------|--------------|------------|
+| Core / `@guard` / LangChain / OpenAI / AutoGen | `InsufficientApprovals` exception | `details["required"]`, `details["received"]` |
+| MCP server | JSON-RPC `-32002` | `data.got`, `data.need` |
+| MCP client (`MCPApprovalRequired`) | Exception on `-32002` | `got`, `need`, `request_hash` |
+| FastAPI | HTTP **409** | `error: "insufficient_approvals"`, `got`, `need` |
+| A2A | `-32020` / wire **1700** | `required`, `received` |
+| Temporal | `ApplicationError.type == "insufficient_approvals"` | message + cause |
+| Google ADK | `{error: "insufficient_approvals"}` dict or raised exception | `got`, `need` |
+| CrewAI | `InsufficientApprovalsDenied` | `got`, `need` on adapter exception |
+
+Gate-first flows (no approvals yet) use **`approval_required`** / MCP `-32002` without counts, A2A `-32019`, FastAPI 409 with `request_hash`.
+
+Malformed approval wire payloads fail closed: HTTP **400** (`invalid_approval`) on FastAPI, A2A `-32021`, Temporal `invalid_approval`.
+
+See [Human Approvals](approvals.md) for mint-time configuration (`.min_approvals()`, `.approval_gates()`) and wire encoding.
 
 ### verify_mcp_call
 

--- a/tenuo-python/tenuo/decorators.py
+++ b/tenuo-python/tenuo/decorators.py
@@ -562,9 +562,19 @@ def _map_result_to_guard_error(
     - ``why_denied().suggestion`` passthrough
     - Structured ``audit_logger`` events with callsite/function metadata
 
-    Raises ``ToolNotAuthorized`` or ``AuthorizationDenied``; never returns.
+    Raises ``ToolNotAuthorized``, ``AuthorizationDenied``, or
+    ``InsufficientApprovals``; never returns.
     """
     from .warrant_ext import DenyCode as _DenyCode
+    from tenuo.exceptions import InsufficientApprovals as _InsufficientApprovals
+
+    if result.error_type == "insufficient_approvals":
+        meta = result.approval_metadata or {}
+        raise _InsufficientApprovals(
+            required=meta.get("need", 0),
+            received=meta.get("got", 0),
+            detail=result.denial_reason or "",
+        )
 
     why = warrant_to_use.why_denied(tool_name, auth_args)
 

--- a/tenuo-python/tenuo/langchain.py
+++ b/tenuo-python/tenuo/langchain.py
@@ -49,6 +49,9 @@ from .decorators import chain_scope, get_allowed_tools_context, key_scope, warra
 from .exceptions import (
     ConfigurationError,
     ConstraintViolation,
+    ExpiredError,
+    InsufficientApprovals,
+    SignatureInvalid,
     ToolNotAuthorized,
 )
 from .schemas import TOOL_SCHEMAS, ToolSchema, _get_tool_name
@@ -224,7 +227,14 @@ class TenuoTool(BaseTool):  # type: ignore[misc]
             return  # passthrough mode
         try:
             self._run_enforcement(tool_input, bw)
-        except (ToolNotAuthorized, ConstraintViolation, ConfigurationError):
+        except (
+            ToolNotAuthorized,
+            ConstraintViolation,
+            ConfigurationError,
+            InsufficientApprovals,
+            ExpiredError,
+            SignatureInvalid,
+        ):
             raise
         except Exception as e:
             from .approval import ApprovalDenied, ApprovalRequired, ApprovalVerificationError
@@ -243,7 +253,14 @@ class TenuoTool(BaseTool):  # type: ignore[misc]
             return  # passthrough mode
         try:
             await self._run_enforcement_async(tool_input, bw)
-        except (ToolNotAuthorized, ConstraintViolation, ConfigurationError):
+        except (
+            ToolNotAuthorized,
+            ConstraintViolation,
+            ConfigurationError,
+            InsufficientApprovals,
+            ExpiredError,
+            SignatureInvalid,
+        ):
             raise
         except Exception as e:
             from .approval import ApprovalDenied, ApprovalRequired, ApprovalVerificationError

--- a/tenuo-python/tenuo/mcp/client.py
+++ b/tenuo-python/tenuo/mcp/client.py
@@ -23,6 +23,7 @@ from ..exceptions import (
     ConfigurationError,
     ConstraintViolation,
     ExpiredError,
+    InsufficientApprovals,
     MCPToolCallError,
     ToolNotAuthorized,
 )
@@ -62,6 +63,13 @@ def _raise_for_denial(result: "EnforcementResult", tool_name: str) -> None:
         raise ToolNotAuthorized(reason)
     if etype == "expired":
         raise ExpiredError(reason)
+    if etype == "insufficient_approvals":
+        meta = result.approval_metadata or {}
+        raise InsufficientApprovals(
+            required=meta.get("need", 0),
+            received=meta.get("got", 0),
+            detail=reason,
+        )
     raise AuthorizationDenied(reason)
 
 
@@ -678,11 +686,15 @@ class SecureMCPClient:
                             _msg = _safe_mcp_tool_error_message(raw_content, tool_name)
                             _tenuo_block = (structured or {}).get("tenuo") or {}
                             _rh = _tenuo_block.get("request_hash") if isinstance(_tenuo_block, dict) else None
+                            _got = _tenuo_block.get("got") if isinstance(_tenuo_block, dict) else None
+                            _need = _tenuo_block.get("need") if isinstance(_tenuo_block, dict) else None
                             raise MCPApprovalRequired(
                                 tool_name=tool_name,
                                 message=_msg,
                                 raw_error=structured,
                                 request_hash=_rh,
+                                got=_got if isinstance(_got, int) else None,
+                                need=_need if isinstance(_need, int) else None,
                             )
                         if raise_on_tool_error:
                             raise MCPToolCallError(

--- a/tenuo-python/tenuo/mcp/server.py
+++ b/tenuo-python/tenuo/mcp/server.py
@@ -288,10 +288,14 @@ class MCPApprovalRequired(MCPAuthorizationError):
         result: Optional[MCPVerificationResult] = None,
         raw_error: Optional[Any] = None,
         request_hash: Optional[str] = None,
+        got: Optional[int] = None,
+        need: Optional[int] = None,
     ) -> None:
         self.tool_name = tool_name
         self.raw_error = raw_error
         self.request_hash = request_hash
+        self.got = got
+        self.need = need
         if result is not None:
             if request_hash and not result.request_hash:
                 result = MCPVerificationResult(

--- a/tenuo-python/tests/contracts/error_type_contract.py
+++ b/tenuo-python/tests/contracts/error_type_contract.py
@@ -66,6 +66,7 @@ class IntegrationExpectation:
     tenuo_wire_code: Optional[int] = None
     got_need_in_payload: bool = False
     returns_tool_message: bool = False
+    returns_error_dict: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -107,6 +108,14 @@ def _rows() -> list[ErrorTypeContract]:
                     got_need_in_payload=True,
                 ),
                 "temporal": IntegrationExpectation(wire_type="insufficient_approvals"),
+                "autogen": IntegrationExpectation(raises=_exc("InsufficientApprovals")),
+                "langchain": IntegrationExpectation(raises=_exc("InsufficientApprovals")),
+                "guard": IntegrationExpectation(raises=_exc("InsufficientApprovals")),
+                "mcp_client": IntegrationExpectation(raises=_exc("InsufficientApprovals")),
+                "google_adk": IntegrationExpectation(
+                    returns_error_dict="insufficient_approvals",
+                    got_need_in_payload=True,
+                ),
             },
         ),
         ErrorTypeContract(
@@ -201,6 +210,11 @@ INTEGRATION_SURFACES = frozenset(
         "mcp",
         "a2a",
         "temporal",
+        "autogen",
+        "langchain",
+        "guard",
+        "mcp_client",
+        "google_adk",
     }
 )
 

--- a/tenuo-python/tests/contracts/test_integration_error_contract.py
+++ b/tenuo-python/tests/contracts/test_integration_error_contract.py
@@ -332,7 +332,7 @@ def test_mcp_client_raise_for_denial_matches_contract(row: ErrorTypeContract) ->
 
 @pytest.mark.parametrize("row", _integration_rows("autogen"), ids=_row_ids)
 def test_autogen_authorize_matches_contract(row: ErrorTypeContract) -> None:
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 
     from tenuo import SigningKey, Warrant
     from tenuo.autogen import GuardBuilder

--- a/tenuo-python/tests/contracts/test_integration_error_contract.py
+++ b/tenuo-python/tests/contracts/test_integration_error_contract.py
@@ -258,6 +258,137 @@ def test_temporal_wire_type_matches_contract(row: ErrorTypeContract) -> None:
 
 
 # ---------------------------------------------------------------------------
+# @guard (decorators._map_result_to_guard_error)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("guard"), ids=_row_ids)
+def test_guard_mapper_matches_contract(row: ErrorTypeContract) -> None:
+    from tenuo import SigningKey, Warrant
+    from tenuo.decorators import _map_result_to_guard_error
+
+    exp = row.integrations["guard"]
+    assert exp.raises is not None
+    key = SigningKey.generate()
+    warrant = Warrant.mint_builder().tool("transfer").mint(key)
+    with pytest.raises(exp.raises):
+        _map_result_to_guard_error(
+            row.result_factory(),
+            warrant,
+            "transfer",
+            row.result_factory().arguments,
+            "test",
+            "fn",
+        )
+
+
+# ---------------------------------------------------------------------------
+# LangChain (TenuoTool._check_authorization)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("langchain"), ids=_row_ids)
+def test_langchain_check_authorization_matches_contract(row: ErrorTypeContract) -> None:
+    from unittest.mock import MagicMock
+
+    from tenuo.langchain import TenuoTool
+
+    exp = row.integrations["langchain"]
+    assert exp.raises is not None
+    result = row.result_factory()
+    tool = MagicMock()
+    bw = MagicMock()
+
+    def _fake_run(tool_input: dict, bound_warrant: object) -> None:
+        if not result.allowed:
+            result.raise_if_denied()
+
+    tool._resolve_bound_warrant.return_value = bw
+    tool._run_enforcement = _fake_run
+
+    with pytest.raises(exp.raises):
+        TenuoTool._check_authorization(tool, result.arguments)
+
+
+# ---------------------------------------------------------------------------
+# MCP client local enforcement (_raise_for_denial)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("mcp_client"), ids=_row_ids)
+def test_mcp_client_raise_for_denial_matches_contract(row: ErrorTypeContract) -> None:
+    from tenuo.mcp.client import _raise_for_denial
+
+    exp = row.integrations["mcp_client"]
+    assert exp.raises is not None
+    with pytest.raises(exp.raises):
+        _raise_for_denial(row.result_factory(), "transfer")
+
+
+# ---------------------------------------------------------------------------
+# AutoGen (GuardBuilder Tier 2 _authorize)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("autogen"), ids=_row_ids)
+def test_autogen_authorize_matches_contract(row: ErrorTypeContract) -> None:
+    from unittest.mock import MagicMock, patch
+
+    from tenuo import SigningKey, Warrant
+    from tenuo.autogen import GuardBuilder
+
+    exp = row.integrations["autogen"]
+    assert exp.raises is not None
+    key = SigningKey.generate()
+    warrant = Warrant.mint_builder().tool("transfer").mint(key)
+
+    def transfer(amount: int) -> str:
+        return str(amount)
+
+    guard = (
+        GuardBuilder()
+        .with_warrant(warrant, key)
+        .with_trusted_roots([key.public_key])
+        .build()
+    )
+    guarded = guard.guard_tool(transfer, tool_name="transfer")
+
+    with patch("tenuo.autogen.enforce_tool_call", return_value=row.result_factory()):
+        with pytest.raises(exp.raises):
+            guarded(amount=100)
+
+
+# ---------------------------------------------------------------------------
+# Google ADK (_deny_insufficient_approvals)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", _integration_rows("google_adk"), ids=_row_ids)
+def test_google_adk_denial_dict_matches_contract(row: ErrorTypeContract) -> None:
+    pytest.importorskip("google.adk")
+    from unittest.mock import MagicMock
+
+    from tenuo.google_adk.guard import TenuoGuard
+
+    exp = row.integrations["google_adk"]
+    assert exp.returns_error_dict is not None
+    guard = TenuoGuard.__new__(TenuoGuard)
+    guard._dry_run = False
+    guard._on_denial = "return"
+    guard._denial_detail = "full"
+    guard._audit = MagicMock()
+
+    out = guard._deny_insufficient_approvals(
+        row.result_factory(), "transfer", row.result_factory().arguments
+    )
+    assert isinstance(out, dict)
+    assert out["error"] == exp.returns_error_dict
+    if exp.got_need_in_payload:
+        assert out["got"] == 1
+        assert out["need"] == 2
+
+
+# ---------------------------------------------------------------------------
 # Structural: explicit auth exception catch lists
 # ---------------------------------------------------------------------------
 

--- a/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
+++ b/tenuo-python/tests/unit/test_insufficient_approvals_signal.py
@@ -773,3 +773,58 @@ class TestGoogleADKInsufficientApprovals:
 
         with pytest.raises(InsufficientApprovals):
             guard.before_tool(tool, tool_args, context)
+
+
+class TestMCPClientInsufficientApprovals:
+    def test_raise_for_denial_maps_insufficient_approvals(self):
+        from tenuo._enforcement import EnforcementResult
+        from tenuo.mcp.client import _raise_for_denial
+
+        result = EnforcementResult(
+            allowed=False,
+            tool="transfer",
+            arguments={"amount": 500},
+            error_type="insufficient_approvals",
+            approval_metadata={"got": 1, "need": 2},
+        )
+        with pytest.raises(InsufficientApprovals) as exc_info:
+            _raise_for_denial(result, "transfer")
+        assert exc_info.value.details["required"] == 2
+        assert exc_info.value.details["received"] == 1
+
+    def test_mcp_approval_required_carries_got_and_need(self):
+        from tenuo.mcp.server import MCPApprovalRequired
+
+        exc = MCPApprovalRequired(
+            tool_name="transfer",
+            message="need more",
+            request_hash="abc123",
+            got=1,
+            need=2,
+        )
+        assert exc.got == 1
+        assert exc.need == 2
+        assert exc.request_hash == "abc123"
+
+
+class TestGuardInsufficientApprovals:
+    def test_map_result_raises_insufficient_approvals(self):
+        from tenuo import SigningKey, Warrant
+        from tenuo._enforcement import EnforcementResult
+        from tenuo.decorators import _map_result_to_guard_error
+
+        key = SigningKey.generate()
+        warrant = Warrant.mint_builder().tool("transfer").mint(key)
+        result = EnforcementResult(
+            allowed=False,
+            tool="transfer",
+            arguments={"amount": 500},
+            error_type="insufficient_approvals",
+            approval_metadata={"got": 1, "need": 2},
+        )
+        with pytest.raises(InsufficientApprovals) as exc_info:
+            _map_result_to_guard_error(
+                result, warrant, "transfer", {"amount": 500}, "test", "fn"
+            )
+        assert exc_info.value.details["required"] == 2
+        assert exc_info.value.details["received"] == 1


### PR DESCRIPTION
## Summary
Follow-up to #466: surfaces `InsufficientApprovals` in `@guard`, LangChain, and MCP client paths that were still collapsing to generic denials. Adds `got`/`need` on `MCPApprovalRequired`, extends contract tests to AutoGen/Google ADK/guard/LangChain/MCP client, and documents per-integration retry signals in the API reference.

## Test plan
- [x] Contract tests for new adapter surfaces
- [x] Unit tests for guard mapper and MCP client
- [ ] CI green