### PR TITLE
release: prepare v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **IETF Draft**: Published `draft-niyikiza-oauth-attenuating-agent-tokens-01`.
 
+## [0.2.3] - 2026-07-02
+
+Covers all changes since the `v0.2.0` release. (Git tags `v0.2.1`/`v0.2.2` were
+never released from `main` and are superseded by this entry.)
+
+### Added
+
+- **Distinct `InsufficientApprovals` retry signal across every integration.**
+  Partial multi-sig (some approvals supplied, threshold not met) now surfaces as
+  a typed, retryable signal instead of collapsing into a generic access denial —
+  in MCP (server + client), FastAPI, Temporal, A2A, LangGraph, OpenAI, AutoGen,
+  CrewAI, Google ADK, LangChain, and the `@guard` decorator. The signal carries
+  structured counts — `got`/`need` (HTTP and MCP wire) or `required`/`received`
+  (Python exceptions and A2A) — so callers can build a retry-with-approval loop
+  without parsing human-readable denial strings. (#466, #484)
+- **Unix domain socket serving mode for the authorizer** (`--socket`,
+  `--socket-mode`, `--socket-group`), letting non-root local clients connect over
+  a filesystem socket. (#463, #465)
+- **`cloud` optional-dependency extra** (`pip install "tenuo[cloud]"`) for the
+  Tenuo Cloud control-plane SDK.
+- **Cross-adapter error-type contract tests** that pin each
+  `EnforcementResult.error_type` to its per-integration signal, preventing
+  integrations from silently drifting apart.
+
+### Changed
+
+- **A2A `INSUFFICIENT_APPROVALS` canonical wire code corrected from `1702` to
+  `1700`** (JSON-RPC `-32020`), aligning with `wire-format-v1`. A2A clients that
+  hard-coded `1702` for insufficient-approvals must update to `1700`.
+
+### Fixed
+
+- **Async Temporal approval handlers are now awaited** instead of being driven
+  through a blocking `run_coroutine_threadsafe` call on the running activity
+  loop, which could deadlock. The typed auth-denial branch now also honors
+  `dry_run` / `on_denial`.
+- **Restored Temporal denial metrics, audit events, and enforcement `WARNING`
+  logs** without losing the typed wire error types.
+- **Rust `FeatureNotEnabled` maps to a typed `FeatureNotEnabled` Python error**
+  rather than a generic `RuntimeError`.
+
+### Security
+
+- **Fail closed on malformed approval wire payloads** instead of silently
+  ignoring them: a malformed approvals header now surfaces as A2A `-32021`,
+  FastAPI HTTP 400 (`invalid_approval`), and Temporal `invalid_approval`, rather
+  than being dropped and treated as "no approvals supplied". (#466 follow-up)
+- **Bumped `quinn-proto`** to resolve RUSTSEC-2026-0185. (#464)
+
 ## [0.1.0-beta.24] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ async def search(query: str, ctx: SecurityContext = Depends(TenuoGuard("search")
 | Component | Supported |
 |-----------|-----------|
 | **Python** | 3.9 – 3.14 |
-| **Node.js** | *Coming v0.2* |
+| **Node.js** | *Planned (TypeScript SDK — [help wanted](#contributing))* |
 | **OS** | Linux, macOS, Windows |
 | **Rust** | Not required (binary wheels for macOS, Linux, Windows) |
 
@@ -313,6 +313,7 @@ uv pip install "tenuo[temporal]"      # + Temporal workflows
 uv pip install "tenuo[autogen]"       # + AutoGen AgentChat (Python ≥3.10)
 uv pip install "tenuo[mcp]"           # + official MCP SDK, client & server verification (Python ≥3.10)
 uv pip install "tenuo[fastmcp]"       # + FastMCP (TenuoMiddleware / FastMCP servers)
+uv pip install "tenuo[cloud]"         # + Tenuo Cloud SDK (proprietary control-plane client)
 ```
 
 ---
@@ -330,8 +331,8 @@ This runs the [orchestrator -> worker -> authorizer demo](https://tenuo.ai/demo.
 **Official Images** on [Docker Hub](https://hub.docker.com/u/tenuo):
 
 ```bash
-docker pull tenuo/authorizer:0.2.0  # Sidecar for warrant verification
-docker pull tenuo/control:0.2.0     # Control plane (demo/reference)
+docker pull tenuo/authorizer:0.2.3  # Sidecar for warrant verification
+docker pull tenuo/control:0.2.3     # Control plane (demo/reference)
 ```
 
 **Helm Chart**:
@@ -377,7 +378,7 @@ What you get in Rust:
 
 ```toml
 [dependencies]
-tenuo = "0.2.0"
+tenuo = "0.2.3"
 ```
 
 Use the Rust API when you need a language-native enforcement boundary

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -702,7 +702,7 @@ This enables:
 
 | A2A JSON-RPC Code | Canonical Wire Code | Name |
 |-------------------|---------------------|------|
-| -32001 | 1202 | Missing warrant |
+| -32001 | — (A2A-specific) | Missing warrant |
 | -32002 | 1100 | Invalid signature |
 | -32003 | 1406 | Untrusted issuer |
 | -32004 | 1300 | Warrant expired |
@@ -713,7 +713,7 @@ This enables:
 | -32020 | 1700 | Insufficient approvals (partial multi-sig) |
 | -32021 | 1701 | Invalid approval |
 
-See [wire format specification](./spec/wire-format-v1#appendix-a-error-codes) for the complete list.
+See [wire format specification](./spec/wire-format-v1#appendix-a-error-code-reference) for the complete list.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -22,7 +22,7 @@ Complete API documentation for the Tenuo Python SDK. For wire format details, se
 - [Warrant Templates](#warrant-templates)
 - [Task Scoping](#task-scoping)
 - [Tool Protection](#tool-protection)
-- [MCP Integration](#mcp)
+- [MCP Integration](#mcp-integration)
 - [Decorators & Context](#decorators--context)
 - [LangChain Integration](#langchain-integration)
 - [LangGraph Integration](#langgraph-integration)
@@ -497,7 +497,7 @@ print(repr(warrant))
 # <Warrant id=tnu_wrt_019b... tools=[a, b, c, +3 more] ttl=0:04:59>
 ```
 
-**Replay Window:** PoP signatures are valid for ~2 minutes to handle clock skew. For sensitive operations, implement deduplication using `warrant.dedup_key(tool, args)`. See [Protocol: Replay Protection](./spec/protocol-spec-v1#replay-protection).
+**Replay Window:** PoP signatures are valid for ~2 minutes to handle clock skew. For sensitive operations, implement deduplication using `warrant.dedup_key(tool, args)`. See [Protocol: Replay Protection](./spec/protocol-spec-v1#74-replay-protection).
 
 #### Principle of Least Authority (POLA)
 

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -267,4 +267,4 @@ Every approval binds to `(warrant_id, tool, args, holder)` via SHA-256 (`compute
 - [Enforcement Architecture](enforcement.md#human-approvals) — Where approvals sit in the pipeline
 - [MCP Approval Gates](mcp.md#approval-gates) — Remote PEP retry flow
 - [FastAPI](fastapi.md#error-handling) — HTTP 409 approval responses
-- [Wire format §16](spec/wire-format-v1.md#16-approval-wire-format) — `SignedApproval` bytes
+- [Wire format §16](spec/wire-format-v1.md#16-approval-wire-format-multi-sig) — `SignedApproval` bytes

--- a/docs/autogen.md
+++ b/docs/autogen.md
@@ -80,7 +80,7 @@ guard = (GuardBuilder()
 
 ## Delegation Chains
 
-For multi-agent delegation with attenuated warrants, see [Delegation Chains](./concepts#delegation).
+For multi-agent delegation with attenuated warrants, see [Monotonic Attenuation](./concepts#monotonic-attenuation).
 
 Use `Warrant.grant_builder()` to create child warrants with narrower scope:
 

--- a/docs/crewai.md
+++ b/docs/crewai.md
@@ -26,7 +26,7 @@ Tenuo integrates with [CrewAI](https://crewai.com) using a **two-tier** protecti
 ## Installation
 
 ```bash
-uv pip install tenuo crewai
+uv pip install "tenuo[crewai]"
 ```
 
 ---
@@ -786,8 +786,8 @@ A: Ensure you are wrapping a standard CrewAI `Tool`. If using custom classes, th
 
 ## See Also
 
-- [GuardedCrew Example](../examples/crewai/guarded_crew.py) - Policy-based protection
-- [Flow Example](../examples/crewai/guarded_flow.py) - Guarded steps in CrewAI Flows
+- [GuardedCrew Example](../tenuo-python/examples/crewai/guarded_crew.py) - Policy-based protection
+- [Flow Example](../tenuo-python/examples/crewai/guarded_flow.py) - Guarded steps in CrewAI Flows
 - [OpenAI Integration](./openai) - Tool protection for OpenAI
 - [LangGraph Integration](./langgraph) - Multi-agent graph security
 - [Constraints Reference](./constraints) - All constraint types

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -138,7 +138,7 @@ print(info())
 Tenuo Configuration
 ==================================================
 
-[OK] SDK Version: 0.1.0b5
+[OK] SDK Version: 0.2.3
 [OK] Rust Core: loaded (wire version 1)
 [OK] Issuer Key: configured
 ```

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -88,7 +88,7 @@ Tenuo runs as a separate container in the same Kubernetes pod. All tool traffic 
 spec:
   containers:
     - name: tenuo-authorizer
-      image: tenuo/authorizer:0.2.0
+      image: tenuo/authorizer:0.2.3
       ports: [{ containerPort: 9090 }]
     - name: tool-api
       image: your-tool:latest
@@ -432,7 +432,7 @@ services:
       - tenuo-authorizer
 
   tenuo-authorizer:
-    image: tenuo/authorizer:0.2.0
+    image: tenuo/authorizer:0.2.3
     ports:
       - "9090:9090"
     environment:

--- a/docs/eu-act.md
+++ b/docs/eu-act.md
@@ -434,9 +434,9 @@ With Tenuo: the model processes the resume and generates the `send_email` call. 
 - [EU AI Act (official consolidated text)](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689), the authoritative source for all article numbers cited here.
 - [EU AI Act Service Desk](https://artificialintelligenceact.eu/), official guidance and FAQ.
 - [Annex III: High-Risk AI Systems](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689#d1e38-206-1), full list of high-risk application domains.
-- [Tenuo security model](/security), cryptographic guarantees and threat model.
-- [Constraint reference](/constraints), all constraint types with semantics and examples.
-- [OWASP Top 10 for Agentic Applications (2026) mapping](/owasp), Tenuo's coverage against the OWASP agentic risk framework.
+- [Tenuo security model](./security), cryptographic guarantees and threat model.
+- [Constraint reference](./constraints), all constraint types with semantics and examples.
+- [OWASP Top 10 for Agentic Applications (2026) mapping](./owasp), Tenuo's coverage against the OWASP agentic risk framework.
 
 ---
 

--- a/docs/fastapi.md
+++ b/docs/fastapi.md
@@ -294,7 +294,7 @@ Common error codes:
 
 Approval retries use **409 Conflict** (not 403) so clients can branch separately from scope denials. Re-submit with `X-Tenuo-Approvals`. See [Human Approvals](approvals.md#signals-by-integration).
 
-See [wire format specification](/docs/spec/wire-format-v1#appendix-a-error-codes) for the complete list.
+See [wire format specification](./spec/wire-format-v1#appendix-a-error-code-reference) for the complete list.
 
 ### Status Codes
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -183,7 +183,7 @@ env:
 ```yaml
 containers:
 - name: tenuo-authorizer
-  image: tenuo/authorizer:0.2.0
+  image: tenuo/authorizer:0.2.3
   args: ["serve", "--config", "/etc/tenuo/gateway.yaml"]
   ports:
   - name: http
@@ -451,7 +451,7 @@ curl -s localhost:9090/status | jq
 
 ```json
 {
-  "version": "0.1.0-beta.16",
+  "version": "0.2.3",
   "uptime_secs": 42,
   "cp": {
     "enabled": true,

--- a/docs/langgraph.md
+++ b/docs/langgraph.md
@@ -627,7 +627,7 @@ except ConstraintViolation as e:
 | `ConstraintViolation` | 1501 | Argument violates constraint | Request within bounds |
 | `ExpiredError` | 1300 | TTL exceeded | Request fresh warrant |
 
-See [wire format specification](/docs/spec/wire-format-v1#appendix-a-error-codes) for the complete list.
+See [wire format specification](./spec/wire-format-v1#appendix-a-error-code-reference) for the complete list.
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -463,7 +463,7 @@ Tenuo sends warrant metadata via `params._meta.tenuo`:
 }
 ```
 
-The `warrant` field accepts either a single base64-encoded warrant (for root warrants issued directly by a trusted root) or a **WarrantStack** — the full delegation chain encoded as a CBOR array. See [Multi-Agent Delegation](#multi-agent-delegation) below.
+The `warrant` field accepts either a single base64-encoded warrant (for root warrants issued directly by a trusted root) or a **WarrantStack** — the full delegation chain encoded as a CBOR array. See [Multi-Agent Delegation](#advanced-multi-agent-delegation) below.
 
 ---
 
@@ -547,7 +547,7 @@ except TenuoError as e:
 | `ConfigurationError` | 1201 | Not connected / extraction failed | Use `async with` or check config |
 | `ExpiredError` | 1300 | TTL exceeded | Request fresh warrant |
 
-See [wire format specification](./spec/wire-format-v1#appendix-a-error-codes) for the complete list.
+See [wire format specification](./spec/wire-format-v1#appendix-a-error-code-reference) for the complete list.
 
 ---
 
@@ -816,7 +816,7 @@ http_request:
 
 ## See Also
 
-- [API Reference → MCP Integration](./api-reference#mcp)
+- [API Reference → MCP Integration](./api-reference#mcp-integration)
 - [Argument Extraction](./constraints#argument-extraction)
 - [Constraints Guide](./constraints)
 - [Security Best Practices](./security)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,6 +42,9 @@ uv pip install "tenuo[mcp]"         # MCP (Python ≥3.10)
 uv pip install "tenuo[a2a]"         # A2A inter-agent delegation
 uv pip install "tenuo[fastapi]"     # FastAPI
 uv pip install "tenuo[autogen]"     # AutoGen AgentChat (Python ≥3.10)
+uv pip install "tenuo[fastmcp]"     # FastMCP (TenuoMiddleware / FastMCP servers)
+uv pip install "tenuo[langgraph]"   # LangGraph (includes LangChain)
+uv pip install "tenuo[cloud]"       # Tenuo Cloud SDK (proprietary control-plane client)
 ```
 
 ## Try It (Copy-Paste, Runs Immediately)

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -792,8 +792,9 @@ Gates and approvers live on the warrant. Configure `approval_handler` on `TenuoP
 |--------|-------------------------|------------|
 | Gate fired, no approvals | `"approval_required"` | `set_activity_approvals()` or `x-tenuo-approvals` header |
 | Partial multi-sig | `"insufficient_approvals"` | Additional `SignedApproval` objects on retry |
+| Malformed `x-tenuo-approvals` | `"invalid_approval"` | Fix client encoding — **not** a retryable approval state |
 
-**Header encoding:** `x-tenuo-approvals` = JSON array of base64(CBOR) strings — **no** outer base64 wrapper (differs from FastAPI). See [Human Approvals](approvals.md#wire-format-retry-payloads).
+**Header encoding:** `x-tenuo-approvals` = JSON array of base64(CBOR) strings — **no** outer base64 wrapper (differs from FastAPI). See [Human Approvals](approvals.md#wire-format-retry-payloads). A malformed header **fails closed**: the activity is denied with a non-retryable `ApplicationError` of type `"invalid_approval"` (it is not silently treated as "no approvals supplied"), so a bad-encoding client bug is distinguishable from a legitimate insufficient-approvals retry.
 
 ```python
 TenuoPluginConfig(

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "axum",
  "base64",

--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo"
-version = "0.2.0"
+version = "0.2.3"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Agent Capability Flow Control - Rust core library"

--- a/tenuo-python/Cargo.lock
+++ b/tenuo-python/Cargo.lock
@@ -2197,7 +2197,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tenuo"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "axum",
  "base64",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-python"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "pyo3",
  "tenuo",

--- a/tenuo-python/Cargo.toml
+++ b/tenuo-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-python"
-version = "0.2.0"
+version = "0.2.3"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Capability tokens for AI agents - Python SDK"

--- a/tenuo-python/README.md
+++ b/tenuo-python/README.md
@@ -16,12 +16,15 @@ uv pip install tenuo                  # Core only
 uv pip install "tenuo[openai]"        # + OpenAI Agents SDK
 uv pip install "tenuo[google_adk]"    # + Google ADK
 uv pip install "tenuo[a2a]"           # + Agent-to-Agent (inter-agent delegation)
-uv pip install "tenuo[langchain]"     # + LangChain / LangGraph
+uv pip install "tenuo[langchain]"     # + LangChain
+uv pip install "tenuo[langgraph]"     # + LangGraph (includes LangChain)
 uv pip install "tenuo[crewai]"        # + CrewAI
+uv pip install "tenuo[autogen]"       # + AutoGen AgentChat (Python ≥3.10)
 uv pip install "tenuo[fastapi]"       # + FastAPI
 uv pip install "tenuo[mcp]"           # + official MCP SDK, client/server (Python ≥3.10)
 uv pip install "tenuo[fastmcp]"       # + FastMCP (``TenuoMiddleware``, FastMCP servers)
 uv pip install "tenuo[temporal]"      # + Temporal Python SDK (workflow + activity authorization)
+uv pip install "tenuo[cloud]"         # + Tenuo Cloud SDK (proprietary control-plane client)
 ```
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tenuo-ai/tenuo/blob/main/notebooks/tenuo_demo.ipynb)

--- a/tenuo-python/examples/agentql/benchmark.py
+++ b/tenuo-python/examples/agentql/benchmark.py
@@ -21,7 +21,7 @@ from typing import Dict
 
 from wrapper import TenuoAgentQLAgent
 
-from tenuo import Exact, OneOf, SigningKey, UrlPattern, Warrant, Wildcard
+from tenuo import Authorizer, Exact, OneOf, SigningKey, UrlPattern, Warrant, Wildcard
 
 
 class Benchmark:
@@ -473,23 +473,30 @@ def benchmark_pop_overhead():
     # Use bound warrant to get access to validate()
     bound = warrant.bind(agent_key)
 
+    # Authorizer trusts the minting (user) key; used for the server-side verify path.
+    authorizer = Authorizer(trusted_roots=[user_key.public_key])
+
+    # URL that satisfies the "https://*.example.com/*" constraint so the verify
+    # path exercises a successful authorization (Authorizer.authorize raises on denial).
+    nav_args = {"url": "https://app.example.com/page"}
+
     bench = Benchmark()
 
     # 1. Sign only
     print("\n5a. Signing only (Client side)...")
     results_sign = bench.measure_latency(
-        lambda: warrant.sign(agent_key, "navigate", {"url": "https://example.com"}, int(time.time())),
+        lambda: warrant.sign(agent_key, "navigate", nav_args, int(time.time())),
         iterations=1000
     )
     print(f"  Mean latency: {results_sign['mean']:.3f} ms")
 
     # 2. Verify only (Server side)
     # Generate a signature first to reuse
-    sig = warrant.sign(agent_key, "navigate", {"url": "https://example.com"}, int(time.time()))
+    sig = warrant.sign(agent_key, "navigate", nav_args, int(time.time()))
 
     print("\n5b. Verify only (Server side)...")
     results_verify = bench.measure_latency(
-        lambda: warrant.authorize("navigate", {"url": "https://example.com"}, sig),
+        lambda: authorizer.authorize(warrant, "navigate", nav_args, bytes(sig)),
         iterations=1000
     )
     print(f"  Mean latency: {results_verify['mean']:.3f} ms")
@@ -497,7 +504,7 @@ def benchmark_pop_overhead():
     # 3. Full Round Trip (bound.validate)
     print("\n5c. Full Round Trip (Sign + Verify)...")
     results_full = bench.measure_latency(
-        lambda: bound.validate("navigate", {"url": "https://example.com"}),
+        lambda: bound.validate("navigate", nav_args),
         iterations=1000
     )
     print(f"  Mean latency: {results_full['mean']:.3f} ms")

--- a/tenuo-python/examples/google_adk_a2a_incident/README.md
+++ b/tenuo-python/examples/google_adk_a2a_incident/README.md
@@ -50,7 +50,7 @@ This demo shows how to build **multi-service agent systems** where:
 
 ### 2. **A2A Protocol Integration**
 - Warrants serialized and transmitted over HTTP
-- **Tier 2 authorization** with `warrant.authorize()` in Rust core
+- **Tier 2 authorization** with `Authorizer.authorize()` in Rust core
 - Cryptographic signature validation at each hop
 - Replay protection via JTI (warrant ID) tracking
 

--- a/tenuo-python/examples/google_adk_a2a_incident/demo_distributed.py
+++ b/tenuo-python/examples/google_adk_a2a_incident/demo_distributed.py
@@ -283,7 +283,7 @@ class DistributedDemo:
                     data = result.get("data", {})
                     info(f"IP 203.0.113.5: {data.get('category', 'unknown')}", 4)
                     info(f"Threat score: {data.get('score', 'N/A')}/100", 4)
-                    info(f"Warrant JTI: {result.get('warrant_jti', 'N/A')[:12]}...", 4)
+                    info(f"Warrant ID: {result.get('warrant_id', 'N/A')[:12]}...", 4)
                 else:
                     info(f"Result: {result}", 4)
 

--- a/tenuo-python/examples/google_adk_a2a_incident/services/analyst_service.py
+++ b/tenuo-python/examples/google_adk_a2a_incident/services/analyst_service.py
@@ -6,12 +6,13 @@ Runs as a separate process, exposing threat intelligence tools via A2A protocol.
 Receives delegated warrant from orchestrator, validates it, and provides
 access to query_threat_db capability.
 
-Security: Uses warrant.authorize() for Tier 2 (PoP) validation.
+Security: Uses Authorizer.authorize() for Tier 2 (PoP) validation.
 """
 
 import argparse
 import asyncio
 import sys
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -22,7 +23,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 # Import tools
 from tools import query_threat_db
 
-from tenuo import SigningKey, Warrant
+from tenuo import Authorizer, SigningKey, Warrant
 from tenuo.exceptions import AuthorizationError, ConstraintViolation
 
 
@@ -111,7 +112,7 @@ class AnalystService:
         """
         Handle threat DB query request.
 
-        Uses warrant.authorize() for Tier 2 validation with PoP.
+        Uses Authorizer.authorize() for Tier 2 validation with PoP.
         """
         query = params.get("query")
         table = params.get("table")
@@ -119,20 +120,24 @@ class AnalystService:
         if not query or not table:
             raise ValueError("Missing required parameters: query, table")
 
-        # TIER 2 AUTHORIZATION: Use warrant.authorize() with PoP signature
+        # TIER 2 AUTHORIZATION: Use Authorizer.authorize() with a PoP signature.
         # This validates:
         # 1. Warrant grants the skill
         # 2. Arguments satisfy constraints
         # 3. Warrant is not expired
-        # 4. Signature chain is valid
+        # 4. Signature chain is valid (PoP + trusted root)
         try:
-            pop_signature = self.signing_key.sign(
-                f"query_threat_db:{query}:{table}".encode()
+            args = {"query": query, "table": table}
+            # Proof-of-Possession: sign the exact (tool, args) with the holder key.
+            pop_signature = self.warrant.sign(
+                self.signing_key, "query_threat_db", args, int(time.time())
             )
-            self.warrant.authorize(
-                tool="query_threat_db",
-                args={"query": query, "table": table},
-                signature=pop_signature,
+            # In production, configure the Authorizer with your control plane's
+            # root public key. For this single-delegation demo the warrant's
+            # issuer is the trusted root.
+            authorizer = Authorizer(trusted_roots=[self.warrant.issuer])
+            authorizer.authorize(
+                self.warrant, "query_threat_db", args, bytes(pop_signature)
             )
         except Exception as e:
             # Re-raise as AuthorizationError for consistent handling
@@ -142,14 +147,14 @@ class AnalystService:
         result = query_threat_db(query, table)
 
         # Get warrant ID for audit trail
-        jti = self.warrant.jti
-        jti_str = jti.hex() if hasattr(jti, 'hex') else str(jti)
+        warrant_id = self.warrant.id
+        warrant_id_str = warrant_id.hex() if hasattr(warrant_id, "hex") else str(warrant_id)
 
         return {
             "success": True,
             "data": result,
-            "warrant_jti": jti_str,
-            "authorized_by": "warrant.authorize()",  # Proof of Tier 2
+            "warrant_id": warrant_id_str,
+            "authorized_by": "Authorizer.authorize()",  # Proof of Tier 2
         }
 
     async def start(self):

--- a/tenuo-python/examples/google_adk_a2a_incident/services/responder_service.py
+++ b/tenuo-python/examples/google_adk_a2a_incident/services/responder_service.py
@@ -6,7 +6,7 @@ Runs as a separate process, exposing blocking/quarantine tools via A2A protocol.
 Receives attenuated warrant from analyst, validates it, and provides
 access to block_ip and quarantine_user capabilities.
 
-Security: Uses warrant.authorize() for Tier 2 (PoP) validation.
+Security: Uses Authorizer.authorize() for Tier 2 (PoP) validation.
 This is CRITICAL for the attenuated warrant - the IP constraint (Exact vs Cidr)
 must be checked at the wire level, not in Python if-statements.
 """
@@ -14,6 +14,7 @@ must be checked at the wire level, not in Python if-statements.
 import argparse
 import asyncio
 import sys
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -24,7 +25,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 # Import tools
 from tools import block_ip, quarantine_user
 
-from tenuo import SigningKey, Warrant
+from tenuo import Authorizer, SigningKey, Warrant
 from tenuo.exceptions import AuthorizationError, ConstraintViolation
 
 
@@ -122,7 +123,7 @@ class ResponderService:
         """
         Handle IP blocking request.
 
-        CRITICAL: Uses warrant.authorize() for Tier 2 validation.
+        CRITICAL: Uses Authorizer.authorize() for Tier 2 validation.
         This is where the attenuated constraint (Exact vs Cidr) is enforced!
 
         If warrant has Exact("203.0.113.5"), only that IP can be blocked.
@@ -134,17 +135,18 @@ class ResponderService:
         if not ip:
             raise ValueError("Missing required parameter: ip")
 
-        # TIER 2 AUTHORIZATION: Use warrant.authorize() with PoP signature
+        # TIER 2 AUTHORIZATION: Use Authorizer.authorize() with a PoP signature.
         # This is the SECURITY BOUNDARY - constraint checking happens in Rust!
         try:
-            pop_signature = self.signing_key.sign(
-                f"block_ip:{ip}:{duration}".encode()
+            args = {"ip": ip, "duration": duration}
+            pop_signature = self.warrant.sign(
+                self.signing_key, "block_ip", args, int(time.time())
             )
-            self.warrant.authorize(
-                tool="block_ip",
-                args={"ip": ip, "duration": duration},
-                signature=pop_signature,
-            )
+            # In production, configure the Authorizer with your control plane's
+            # root public key. For this single-delegation demo the warrant's
+            # issuer is the trusted root.
+            authorizer = Authorizer(trusted_roots=[self.warrant.issuer])
+            authorizer.authorize(self.warrant, "block_ip", args, bytes(pop_signature))
         except Exception as e:
             # Re-raise as AuthorizationError for consistent handling
             raise AuthorizationError(f"Authorization failed: {e}")
@@ -153,14 +155,14 @@ class ResponderService:
         result = block_ip(ip, duration)
 
         # Get warrant ID for audit trail
-        jti = self.warrant.jti
-        jti_str = jti.hex() if hasattr(jti, 'hex') else str(jti)
+        warrant_id = self.warrant.id
+        warrant_id_str = warrant_id.hex() if hasattr(warrant_id, "hex") else str(warrant_id)
 
         return {
             "success": True,
             "data": result,
-            "warrant_jti": jti_str,
-            "authorized_by": "warrant.authorize()",  # Proof of Tier 2
+            "warrant_id": warrant_id_str,
+            "authorized_by": "Authorizer.authorize()",  # Proof of Tier 2
         }
 
     async def _handle_quarantine_user(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -172,28 +174,26 @@ class ResponderService:
 
         # TIER 2 AUTHORIZATION
         try:
-            pop_signature = self.signing_key.sign(
-                f"quarantine_user:{user_id}".encode()
+            args = {"user_id": user_id}
+            pop_signature = self.warrant.sign(
+                self.signing_key, "quarantine_user", args, int(time.time())
             )
-            self.warrant.authorize(
-                tool="quarantine_user",
-                args={"user_id": user_id},
-                signature=pop_signature,
-            )
+            authorizer = Authorizer(trusted_roots=[self.warrant.issuer])
+            authorizer.authorize(self.warrant, "quarantine_user", args, bytes(pop_signature))
         except Exception as e:
             raise AuthorizationError(f"Authorization failed: {e}")
 
         # Authorized - execute tool
         result = quarantine_user(user_id)
 
-        jti = self.warrant.jti
-        jti_str = jti.hex() if hasattr(jti, 'hex') else str(jti)
+        warrant_id = self.warrant.id
+        warrant_id_str = warrant_id.hex() if hasattr(warrant_id, "hex") else str(warrant_id)
 
         return {
             "success": True,
             "data": result,
-            "warrant_jti": jti_str,
-            "authorized_by": "warrant.authorize()",
+            "warrant_id": warrant_id_str,
+            "authorized_by": "Authorizer.authorize()",
         }
 
     async def start(self):

--- a/tenuo-python/examples/local_llm_demo/protected_tools.py
+++ b/tenuo-python/examples/local_llm_demo/protected_tools.py
@@ -48,8 +48,8 @@ class ProtectedToolWrapper:
 
             # CRYPTOGRAPHIC AUTHORIZATION using Proof-of-Possession
             # warrant.validate() internally:
-            # 1. Signs: pop_sig = warrant.sign(key, tool, args)
-            # 2. Verifies: warrant.authorize(tool, args, pop_sig)
+            # 1. Signs a PoP: pop_sig = warrant.sign(key, tool, args)
+            # 2. Verifies the warrant chain, PoP, and constraints
             result = self.warrant.validate(self.signing_key, tool_name, kwargs)
 
             if not result:

--- a/tenuo-python/examples/local_llm_demo/requirements.txt
+++ b/tenuo-python/examples/local_llm_demo/requirements.txt
@@ -1,4 +1,4 @@
-tenuo>=0.1.0b1
+tenuo>=0.2.3
 lmstudio
 tavily-python
 rich

--- a/tenuo-python/examples/mcp/mcp_integration.py
+++ b/tenuo-python/examples/mcp/mcp_integration.py
@@ -129,17 +129,16 @@ def main():
         # Create PoP signature
         pop_signature = warrant.sign(control_keypair, "filesystem_read", constraints_dict, int(time.time()))
 
-        authorized = warrant.authorize(
-            tool="filesystem_read",
-            args=constraints_dict,  # Use extracted constraints directly (names match warrant)
-            signature=bytes(pop_signature),
+        # Authorizer.authorize() raises on denial (trust, chain, PoP, constraints)
+        authorizer.authorize(
+            warrant,
+            "filesystem_read",
+            constraints_dict,  # Use extracted constraints directly (names match warrant)
+            bytes(pop_signature),
         )
-        if authorized:
-            print("   [OK] Warrant authorization: Allowed")
-        else:
-            print("   [ERR] Warrant authorization: Denied (constraints not satisfied)")
+        print("   [OK] Warrant authorization: Allowed")
     except Exception as e:
-        print(f"   [ERR] Warrant authorization error: {e}")
+        print(f"   [ERR] Warrant authorization: Denied ({e})")
 
     # 7. Full authorization with Authorizer (verifies signature + constraints)
     print("\n7. Full authorization with Authorizer.check()...")
@@ -199,12 +198,14 @@ def demo_without_config(control_keypair):
     # Authorize
     try:
         pop_sig = warrant.sign(control_keypair, "filesystem_read", extracted_constraints, int(time.time()))
-        authorized = warrant.authorize("filesystem_read", extracted_constraints, bytes(pop_sig))
-        print(f"\n✓ Warrant authorization: {authorized}")
 
-        # Full authorization with Authorizer
         public_key = control_keypair.public_key
         authorizer = Authorizer(trusted_roots=[public_key])
+
+        # Authorizer.authorize() raises on denial (signature + constraints)
+        authorizer.authorize(warrant, "filesystem_read", extracted_constraints, bytes(pop_sig))
+        print("\n✓ Warrant authorization: Allowed")
+
         try:
             authorizer.check(warrant, "filesystem_read", extracted_constraints, bytes(pop_sig))
             print("✓ Full authorization (Authorizer.check): Success")

--- a/tenuo-python/examples/trust_cliff_demo.py
+++ b/tenuo-python/examples/trust_cliff_demo.py
@@ -16,6 +16,7 @@ Run:
 import time
 
 from tenuo import (
+    Authorizer,
     Pattern,
     Range,
     SigningKey,
@@ -30,6 +31,18 @@ def main():
     print("=" * 70)
 
     key = SigningKey.generate()
+
+    # Authorizer performs full verification (trust, chain, PoP, constraints).
+    # It raises on denial, so wrap it in a boolean helper for this demo.
+    authorizer = Authorizer()
+    authorizer.add_trusted_root(key.public_key)
+
+    def authorize(warrant, tool, args, pop):
+        try:
+            authorizer.authorize(warrant, tool, args, bytes(pop))
+            return True
+        except Exception:
+            return False
 
     # =========================================================================
     # 1. No Constraints = OPEN (any arguments allowed)
@@ -48,7 +61,7 @@ def main():
     # Create PoP and authorize
     args = {"url": "https://any.com", "timeout": 999, "retries": 100}
     pop = open_warrant.sign(key, "api_call", args, int(time.time()))
-    result = open_warrant.authorize("api_call", args, bytes(pop))
+    result = authorize(open_warrant, "api_call", args, pop)
     if result:
         print("   ✅ ALLOWED: url=https://any.com, timeout=999, retries=100")
         print("   ℹ️  No constraints = all arguments pass through")
@@ -72,7 +85,7 @@ def main():
     # Try with unknown field 'timeout' - should be BLOCKED
     args = {"url": "https://api.example.com/v1", "timeout": 30}
     pop = closed_warrant.sign(key, "api_call", args, int(time.time()))
-    result = closed_warrant.authorize("api_call", args, bytes(pop))
+    result = authorize(closed_warrant, "api_call", args, pop)
     if not result:
         # Get detailed reason
         reason = closed_warrant.check_constraints("api_call", args)
@@ -104,7 +117,7 @@ def main():
 
     args = {"url": "https://api.example.com/v1", "timeout": 30, "retries": 5}
     pop = permissive_warrant.sign(key, "api_call", args, int(time.time()))
-    result = permissive_warrant.authorize("api_call", args, bytes(pop))
+    result = authorize(permissive_warrant, "api_call", args, pop)
     if result:
         print("   ✅ ALLOWED: url, timeout=30, retries=5")
         print("   ℹ️  _allow_unknown: True → unknown fields pass through")
@@ -133,7 +146,7 @@ def main():
     # All fields constrained (even if Wildcard) → allowed
     args = {"url": "https://api.example.com/v1", "timeout": 9999, "retries": 2}
     pop = selective_warrant.sign(key, "api_call", args, int(time.time()))
-    result = selective_warrant.authorize("api_call", args, bytes(pop))
+    result = authorize(selective_warrant, "api_call", args, pop)
     if result:
         print("   ✅ ALLOWED: timeout=9999, retries=2")
         print("   ℹ️  timeout=Wildcard() allows any value")
@@ -144,7 +157,7 @@ def main():
     # Try with retries too high
     args_bad = {"url": "https://api.example.com/v1", "timeout": 30, "retries": 10}
     pop_bad = selective_warrant.sign(key, "api_call", args_bad, int(time.time()))
-    result_bad = selective_warrant.authorize("api_call", args_bad, bytes(pop_bad))
+    result_bad = authorize(selective_warrant, "api_call", args_bad, pop_bad)
     if not result_bad:
         print("   ❌ BLOCKED: retries=10 exceeds Range.max_value(3)")
         print("   ℹ️  Wildcard on 'timeout' doesn't affect 'retries' constraint")
@@ -154,7 +167,7 @@ def main():
     # Try with unknown field - should be blocked even though others have Wildcard
     args_unknown = {"url": "https://api.example.com/v1", "timeout": 30, "retries": 2, "unknown_field": True}
     pop_unknown = selective_warrant.sign(key, "api_call", args_unknown, int(time.time()))
-    result_unknown = selective_warrant.authorize("api_call", args_unknown, bytes(pop_unknown))
+    result_unknown = authorize(selective_warrant, "api_call", args_unknown, pop_unknown)
     if not result_unknown:
         print("   ❌ BLOCKED: 'unknown_field' not in constraint set")
         print("   ℹ️  Wildcard() for specific fields doesn't open everything")
@@ -197,7 +210,7 @@ def main():
     # Child will block unknown fields even though parent allowed them
     args = {"url": "https://api.example.com/v1", "timeout": 30}
     pop = child.sign(key, "api_call", args, int(time.time()))
-    result = child.authorize("api_call", args, bytes(pop))
+    result = authorize(child, "api_call", args, pop)
     if not result:
         reason = child.check_constraints("api_call", args)
         print(f"   ❌ BLOCKED: {reason}")

--- a/tenuo-python/pyproject.toml
+++ b/tenuo-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tenuo"
-version = "0.2.0"
+version = "0.2.3"
 description = "Capability tokens for AI agents - Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -84,6 +84,12 @@ temporal = [
 fastapi = [
     "fastapi>=0.100.0",
     "uvicorn>=0.20.0",  # ASGI server for FastAPI
+]
+cloud = [
+    # Proprietary SDK for connecting to Tenuo Cloud. Published separately;
+    # intentionally excluded from the `dev` extra so open-source installs / CI
+    # do not require access to the proprietary package.
+    "tenuo-cloud>=0.2,<0.3",
 ]
 
 # Development dependencies (includes features + tools)

--- a/tenuo-python/tenuo/__init__.py
+++ b/tenuo-python/tenuo/__init__.py
@@ -377,4 +377,4 @@ __all__ = [
     "get_default_nonce_store",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.3"

--- a/tenuo-wasm/Cargo.lock
+++ b/tenuo-wasm/Cargo.lock
@@ -1404,7 +1404,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tenuo"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "base64",
  "cel-interpreter",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-wasm"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "base64",
  "chrono",

--- a/tenuo-wasm/Cargo.toml
+++ b/tenuo-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-wasm"
-version = "0.2.0"
+version = "0.2.3"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "WASM bindings for Tenuo"


### PR DESCRIPTION
## Summary

Prepares the **v0.2.3** release (everything since `v0.2.0` — git tags `v0.2.1`/`v0.2.2` were never released from `main` and are superseded).

### Version
- Bumped to `0.2.3` consistently: `pyproject.toml`, `tenuo/__init__.py`, and all three Cargo manifests + lockfiles (core, python, wasm) via `cargo update` so `--locked` builds stay valid.

### New `cloud` extra
- Added `tenuo[cloud]` → `tenuo-cloud>=0.2,<0.3` (proprietary control-plane SDK). Deliberately **excluded from the `dev` aggregate** so open-source installs / CI don't require the proprietary package. Documented in the root README, `tenuo-python/README.md`, and `docs/quickstart.md`.

### CHANGELOG
- Added a full `[0.2.3]` entry (Added / Changed / Fixed / Security) covering the `InsufficientApprovals` distinct-signal series (#466, #484), the Unix domain socket authorizer mode (#463/#465), fail-closed malformed-approval handling, and the quinn-proto RUSTSEC-2026-0185 bump (#464).

### Documentation (from a multi-agent doc audit)
- **Fixed ~12 broken internal links/anchors** across mcp, a2a, langgraph, fastapi, approvals, api-reference, autogen, crewai, eu-act — each target heading verified.
- **Corrected the A2A wire-code table**: `-32001` has no canonical wire code (was wrongly mapped to `1202`, which is malformed-cbor).
- **Bumped stale version strings** (docker image tags, Rust crate snippet, sample outputs, `local_llm_demo/requirements.txt`) to 0.2.3.
- Reconciled extras listings; `crewai` install uses the `tenuo[crewai]` extra; de-committed the README "Coming v0.2" Node.js row; added a Temporal malformed-header (`invalid_approval`) ops note.

### Examples
- Replaced the **removed `warrant.authorize()` / `warrant.jti`** API with `Authorizer.authorize()` + proper `warrant.sign()` PoP in `trust_cliff_demo.py`, `mcp/mcp_integration.py`, `agentql/benchmark.py`, and the two `google_adk_a2a_incident` services (also fixed their raw-string PoP bug).

## Test plan
- [x] `trust_cliff_demo.py`, `mcp/mcp_integration.py`, and `agentql/benchmark.py` run clean (verified locally).
- [x] `analyst_service.py` / `responder_service.py` / `demo_distributed.py` `py_compile` cleanly; the auth pattern (`Authorizer(trusted_roots=[warrant.issuer]).authorize(...)`) verified in isolation. Full multi-service demo run needs `google-adk` + orchestration (not run here).
- [ ] CI green

## Notes for the releaser
- Orphaned tags `v0.2.1` / `v0.2.2` (not on `main`) should be deleted to avoid confusion.
- The release publishes on GitHub Release `published` (`release.yml`) → PyPI + crates.io + multi-arch Docker.