### PR TITLE
docs: document authorizer Unix domain socket serving mode

### DIFF
--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -95,6 +95,37 @@ spec:
       # Only accepts traffic from localhost (sidecar)
 ```
 
+#### Serving over a Unix domain socket
+
+When the agent and the authorizer share a pod or host, the sidecar can serve the
+**same HTTP API over a Unix domain socket** instead of a localhost TCP port. This
+keeps authorization traffic off the network stack entirely and lets you gate access
+with filesystem permissions.
+
+```bash
+tenuo-authorizer serve \
+  --config /etc/tenuo/authorizer.yaml \
+  --socket /var/run/tenuo/authorizer.sock \
+  --socket-mode 0660 \
+  --socket-group tenuo
+```
+
+- `--socket PATH` — serve over `AF_UNIX` at `PATH`. Mutually exclusive with `--port` / `--bind` (the CLI rejects combining them).
+- `--socket-mode` — octal bits controlling who may *connect* (default `0660` = owner + group). Use `0600` for owner-only or `0666` for any local user.
+- `--socket-group` — group name or numeric gid the socket is `chgrp`'d to after bind. With the default `0660`, this lets a **non-root client** (e.g. an app user in a shared `tenuo` group) reach an authorizer running as root.
+
+Clients connect with any HTTP-over-UDS client, e.g.:
+
+```bash
+curl --unix-socket /var/run/tenuo/authorizer.sock http://localhost/health
+```
+
+**Security:** the socket's trust rests on its *parent directory*. The authorizer
+refuses to bind if that directory is group- or world-writable, refuses a symlink or
+non-socket file at the path, and removes a stale socket left by a previous crash.
+Place the socket in a directory only the authorizer's own user can write to (for
+example `/var/run/tenuo`).
+
 ### Gateway: Centralized Enforcement for Multiple Services
 
 One Tenuo instance protects many backend services. Plugs into existing service mesh infrastructure via Envoy's `ext_authz` gRPC protocol. No new proxy to deploy if you already run Envoy or Istio.

--- a/tenuo-core/src/bin/authorizer.rs
+++ b/tenuo-core/src/bin/authorizer.rs
@@ -825,8 +825,9 @@ async fn serve_http(
 /// because connecting to (and creating/replacing) the socket requires write
 /// access to that directory, a directory that no untrusted user can write to is
 /// what lets a client authenticate the responder by ownership instead of a
-/// shared secret (see `_safe_managed_socket` on the client side). This function
-/// enforces that invariant on the server and refuses path-confusion tricks:
+/// shared secret: a client trusts the responder because the socket lives in a
+/// directory only a trusted user can write to. This function enforces that
+/// invariant on the server and refuses path-confusion tricks:
 ///
 /// - The parent directory must exist (created if missing) and must NOT be
 ///   group- or world-writable. We refuse otherwise — a writable directory would


### PR DESCRIPTION
## Summary
Follow-up to the v0.2.3 `--socket` authorizer feature (#463/#465), which shipped without user-facing documentation.

- **docs/enforcement.md**: adds a *"Serving over a Unix domain socket"* subsection under the Sidecar deployment model — the `--socket` / `--socket-mode` / `--socket-group` flags, a run example, how a client connects (`curl --unix-socket`), and the parent-directory trust/security model (refuses group/world-writable dirs, symlinks, and non-socket files; removes stale sockets).
- **tenuo-core/src/bin/authorizer.rs**: removes the dangling `_safe_managed_socket` reference in the `prepare_unix_socket` doc comment — that helper does not exist in this repo (it belongs to the proprietary Cloud SDK). Replaced with an inline description of the directory-ownership trust model.

## Context
During v0.2.3 release verification the socket feature was confirmed complete, secure, and well-tested, but had zero user docs. This closes that gap. Docs-only + one comment change; no behavior change.

## Test plan
- [x] Markdown fences balanced; flags/defaults verified against `authorizer.rs` (default mode `0660`, `conflicts_with_all = [port, bind]`).
- [ ] CI green