### PR TITLE
docs: make top-level README more accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,26 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License"></a>
 </p>
 
-> **Tenuo Cloud: Early Access**
->
-> Managed control plane with revocation, observability, and multi-tenant warrant issuance.
->
-> [Request access →](https://tenuo.ai/early-access.html)
-
 Tenuo is cryptographic authorization infrastructure for AI agents. A useful mental model is a prepaid card instead of a corporate Amex: scoped capability tokens that expire with the task.
 
-A **warrant** is a signed token specifying which tools an agent can call, under what constraints, and for how long. It is bound to a cryptographic key, and the caller must prove possession of that key (PoP). Verification is offline (under 50 μs), and delegation attenuates monotonically: authority can narrow but not expand. If an agent is prompt-injected, execution is still limited by warrant constraints.
+Agents stay flexible without turning security into prompt engineering: they can still read across systems, call tools, and delegate work, while sensitive actions remain bounded by deterministic checks at runtime.
 
-Tenuo is designed for teams running tool-calling and multi-agent workflows where authorization must hold at runtime, not just at session start.
+The token is called a **warrant**: a signed grant of which tools an agent can call, under what constraints, and for how long.
+
+- **Holder-bound**: a warrant is tied to a cryptographic key, and the caller must prove possession of it (PoP). A stolen warrant is useless without the key.
+- **Verified offline**: checks run in under 50 μs, with no network calls.
+- **Attenuates monotonically**: delegated authority can narrow but never expand.
+- **Holds under prompt injection**: even a hijacked agent is still limited by its warrant's constraints.
+
+Tenuo is designed for teams running tool-calling and multi-agent workflows where authorization must hold at runtime, not just at session start. For sensitive actions, warrants can also require signed human approvals before execution. See the [approvals guide](./docs/approvals.md).
 
 It can be deployed in-process or at boundary enforcement points (sidecar/gateway), with the same warrant semantics and enforcement behavior.
 
 > **Status: v0.2 - Production/Stable.** Core semantics are stable. See [CHANGELOG](./CHANGELOG.md).
+>
+> **Tenuo Cloud: Early Access.** Managed control plane with revocation, observability, and multi-tenant warrant issuance. [Request access →](https://tenuo.ai/early-access.html)
+
+## Install
 
 ```bash
 # Using uv (recommended)
@@ -38,6 +43,8 @@ uv pip install tenuo
 # Or standard pip
 pip install tenuo
 ```
+
+Or try it without installing:
 
 <a href="https://colab.research.google.com/github/tenuo-ai/tenuo/blob/main/notebooks/tenuo_demo.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a>
 <a href="https://tenuo.ai/explorer/"><img src="https://img.shields.io/badge/Explorer-decode_warrants-1a1a1a" alt="Explorer"></a>
@@ -74,18 +81,11 @@ Even if the agent is prompt-injected, enforcement still happens at the tool boun
 
 When the `mint_sync` block exits, the warrant expires naturally. No manual cleanup or revocation flow is required.
 
-30-second architecture:
-
-1. **Issuer** mints a root warrant for a task.
-2. **Delegator** attenuates scope for downstream agents/tools.
-3. **Authorizer** verifies warrant + PoP at the tool-call boundary.
-4. **Signed receipt** records the authorization decision and execution context.
-
 ---
 
 ## Why Tenuo?
 
-IAM answers "who are you?" Tenuo adds "what can this workload do right now for this task?" That gives teams a deterministic authorization boundary at agent speed.
+IAM answers "who are you?" Tenuo adds "what can this workload do right now for this task?" That gives teams a deterministic authorization boundary at agent speed, without reducing useful agents to a static menu of pre-baked behaviors.
 
 | Failure mode in agent systems | Tenuo strength | Practical outcome |
 |------------------------------|----------------|-------------------|
@@ -141,7 +141,7 @@ Tenuo implements **Subtractive Delegation**: each step in the chain can only red
 
 ## Integrations
 
-**OpenAI**: Tool-call enforcement with streaming TOCTOU protection
+**OpenAI**: Tool-call enforcement with streaming TOCTOU (time-of-check/time-of-use) protection
 ```python
 from tenuo.openai import GuardBuilder, Subpath, UrlSafe, Range, Pattern
 
@@ -359,7 +359,7 @@ Self-hosted Tenuo is free forever. The core library and sidecar run entirely in 
 
 See [Security Model](https://tenuo.ai/security) for the full threat model and production hardening guidance.
 
-**[Tenuo Cloud](https://tenuo.ai/early-access.html)** adds managed warrant issuance, key rotation, revocation (SRL), observability dashboards, and multi-tenant isolation for teams that prefer a hosted control plane.
+**[Tenuo Cloud](https://tenuo.ai/early-access.html)** adds managed warrant issuance, key rotation, revocation via signed revocation lists (SRL), observability dashboards, and multi-tenant isolation for teams that prefer a hosted control plane.
 
 ---
 

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/tenuo-core/src/bin/generate_test_vectors.rs
+++ b/tenuo-core/src/bin/generate_test_vectors.rs
@@ -3096,13 +3096,13 @@ fn print_complete_envelope(warrant: &Warrant) {
         warrant.payload_bytes().len(),
         warrant.payload_bytes().len()
     );
-    println!("      {}...", &hex::encode(&warrant.payload_bytes()[..16]));
+    println!("      {}...", hex::encode(&warrant.payload_bytes()[..16]));
     println!("   82                       # signature array(2)");
     println!("      01                    # algorithm = Ed25519");
     println!("      58 40                 # signature bytes (64)");
     println!(
         "         {}...",
-        &hex::encode(&warrant.signature().to_bytes()[..16])
+        hex::encode(&warrant.signature().to_bytes()[..16])
     );
     println!("```");
     println!();

--- a/tenuo-core/src/diff.rs
+++ b/tenuo-core/src/diff.rs
@@ -254,10 +254,7 @@ impl DelegationDiff {
         ));
 
         let child_id = self.child_warrant_id.as_deref().unwrap_or("(pending)");
-        let header = format!(
-            "  Parent: {} → Child: {}",
-            self.parent_warrant_id, child_id
-        );
+        let header = format!("  Parent: {} → Child: {}", self.parent_warrant_id, child_id);
         let padding = width.saturating_sub(header.len());
         lines.push(format!("║{}{:padding$}║", header, "", padding = padding));
 

--- a/tenuo-core/src/diff.rs
+++ b/tenuo-core/src/diff.rs
@@ -256,7 +256,7 @@ impl DelegationDiff {
         let child_id = self.child_warrant_id.as_deref().unwrap_or("(pending)");
         let header = format!(
             "  Parent: {} → Child: {}",
-            &self.parent_warrant_id, child_id
+            self.parent_warrant_id, child_id
         );
         let padding = width.saturating_sub(header.len());
         lines.push(format!("║{}{:padding$}║", header, "", padding = padding));

--- a/tenuo-python/Cargo.lock
+++ b/tenuo-python/Cargo.lock
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/tenuo-wasm/Cargo.lock
+++ b/tenuo-wasm/Cargo.lock
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- Reworks the README intro: the dense warrant paragraph is now a plain-English definition plus four short bullets (holder binding, offline verification, monotonic attenuation, prompt-injection resilience)
- Moves the Tenuo Cloud early-access callout below the intro so readers learn what Tenuo is before seeing the hosted offering
- Removes the "30-second architecture" list that duplicated the "How It Works" section
- Expands TOCTOU and SRL acronyms on first use, adds an `## Install` heading, and adds a lead-in to the Colab/Explorer/Demo badge row

## CI fixes (unrelated to docs, needed to go green)
- Bumps `crossbeam-epoch` to 0.9.20 in all lockfiles ([RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204), published Jul 6)
- Fixes new `useless_borrows_in_formatting` clippy lint (Rust 1.97) in `diff.rs` and `generate_test_vectors.rs`

## Test plan
- [x] All CI checks green
- [ ] Preview README rendering on GitHub