### PR TITLE
fix(auth): distinguish missing tool denials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **IETF Draft**: Published `draft-niyikiza-oauth-attenuating-agent-tokens-01`.
+- **Distinct missing-tool denial category.** Requests for tools outside a
+  warrant's capabilities now surface as `tool_not_allowed` instead of
+  `constraint_violation` in authorizer audit events and Python enforcement.
+  MCP responses identify these as tool-authorization failures while argument
+  constraint failures retain their existing category and detail.
 
 ## [0.2.3] - 2026-07-02
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -405,7 +405,7 @@ X-Tenuo-Deny-Reason: constraint_violation: path=/etc/passwd not in Pattern(/data
 
 | Reason | Cause | Fix |
 |--------|-------|-----|
-| `tool_not_in_warrant` | Tool not authorized | Issue warrant with correct tools |
+| `tool_not_allowed` | Tool not authorized | Issue warrant with correct tools |
 | `constraint_violation` | Argument out of bounds | Check constraints or widen warrant |
 | `warrant_expired` | TTL passed | Issue new warrant or increase TTL |
 | `missing_pop` | No PoP signature | Ensure keypair is set in context |

--- a/tenuo-core/src/bin/authorizer.rs
+++ b/tenuo-core/src/bin/authorizer.rs
@@ -519,6 +519,12 @@ impl DenyReason {
         self
     }
 
+    fn with_tool_not_allowed(mut self) -> Self {
+        self.reason = "tool_not_allowed".to_string();
+        self.constraint = Some("tool".to_string());
+        self
+    }
+
     fn with_constraint(mut self, name: &str, expected: &str, actual: Value) -> Self {
         self.reason = "constraint_violation".to_string();
         self.constraint = Some(name.to_string());
@@ -1791,6 +1797,9 @@ fn parse_deny_reason(
     let mut deny = DenyReason::new(tool, warrant_id, request_id);
 
     match error {
+        Error::ToolNotAuthorized { .. } => {
+            deny = deny.with_tool_not_allowed();
+        }
         Error::ConstraintNotSatisfied { field, reason } => {
             // Try to extract the actual value from constraints
             let actual = constraints
@@ -1889,6 +1898,36 @@ routes:
     method: ["POST"]
     tool: "deploy"
 "#;
+
+    #[test]
+    fn parse_deny_reason_distinguishes_tool_scope_from_argument_constraint() {
+        let missing_tool = tenuo::Error::ToolNotAuthorized {
+            tool: "delete_file".to_string(),
+        };
+        let deny = parse_deny_reason(
+            &missing_tool,
+            "delete_file",
+            "tnu_wrt_test",
+            "request-1",
+            &HashMap::new(),
+        );
+        assert_eq!(deny.reason, "tool_not_allowed");
+        assert_eq!(deny.constraint.as_deref(), Some("tool"));
+
+        let invalid_argument = tenuo::Error::ConstraintNotSatisfied {
+            field: "path".to_string(),
+            reason: "outside allowed prefix".to_string(),
+        };
+        let deny = parse_deny_reason(
+            &invalid_argument,
+            "read_file",
+            "tnu_wrt_test",
+            "request-2",
+            &HashMap::new(),
+        );
+        assert_eq!(deny.reason, "constraint_violation");
+        assert_eq!(deny.constraint.as_deref(), Some("path"));
+    }
 
     /// Build a minimal test app with the given authorizer and gateway YAML.
     fn build_test_app(authorizer: Authorizer) -> Router {

--- a/tenuo-core/src/error.rs
+++ b/tenuo-core/src/error.rs
@@ -491,6 +491,10 @@ pub enum Error {
     // =========================================================================
     // Constraint Matching Errors (Authorization)
     // =========================================================================
+    /// Requested tool is not present in the warrant's capabilities.
+    #[error("warrant does not authorize tool '{tool}'")]
+    ToolNotAuthorized { tool: String },
+
     /// Constraint does not match the action.
     #[error("constraint not satisfied: {field} - {reason}")]
     ConstraintNotSatisfied { field: String, reason: String },
@@ -706,6 +710,7 @@ impl Error {
             Self::ExactValueMismatch { .. } => ErrorCode::InvalidAttenuation,
 
             // Constraint Matching Errors (Authorization)
+            Self::ToolNotAuthorized { .. } => ErrorCode::ToolNotAuthorized,
             Self::ConstraintNotSatisfied { .. } => ErrorCode::ConstraintViolation,
             Self::InsufficientClearance { .. } => ErrorCode::ToolNotAuthorized,
 
@@ -908,6 +913,21 @@ mod tests {
         assert_eq!(err.code(), ErrorCode::ConstraintViolation);
         assert_eq!(err.name(), "constraint-violation");
 
+        // `tool` is also a valid argument name; only the dedicated variant
+        // represents a missing capability.
+        let err = Error::ConstraintNotSatisfied {
+            field: "tool".into(),
+            reason: "argument value not allowed".into(),
+        };
+        assert_eq!(err.code(), ErrorCode::ConstraintViolation);
+        assert_eq!(err.name(), "constraint-violation");
+
+        let err = Error::ToolNotAuthorized {
+            tool: "delete_file".into(),
+        };
+        assert_eq!(err.code(), ErrorCode::ToolNotAuthorized);
+        assert_eq!(err.name(), "tool-not-authorized");
+
         // Monotonicity violations
         let err = Error::RangeExpanded {
             bound: "max".into(),
@@ -962,6 +982,9 @@ mod tests {
             Error::ConstraintNotSatisfied {
                 field: "a".into(),
                 reason: "b".into(),
+            },
+            Error::ToolNotAuthorized {
+                tool: "missing".into(),
             },
             Error::InvalidPattern("test".into()),
             Error::InvalidRange("test".into()),

--- a/tenuo-core/src/mcp.rs
+++ b/tenuo-core/src/mcp.rs
@@ -362,6 +362,9 @@ pub fn auth_error_to_jsonrpc(error: &crate::error::Error) -> (i32, String) {
     use crate::error::Error;
 
     match error {
+        Error::ToolNotAuthorized { .. } => {
+            (-32001, "Access denied: Tool not authorized".to_string())
+        }
         Error::ConstraintNotSatisfied { field, reason } => (
             -32001,
             format!(
@@ -390,6 +393,27 @@ mod tests {
     use std::collections::HashMap;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_auth_error_distinguishes_tool_scope_from_argument_constraint() {
+        let missing_tool = crate::error::Error::ToolNotAuthorized {
+            tool: "delete_file".to_string(),
+        };
+        let (code, message) = auth_error_to_jsonrpc(&missing_tool);
+        assert_eq!(code, -32001);
+        assert_eq!(message, "Access denied: Tool not authorized");
+
+        let invalid_argument = crate::error::Error::ConstraintNotSatisfied {
+            field: "path".to_string(),
+            reason: "outside allowed prefix".to_string(),
+        };
+        let (code, message) = auth_error_to_jsonrpc(&invalid_argument);
+        assert_eq!(code, -32001);
+        assert_eq!(
+            message,
+            "Access denied: Constraint 'path' not satisfied: outside allowed prefix"
+        );
+    }
 
     #[test]
     fn test_mcp_config_from_file() {

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -148,6 +148,9 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
             ),
 
             // Constraints
+            crate::error::Error::ToolNotAuthorized { tool } => {
+                ("ToolNotAuthorized", PyTuple::new(py, [tool.as_str()]))
+            }
             crate::error::Error::ConstraintNotSatisfied { field, reason } => (
                 "ConstraintViolation",
                 PyTuple::new(py, [field.as_str(), reason.as_str()]),
@@ -4068,6 +4071,10 @@ impl PyWarrant {
 
         match self.inner.check_constraints(tool, &rust_args) {
             Ok(()) => Ok(None),
+            Err(crate::error::Error::ToolNotAuthorized { tool }) => Ok(Some(format!(
+                "Constraint 'tool' not satisfied: warrant does not authorize tool '{}'",
+                tool
+            ))),
             Err(crate::error::Error::ConstraintNotSatisfied { field, reason }) => Ok(Some(
                 format!("Constraint '{}' not satisfied: {}", field, reason),
             )),
@@ -4095,6 +4102,10 @@ impl PyWarrant {
 
         match self.inner.check_constraints(tool, &rust_args) {
             Ok(()) => Ok(None),
+            Err(crate::error::Error::ToolNotAuthorized { tool }) => Ok(Some((
+                "tool".to_string(),
+                format!("warrant does not authorize tool '{}'", tool),
+            ))),
             Err(crate::error::Error::ConstraintNotSatisfied { field, reason }) => {
                 Ok(Some((field, reason)))
             }

--- a/tenuo-core/src/warrant.rs
+++ b/tenuo-core/src/warrant.rs
@@ -1113,9 +1113,8 @@ impl Warrant {
         } else if let Some(c) = self.payload.tools.get("*") {
             c
         } else {
-            return Err(Error::ConstraintNotSatisfied {
-                field: "tool".to_string(),
-                reason: format!("warrant does not authorize tool '{}'", tool),
+            return Err(Error::ToolNotAuthorized {
+                tool: tool.to_string(),
             });
         };
 
@@ -1184,9 +1183,8 @@ impl Warrant {
         } else if let Some(c) = self.payload.tools.get("*") {
             c
         } else {
-            return Err(Error::ConstraintNotSatisfied {
-                field: "tool".to_string(),
-                reason: format!("warrant does not authorize tool '{}'", tool),
+            return Err(Error::ToolNotAuthorized {
+                tool: tool.to_string(),
             });
         };
 
@@ -1210,9 +1208,8 @@ impl Warrant {
         } else if let Some(c) = self.payload.tools.get("*") {
             c
         } else {
-            return Err(Error::ConstraintNotSatisfied {
-                field: "tool".to_string(),
-                reason: format!("warrant does not authorize tool '{}'", tool),
+            return Err(Error::ToolNotAuthorized {
+                tool: tool.to_string(),
             });
         };
 

--- a/tenuo-python/tenuo/_enforcement.py
+++ b/tenuo-python/tenuo/_enforcement.py
@@ -295,6 +295,13 @@ def _constraint_field_from_exception(exc: BaseException) -> Optional[str]:
     return _extract_violated_field(str(exc))
 
 
+def _constraint_field_for_authorization_error(exc: BaseException) -> Optional[str]:
+    """Preserve the synthetic ``tool`` field for capability-scope denials."""
+    if isinstance(exc, ToolNotAuthorized):
+        return "tool"
+    return _constraint_field_from_exception(exc)
+
+
 def _enforcement_result_from_chain_error(
     exc: BaseException,
     tool_name: str,
@@ -334,6 +341,7 @@ def _enforcement_result_from_chain_error(
             tool=tool_name,
             arguments=tool_args,
             denial_reason=str(exc),
+            constraint_violated="tool",
             error_type="tool_not_allowed",
             warrant_id=warrant_id,
         )
@@ -1134,7 +1142,7 @@ def enforce_tool_call(
             tool=tool_name,
             arguments=tool_args,
             denial_reason=str(e),
-            constraint_violated=_constraint_field_from_exception(e),
+            constraint_violated=_constraint_field_for_authorization_error(e),
             error_type=err_type,
             warrant_id=warrant_id,
         )
@@ -1457,7 +1465,7 @@ async def enforce_tool_call_async(
         return EnforcementResult(
             allowed=False, tool=tool_name, arguments=tool_args,
             denial_reason=str(e),
-            constraint_violated=_constraint_field_from_exception(e),
+            constraint_violated=_constraint_field_for_authorization_error(e),
             error_type=err_type, warrant_id=warrant_id,
         )
     except TenuoError as e:

--- a/tenuo-python/tenuo/exceptions.py
+++ b/tenuo-python/tenuo/exceptions.py
@@ -492,7 +492,7 @@ class ToolNotAuthorized(ScopeViolation):
     """Tool is not authorized by the warrant."""
 
     error_code = "tool_not_authorized"
-    rust_variant = "Unauthorized"
+    rust_variant = "ToolNotAuthorized"
 
     def __init__(self, tool: str, authorized_tools: Optional[list[str]] = None, hint: Optional[str] = None):
         details: dict[str, Any] = {"tool": tool}
@@ -1457,4 +1457,3 @@ class AuthorizationDenied(ScopeViolation):
                 lines.append(f"  ✅ {result.name}: OK")
 
         return "\n".join(lines)
-

--- a/tenuo-python/tests/adapters/test_langgraph.py
+++ b/tenuo-python/tests/adapters/test_langgraph.py
@@ -1054,7 +1054,7 @@ class TestPhilosophyAndDesign:
             result = enforce_tool_call("delete_file", {"path": "/"}, bound)
 
         assert not result.allowed
-        assert result.error_type == "constraint_violation"
+        assert result.error_type == "tool_not_allowed"
 
         # Tool not in warrant — expected denial logged at DEBUG on tenuo.enforcement.
         denial_records = [

--- a/tenuo-python/tests/unit/test_enforcement.py
+++ b/tenuo-python/tests/unit/test_enforcement.py
@@ -24,6 +24,7 @@ from tenuo._enforcement import (
     EnforcementResult,
     _extract_violated_field,
     enforce_tool_call,
+    enforce_tool_call_async,
     filter_tools_by_warrant,
     handle_denial,
 )
@@ -396,7 +397,20 @@ class TestEnforceToolCall:
         """Unlisted tool should be denied by Rust core."""
         result = enforce_tool_call("delete_file", {}, bound_warrant, trusted_roots=[signing_key.public_key])
         assert result.allowed is False
-        assert "delete_file" in result.denial_reason or result.error_type == "tool_not_allowed"
+        assert result.error_type == "tool_not_allowed"
+
+    @pytest.mark.asyncio
+    async def test_unlisted_tool_denied_by_rust_core_async(self, bound_warrant, signing_key):
+        """Async enforcement should expose the same missing-tool category."""
+        result = await enforce_tool_call_async(
+            "delete_file",
+            {},
+            bound_warrant,
+            trusted_roots=[signing_key.public_key],
+        )
+        assert result.allowed is False
+        assert result.error_type == "tool_not_allowed"
+        assert result.constraint_violated == "tool"
 
     def test_application_allowlist_restricts_tools(self, bound_warrant):
         """Application allowed_tools should restrict beyond warrant."""
@@ -477,7 +491,32 @@ class TestEnforceToolCall:
             trusted_roots=[signing_key.public_key],
         )
         assert result.allowed is False
-        # Should capture constraint violation details
+        assert result.error_type == "constraint_violation"
+        assert result.constraint_violated == "path"
+
+    def test_constraint_named_tool_remains_constraint_violation(self, signing_key):
+        """An argument named tool must not be confused with capability scope."""
+        from tenuo import Exact
+
+        warrant = (
+            Warrant.mint_builder()
+            .capability("dispatch", constraints={"tool": Exact("safe")})
+            .holder(signing_key.public_key)
+            .ttl(3600)
+            .mint(signing_key)
+        )
+        bound = warrant.bind(signing_key)
+
+        result = enforce_tool_call(
+            "dispatch",
+            {"tool": "unsafe"},
+            bound,
+            trusted_roots=[signing_key.public_key],
+        )
+
+        assert result.allowed is False
+        assert result.error_type == "constraint_violation"
+        assert result.constraint_violated == "tool"
 
     def test_critical_tool_without_constraints_denied(self, signing_key):
         """Critical tools should require relevant constraints."""
@@ -897,5 +936,5 @@ class TestEnforceToolCallWithAuthorizer:
             authorizer=authorizer,
         )
         assert result.allowed is False
-        assert result.error_type == "constraint_violation"
+        assert result.error_type == "tool_not_allowed"
         assert result.constraint_violated == "tool"


### PR DESCRIPTION
## Summary

- add a dedicated core error for tools absent from warrant capabilities
- emit `tool_not_allowed` in authorizer audit events and Python enforcement while preserving `failed_constraint="tool"`
- keep argument constraint failures, including an argument literally named `tool`, categorized as `constraint_violation`
- align MCP denial wording and the Kubernetes denial-reason reference

## Testing

- `cargo clippy --manifest-path tenuo-core/Cargo.toml --all-targets --all-features -- -D warnings`
- focused all-feature Rust tests for canonical error codes, MCP mapping, and authorizer audit mapping
- 6 focused Python enforcement and LangGraph tests, including sync, async, verify-mode, and the `tool` argument regression
- `ruff check` on changed Python paths

The full all-feature Rust suite was attempted locally but the isolated `/tmp` checkout exhausted its disk quota while linking unrelated test binaries; the focused tests and all-feature Clippy completed successfully.

Task: https://nexus.brooksmcmillin.com/task/1686
