### PR TITLE
fix(explorer): import WASM binary with explicit ?url suffix

### DIFF
--- a/tenuo-explorer/src/App.tsx
+++ b/tenuo-explorer/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import init, { decode_warrant, check_access, check_chain_access, create_sample_warrant, create_warrant_from_config, init_panic_hook, decode_pem_chain_wasm } from './wasm/tenuo_wasm'
-import wasmUrl from './wasm/tenuo_wasm_bg.wasm'
+import wasmUrl from './wasm/tenuo_wasm_bg.wasm?url'
 import { cleanInput, truncate, generateId } from './utils';
 import packageJson from '../package.json';
 


### PR DESCRIPTION
## Summary

Unblocks #480 (the explorer build-group bump to Vite 8.1.4). That PR fails `Explorer Build`, and the cause is not the bump itself but an assumption in our own code that stopped holding.

`src/App.tsx` imported the wasm-bindgen binary bare:

```ts
import wasmUrl from './wasm/tenuo_wasm_bg.wasm'
```

and relied on `assetsInclude: ['**/*.wasm']` in `vite.config.ts` to make that resolve to an asset URL, which is what `init(wasmUrl)` needs. As of Vite 8.1, bare `.wasm` imports are routed through WASM ESM integration instead of the asset pipeline, and `assetsInclude` no longer overrides that. The module is then treated as an ES module, so there is no `default` export to bind and the build fails.

The `?url` suffix asks for the asset URL explicitly, which is version-independent and works on the currently pinned Vite as well as 8.1.

## Why the CI error looked different

On #480 the failure reads `[UNRESOLVED_IMPORT] Could not resolve './tenuo_wasm_bg.js' in src/wasm/tenuo_wasm_bg.wasm` — Vite emitted an import for the module specifier in the wasm's own import section. Reproducing locally with a populated `src/wasm/` gives `[MISSING_EXPORT] "default" is not exported by "src/wasm/tenuo_wasm_bg.wasm"` instead. Same root cause, two symptoms depending on whether the sibling `tenuo_wasm_bg.js` resolves.

## Test plan

- [x] `vite build` on Vite 8.0.16 (currently pinned) — passes, `tenuo_wasm_bg.wasm` still emitted to `dist/assets/` at its original name
- [x] `vite build` on Vite 8.1.4 (the version #480 bumps to) — fails before this change, passes after
- [x] `tsc --noEmit` — clean; `?url` is typed as `string` by `vite/client`, which `tsconfig.app.json` already includes
- [x] Confirmed the two `TS6133` unused-variable warnings under `tsconfig.app.json` are pre-existing and unrelated

Once this lands, #480 should be rebased and should go green.