### PR TITLE
ci: bound job runtimes and retry apt so a stalled mirror fails fast

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -1,0 +1,34 @@
+name: apt install
+description: >-
+  Install apt packages, retrying around the mirror stalls that intermittently
+  hang hosted runners.
+
+inputs:
+  packages:
+    description: Space-separated list of packages to install.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        APT_PACKAGES: ${{ inputs.packages }}
+      run: |
+        set -euo pipefail
+
+        # apt applies no deadline of its own, so a stalled mirror hangs until the
+        # job's timeout rather than failing. `timeout` bounds each attempt so a
+        # stall costs seconds and retries instead of the whole job budget.
+        for attempt in 1 2 3; do
+          # shellcheck disable=SC2086  # deliberate word splitting into packages
+          if sudo timeout 120 apt-get update \
+            && sudo timeout 300 apt-get install -y $APT_PACKAGES; then
+            exit 0
+          fi
+          echo "::warning::apt failed to install '$APT_PACKAGES' (attempt $attempt/3)"
+          sleep 15
+        done
+
+        echo "::error::apt could not install '$APT_PACKAGES' after 3 attempts"
+        exit 1

--- a/.github/workflows/authorizer-binaries.yml
+++ b/.github/workflows/authorizer-binaries.yml
@@ -83,9 +83,9 @@ jobs:
 
       - name: Install mold linker (Linux)
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mold clang
+        uses: ./.github/actions/apt-install
+        with:
+          packages: mold clang
 
       - name: Configure mold linker (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
   rust-core:
     name: Rust Core
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
@@ -30,9 +31,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install mold linker
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
+        uses: ./.github/actions/apt-install
+        with:
+          packages: mold
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -100,6 +101,7 @@ jobs:
   python-sdk:
     name: Python ${{ matrix.python-version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -237,6 +239,7 @@ jobs:
   mcp-smoke:
     name: MCP Smoke (FastMCP + SecureMCPClient)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -328,6 +331,7 @@ jobs:
   langchain-compat:
     name: LangChain ${{ matrix.langchain-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -384,6 +388,7 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -416,6 +421,7 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -448,6 +454,7 @@ jobs:
   notebooks-examples:
     name: Notebooks & Examples
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -507,6 +514,7 @@ jobs:
   explorer:
     name: Explorer Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -592,6 +600,7 @@ jobs:
   doc-examples:
     name: Doc Code Examples
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -718,6 +727,7 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -782,6 +792,7 @@ jobs:
   performance:
     name: Performance Regression
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
@@ -789,9 +800,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install mold linker
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
+        uses: ./.github/actions/apt-install
+        with:
+          packages: mold
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -865,6 +876,7 @@ jobs:
   benchmark-validation:
     name: Benchmark Harness Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/integration-compatibility-matrix.yml
+++ b/.github/workflows/integration-compatibility-matrix.yml
@@ -24,6 +24,7 @@ jobs:
   test-compatibility:
     name: ${{ matrix.integration }} @ ${{ matrix.version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   python-security:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     name: Python Red Team Tests
     
     steps:
@@ -60,6 +61,7 @@ jobs:
 
   rust-security:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     name: Rust Red Team Tests
     
     steps:
@@ -80,6 +82,7 @@ jobs:
 
   security-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     name: Dependency Audit
     
     steps:


### PR DESCRIPTION
## What happened

The `Performance Regression` job on `f3bdecc8` (the #502 merge) hung for six hours on step 3 of 10, `Install mold linker`, and was eventually killed by GitHub's default limit. It left `main`'s status indeterminate and held a runner the entire time.

It was not the code. That same job **passed on the identical content** in the #502 branch run, taking 12.5 minutes. I cancelled and re-ran it on `main` and it hung on the same step again, so the stall was reproducible but external — a mirror problem, not ours.

Two things made a transient mirror stall this expensive.

## `apt` has no deadline of its own

`sudo apt-get update` will block indefinitely against an unresponsive mirror. The three copies of the mold install now share a composite action that bounds each attempt with `timeout` and retries up to three times:

```yaml
      - name: Install mold linker
        uses: ./.github/actions/apt-install
        with:
          packages: mold
```

Package selection is deliberately unchanged — no `--no-install-recommends`, no quiet flags — so this PR only changes the wrapping, not what lands on the runner. A stall now costs seconds and retries instead of the job's whole budget.

## Almost nothing set a timeout

Only **2 of 33 jobs** set `timeout-minutes`, despite one of them carrying the comment `# Fail fast if hanging`. The intent existed; it just was not applied.

Every job that gates a pull request now sets one, sized as a generous multiple of the longest duration observed across recent runs rather than guessed:

| Job | Observed max | Budget |
|---|---|---|
| Rust Core | 2 min | 20 |
| Python matrix | 9 min | 25 |
| MCP Smoke | 3 min | 15 |
| LangChain compat | 2 min | 15 |
| Security Audit | 3 min | 15 |
| Docker | no clean sample | 30 |
| Notebooks & Examples | 2 min | 15 |
| Explorer Build | 2 min | 15 |
| Doc Code Examples | no clean sample | 20 |
| Code Coverage | 5 min | 25 |
| Performance Regression | ~13 min | 30 |
| Benchmark Harness Validation | 3 min | 20 |

`security.yml`'s three jobs get 20 each, and `integration-compatibility-matrix.yml`'s `test-compatibility` gets 20 to match its sibling `temporal-compatibility`, which already had it.

No job has exceeded 9 minutes in recent history, so these bounds leave a lot of headroom: a genuine slowdown still passes, a hang fails fast.

## What is deliberately left alone

The 16 remaining jobs without a timeout are release, publish, docker multi-arch, and docs deploy. I have no comparable duration baseline for those, and a bound that is too tight there risks breaking a release — worse than the problem being fixed. Worth a follow-up once someone with release context picks numbers.

## Test plan

- [x] All workflow and action YAML parses
- [x] Action's shell script passes `bash -n`
- [x] `checkout` precedes `apt-install` at all three call sites (local actions are unavailable before checkout)
- [ ] CI green on this PR, which exercises the new action in `Rust Core` and `Performance Regression`