### PR TITLE
feat(temporal): authorize scheduled and async dispatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `create_scheduled_workflow_with_warrant()` and
   `tenuo_complete_async_activity()` are now exported from `tenuo.temporal`.
   Scheduled starts carry real `x-tenuo-*` headers, while async completion
-  fails closed unless the warrant chain is trusted and the configured key
-  resolves to the warrant holder.
+  performs a local preflight that rejects untrusted, malformed, expired, or
+  revoked warrant chains before calling Temporal's completion handle. This
+  helper is not a Temporal enforcement boundary and can be bypassed by callers
+  that invoke the raw completion API directly.
 
 ### Fixed
 
@@ -31,11 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer computes an unused signature or silently completes without validation.
   Temporal's async-completion RPC has no user-header field, so the previous
   signature never left the process and could not be checked downstream.
+- **Root expiry and Python revocation enforcement.** `verify_chain()` now checks
+  current-time validity for every warrant, including singleton roots. Python's
+  `Authorizer` now exposes `set_revocation_list()` and accepts an SRL only when
+  its signature is valid and its issuer is an already-configured trusted root;
+  Temporal no longer silently skips SRL enforcement when the binding is absent.
 - **Temporal helper compatibility and failure handling.** Deprecated Schedule
   `workflow_kwargs` continue to be forwarded as action options, and omitted
   async-completion `task_queue` values remain supported when exactly one worker
-  config is registered. Resolver failures are consistently wrapped, delegated
-  completions require an explicit chain, and trusted-root provider failures
+  config is registered. Delegated completions require an explicit chain, and
+  trusted-root provider failures
   retain the last configured root snapshot. Revocation-provider failures retain
   the configured revocation list, and plugin workers now reject a missing task
   queue during setup instead of failing later during completion or minting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Tenuo context. Schedule actions now use Temporal's workflow-header field.
 - **Temporal async completion discarded its best-effort PoP.** The helper no
   longer computes an unused signature or silently completes without validation.
+  Temporal's async-completion RPC has no user-header field, so the previous
+  signature never left the process and could not be checked downstream.
+- **Temporal helper compatibility and failure handling.** Deprecated Schedule
+  `workflow_kwargs` continue to be forwarded as action options, and omitted
+  async-completion `task_queue` values remain supported when exactly one worker
+  config is registered. Resolver failures are consistently wrapped, delegated
+  completions require an explicit chain, and trusted-root provider failures
+  retain the last configured root snapshot.
 
 - **MCP tool-call denials could be read as successes on MCP SDK 2.x.** The SDK
   renamed `CallToolResult.isError` to `is_error`, so `SecureMCPClient`'s error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   async-completion `task_queue` values remain supported when exactly one worker
   config is registered. Resolver failures are consistently wrapped, delegated
   completions require an explicit chain, and trusted-root provider failures
-  retain the last configured root snapshot.
+  retain the last configured root snapshot. Revocation-provider failures retain
+  the configured revocation list, and plugin workers now reject a missing task
+  queue during setup instead of failing later during completion or minting.
 
 - **MCP tool-call denials could be read as successes on MCP SDK 2.x.** The SDK
   renamed `CallToolResult.isError` to `is_error`, so `SecureMCPClient`'s error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Temporal per-Activity warrant overrides.**
+  `tenuo_execute_activity(..., warrant=..., key_id=...)` now applies a
+  task-local warrant to one dispatch, including the active delegation chain.
+  This makes warrants returned by `workflow_grant()` and
+  `workflow_issue_execution()` usable without replacing the workflow's base
+  warrant and without cross-talk between concurrent workflow tasks.
+- **Supported Temporal Schedule and async-completion helpers.**
+  `create_scheduled_workflow_with_warrant()` and
+  `tenuo_complete_async_activity()` are now exported from `tenuo.temporal`.
+  Scheduled starts carry real `x-tenuo-*` headers, while async completion
+  fails closed unless the warrant chain is trusted and the configured key
+  resolves to the warrant holder.
+
 ### Fixed
+
+- **Temporal scheduled warrants were written to memo instead of headers.**
+  Workers never read warrant material from memo, so scheduled workflows had no
+  Tenuo context. Schedule actions now use Temporal's workflow-header field.
+- **Temporal async completion discarded its best-effort PoP.** The helper no
+  longer computes an unused signature or silently completes without validation.
 
 - **MCP tool-call denials could be read as successes on MCP SDK 2.x.** The SDK
   renamed `CallToolResult.isError` to `is_error`, so `SecureMCPClient`'s error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- **Temporal `TenuoPluginConfig` now rejects two previously ignored SRL settings.**
+  `revocation_refresh_secs` without `revocation_list_provider`, and passing both
+  `revocation_list` and `revocation_list_provider`, raise `ConfigurationError`
+  at worker construction. Audit worker configs before upgrade.
+
 ### Added
 
 - **Temporal per-Activity warrant overrides.**
@@ -34,7 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Temporal's async-completion RPC has no user-header field, so the previous
   signature never left the process and could not be checked downstream.
 - **Root expiry and Python revocation enforcement.** `verify_chain()` now checks
-  current-time validity for every warrant, including singleton roots. Python's
+  current-time validity for every warrant, including singleton roots. Archival
+  or offline callers that previously used `verify_chain()` after expiry will
+  now receive `WarrantExpired`. Python's
   `Authorizer` now exposes `set_revocation_list()` and accepts an SRL only when
   its signature is valid and its issuer is an already-configured trusted root;
   Temporal no longer silently skips SRL enforcement when the binding is absent.
@@ -45,10 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trusted-root provider failures retain the last accepted root snapshot.
   Revocation providers are installed at startup and fail worker construction
   with `ConfigurationError` if the initial provider call fails; later failed
-  SRL refreshes no longer poison the config snapshot. SRL version rollback and
-  same-version replacement are rejected, and plugin workers now reject a
-  missing task queue during setup instead of failing later during completion or
-  minting.
+  SRL refreshes no longer poison the config snapshot. SRL version rollback is
+  rejected; a different revoked-ID set at the same version is rejected as
+  `SRLContentChanged`. Re-signing the same revoked set at the same version is
+  accepted. Plugin workers now reject a missing task queue during setup instead
+  of failing later during completion or minting.
 
 - **MCP tool-call denials could be read as successes on MCP SDK 2.x.** The SDK
   renamed `CallToolResult.isError` to `is_error`, so `SecureMCPClient`'s error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `workflow_kwargs` continue to be forwarded as action options, and omitted
   async-completion `task_queue` values remain supported when exactly one worker
   config is registered. Delegated completions require an explicit chain, and
-  trusted-root provider failures
-  retain the last configured root snapshot. Revocation-provider failures retain
-  the configured revocation list, and plugin workers now reject a missing task
-  queue during setup instead of failing later during completion or minting.
+  trusted-root provider failures retain the last accepted root snapshot.
+  Revocation providers are installed at startup, failed SRL refreshes no longer
+  poison the config snapshot, SRL version rollback is rejected, and plugin
+  workers now reject a missing task queue during setup instead of failing later
+  during completion or minting.
 
 - **MCP tool-call denials could be read as successes on MCP SDK 2.x.** The SDK
   renamed `CallToolResult.isError` to `is_error`, so `SecureMCPClient`'s error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   async-completion `task_queue` values remain supported when exactly one worker
   config is registered. Delegated completions require an explicit chain, and
   trusted-root provider failures retain the last accepted root snapshot.
-  Revocation providers are installed at startup, failed SRL refreshes no longer
-  poison the config snapshot, SRL version rollback is rejected, and plugin
-  workers now reject a missing task queue during setup instead of failing later
-  during completion or minting.
+  Revocation providers are installed at startup and fail worker construction
+  with `ConfigurationError` if the initial provider call fails; later failed
+  SRL refreshes no longer poison the config snapshot. SRL version rollback and
+  same-version replacement are rejected, and plugin workers now reject a
+  missing task queue during setup instead of failing later during completion or
+  minting.
 
 - **MCP tool-call denials could be read as successes on MCP SDK 2.x.** The SDK
   renamed `CallToolResult.isError` to `is_error`, so `SecureMCPClient`'s error

--- a/docs/spec/wire-format-v1.md
+++ b/docs/spec/wire-format-v1.md
@@ -2201,6 +2201,7 @@ pub enum ErrorCode {
     WarrantRevoked = 1800,
     SRLInvalid = 1801,
     SRLVersionRollback = 1802,
+    SRLContentChanged = 1803,
     
     // Size limit errors (1900-1999)
     WarrantTooLarge = 1900,

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -898,6 +898,9 @@ field, so the helper validates locally before releasing the completion:
 - trusted-root chain, signature, linkage, and current-time validation; and
 - configured revocation-list validation.
 
+This is warrant liveness, not capability scope: the helper does not check
+whether the warrant authorizes completing this Activity.
+
 Delegated warrants must include `warrant_chain=[root, ..., leaf]`. Validation is
 performed before this helper calls the completion handle; it never falls back
 to an unverified completion. This is a caller-side preflight, not a Temporal
@@ -908,8 +911,9 @@ worker config with a deprecation warning. Zero or multiple registrations fail
 closed. Provider failures or empty results retain the config's last accepted
 trusted-root snapshot; revocation-provider failures or `None` results likewise
 retain the last accepted signed revocation list. SRL refreshes must be
-monotonic: lower versions are rejected, and a different SRL with the same
-version is rejected so revocations cannot be silently rolled back.
+monotonic: lower versions are rejected, and a different revoked-ID set at the
+same version is rejected. Re-signing the same set at the same version is
+accepted.
 `TenuoTemporalPlugin` validates that the worker has a non-empty task queue
 during worker setup, so the registry cannot be silently left unconfigured.
 

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -593,6 +593,12 @@ Default dedup is **in-memory per process** (`InMemoryPopDedupStore`). For fleet-
 
 Static `trusted_roots` require a restart to pick up new issuer keys. For rotation without restarts, use `trusted_roots_provider` + `trusted_roots_refresh_interval_secs`. During rotation, return overlapping old and new issuer keys. On refresh failure, the worker retains the previous `Authorizer` and logs a warning.
 
+Signed revocation lists loaded through Python Temporal config must be signed by
+one of the configured `trusted_roots`. This matches the one-argument binding
+exposed to Python today; the Rust authorizer has an explicit issuer form for
+deployments that separate warrant-issuing authority from revocation-list
+signing authority.
+
 ### Out of scope
 
 - **Compromised Temporal service**: address with Temporal security, not Tenuo alone.
@@ -901,12 +907,14 @@ For compatibility, callers that omit `task_queue=` may use the sole registered
 worker config with a deprecation warning. Zero or multiple registrations fail
 closed. Provider failures or empty results retain the config's last accepted
 trusted-root snapshot; revocation-provider failures or `None` results likewise
-retain the last accepted signed revocation list. `TenuoTemporalPlugin` validates that the
-worker has a non-empty task queue during worker setup, so the registry cannot be
-silently left unconfigured.
+retain the last accepted signed revocation list. SRL refreshes must be
+monotonic: lower versions are rejected, and a different SRL with the same
+version is rejected so revocations cannot be silently rolled back.
+`TenuoTemporalPlugin` validates that the worker has a non-empty task queue
+during worker setup, so the registry cannot be silently left unconfigured.
 
-An empty, valid signed revocation list is different from `None`: it explicitly
-replaces the prior list and clears its revoked-ID set.
+An empty, valid signed revocation list is different from `None`: at a higher
+version, it explicitly replaces the prior list and clears its revoked-ID set.
 
 Temporal's async-completion RPC cannot carry user headers. Earlier helper code
 computed a PoP signature but discarded it, so no downstream validator could

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -897,7 +897,10 @@ fail-closed; the helper never falls back to an unverified completion.
 For compatibility, callers that omit `task_queue=` may use the sole registered
 worker config with a deprecation warning. Zero or multiple registrations fail
 closed. Provider failures or empty results retain the config's last known-good
-trusted-root snapshot.
+trusted-root snapshot; revocation-provider failures or `None` results likewise
+retain the configured revocation list. `TenuoTemporalPlugin` validates that the
+worker has a non-empty task queue during worker setup, so the registry cannot be
+silently left unconfigured.
 
 Temporal's async-completion RPC cannot carry user headers. Earlier helper code
 computed a PoP signature but discarded it, so no downstream validator could

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -877,6 +877,10 @@ override warrant automatically.
 It never stores warrant material in memo. Because a Schedule action is static,
 the same warrant is used by every trigger; choose a TTL that covers the bounded
 Schedule lifetime or use an issuer warrant plus per-Activity execution warrants.
+Temporal action settings such as `execution_timeout` belong in
+`action_options=`. The legacy `workflow_kwargs=` alias remains temporarily
+supported with a deprecation warning; workflow input remains positional via
+`workflow_args=`.
 
 ### Async Activity Completion
 
@@ -890,6 +894,15 @@ field, so the helper validates locally before releasing the completion:
 
 Delegated warrants must include `warrant_chain=[root, ..., leaf]`. Validation is
 fail-closed; the helper never falls back to an unverified completion.
+For compatibility, callers that omit `task_queue=` may use the sole registered
+worker config with a deprecation warning. Zero or multiple registrations fail
+closed. Provider failures or empty results retain the config's last known-good
+trusted-root snapshot.
+
+Temporal's async-completion RPC cannot carry user headers. Earlier helper code
+computed a PoP signature but discarded it, so no downstream validator could
+observe it. The helper therefore validates locally before releasing completion;
+the original Activity dispatch remains the worker-boundary PoP authorization.
 
 ---
 

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -899,9 +899,9 @@ enforcement boundary: code that directly invokes `AsyncActivityHandle.complete()
 can bypass it.
 For compatibility, callers that omit `task_queue=` may use the sole registered
 worker config with a deprecation warning. Zero or multiple registrations fail
-closed. Provider failures or empty results retain the config's last known-good
+closed. Provider failures or empty results retain the config's last accepted
 trusted-root snapshot; revocation-provider failures or `None` results likewise
-retain the configured revocation list. `TenuoTemporalPlugin` validates that the
+retain the last accepted signed revocation list. `TenuoTemporalPlugin` validates that the
 worker has a non-empty task queue during worker setup, so the registry cannot be
 silently left unconfigured.
 

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -628,7 +628,11 @@ What the TTL **does** bound is how long activities scheduled by that workflow ca
 
 - **Short workflows (< TTL):** mint a warrant whose TTL covers the worst-case workflow duration including retries and timer sleeps.
 - **Long workflows (> a single warrant can safely cover):** treat the warrant like a short-lived session token. Use one of:
-  - `workflow_grant(...)` to mint a narrower per-phase warrant inside the workflow (requires the parent warrant to be an issuer).
+  - `workflow_issue_execution(...)` to mint a short-lived execution warrant
+    from a longer-lived issuer warrant, then pass it to
+    `tenuo_execute_activity(..., warrant=execution_warrant, key_id=...)`.
+  - `workflow_grant(...)` to mint a narrower per-phase delegated warrant, then
+    pass it to the same per-Activity override (requires the parent holder key).
   - `tenuo_execute_child_workflow(...)` to spawn child workflows each with their own freshly-minted warrant.
   - A resolver-side key rotation so `retry_pop_max_windows` extends the PoP window for durable retries (see previous section).
 - **Unbounded workflows:** structure work as a series of child workflows rather than a single long-lived parent so each fresh warrant is scoped to a bounded unit of work.
@@ -849,9 +853,43 @@ file_warrant = await workflow_grant(
     constraints={"path": path},
     ttl_seconds=60,
 )
+
+contents = await tenuo_execute_activity(
+    read_file,
+    args=[path],
+    warrant=file_warrant,
+    key_id=current_key_id(),
+    start_to_close_timeout=timedelta(seconds=30),
+)
 ```
 
 Constraint keys must already exist in the parent warrant.
+
+The per-Activity override is held in a workflow task-local `ContextVar`, so
+parallel workflow tasks cannot consume one another's warrant. When
+`warrant_chain=` is omitted, Tenuo extends the active workflow chain with the
+override warrant automatically.
+
+### Scheduled Workflows
+
+`create_scheduled_workflow_with_warrant(...)` places Tenuo payloads in the
+`ScheduleActionStartWorkflow.headers` field consumed by the worker interceptor.
+It never stores warrant material in memo. Because a Schedule action is static,
+the same warrant is used by every trigger; choose a TTL that covers the bounded
+Schedule lifetime or use an issuer warrant plus per-Activity execution warrants.
+
+### Async Activity Completion
+
+`tenuo_complete_async_activity(...)` completes an Activity whose original
+dispatch was already authorized. Temporal's completion RPC has no user-header
+field, so the helper validates locally before releasing the completion:
+
+- exact task-queue worker-config selection;
+- trusted-root chain, expiry, and configured revocation-list validation; and
+- `key_id` resolution to the leaf warrant's holder key.
+
+Delegated warrants must include `warrant_chain=[root, ..., leaf]`. Validation is
+fail-closed; the helper never falls back to an unverified completion.
 
 ---
 

--- a/docs/temporal-reference.md
+++ b/docs/temporal-reference.md
@@ -889,11 +889,14 @@ dispatch was already authorized. Temporal's completion RPC has no user-header
 field, so the helper validates locally before releasing the completion:
 
 - exact task-queue worker-config selection;
-- trusted-root chain, expiry, and configured revocation-list validation; and
-- `key_id` resolution to the leaf warrant's holder key.
+- trusted-root chain, signature, linkage, and current-time validation; and
+- configured revocation-list validation.
 
 Delegated warrants must include `warrant_chain=[root, ..., leaf]`. Validation is
-fail-closed; the helper never falls back to an unverified completion.
+performed before this helper calls the completion handle; it never falls back
+to an unverified completion. This is a caller-side preflight, not a Temporal
+enforcement boundary: code that directly invokes `AsyncActivityHandle.complete()`
+can bypass it.
 For compatibility, callers that omit `task_queue=` may use the sole registered
 worker config with a deprecation warning. Zero or multiple registrations fail
 closed. Provider failures or empty results retain the config's last known-good
@@ -902,10 +905,14 @@ retain the configured revocation list. `TenuoTemporalPlugin` validates that the
 worker has a non-empty task queue during worker setup, so the registry cannot be
 silently left unconfigured.
 
+An empty, valid signed revocation list is different from `None`: it explicitly
+replaces the prior list and clears its revoked-ID set.
+
 Temporal's async-completion RPC cannot carry user headers. Earlier helper code
 computed a PoP signature but discarded it, so no downstream validator could
-observe it. The helper therefore validates locally before releasing completion;
-the original Activity dispatch remains the worker-boundary PoP authorization.
+observe it. The helper therefore does not resolve or load the holder's private
+key merely to compare its public half. The original Activity dispatch remains
+the worker-boundary PoP authorization.
 
 ---
 

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -163,6 +163,57 @@ await handle.signal(ApprovalWorkflow.approve, decision)
 result = await handle.result()
 ```
 
+### Use a fresh warrant for one Activity
+
+Long-running workflows can keep a longer-lived issuer warrant as their base
+authority while issuing a short-lived execution warrant for a consequential
+dispatch. The override is scoped to this call and is safe when workflow tasks
+schedule Activities concurrently:
+
+```python
+from tenuo.temporal import (
+    current_key_id, tenuo_execute_activity, workflow_issue_execution,
+)
+
+execution_warrant = await workflow_issue_execution(
+    "transfer_funds",
+    constraints={"account": account, "amount": amount},
+    ttl_seconds=60,
+)
+await tenuo_execute_activity(
+    transfer_funds,
+    args=[account, amount],
+    warrant=execution_warrant,
+    key_id=current_key_id(),
+    start_to_close_timeout=timedelta(seconds=30),
+)
+```
+
+### Scheduled workflows
+
+Use `create_scheduled_workflow_with_warrant()` so each scheduled workflow start
+carries Tenuo headers—not warrant material in a memo:
+
+```python
+from tenuo.temporal import create_scheduled_workflow_with_warrant
+
+await create_scheduled_workflow_with_warrant(
+    client,
+    "nightly-report",
+    ReportWorkflow.run,
+    issuer_warrant,
+    "report-agent",
+    schedule_spec,
+    workflow_args=[tenant_id],
+    task_queue="reports",
+)
+```
+
+The Schedule action reuses this warrant on every trigger. Its TTL must cover
+the Schedule lifetime. For unbounded recurring Schedules, use a longer-lived,
+narrowly scoped issuer warrant and mint short-lived per-Activity execution
+warrants as shown above.
+
 ## Capability constraints
 
 Warrants use a **closed-world (zero-trust) model**: every argument the activity receives must be declared in the capability, even if unconstrained. Use `Wildcard()` for arguments that can take any value:

--- a/docs/temporal_partnership.md
+++ b/docs/temporal_partnership.md
@@ -39,7 +39,7 @@ Durability sharpens the problem. An agent loop that pauses on a signal, resumes 
 
 Tenuo addresses this challenge with a task-scoped warrant: a cryptographic authorization layer that operates on top of your worker's existing credentials (service account or OAuth token) and is verified offline at the worker boundary before any Activity runs.
 
-This separate layer bounds a prompt-injected agent's actions, gates high-risk calls on cryptographically signed human approvals, and produces verifiable execution evidence for every protected action.
+This separate layer bounds a prompt-injected agent's actions, gates high-risk calls on cryptographically signed human approvals, and produces an attested receipt for every single action taken.
 
 This is achieved without touching your existing Activity code by leveraging Temporal primitives you already understand: interceptors enforce warrants, signals carry approvals, and event history provides a verifiable audit log.
 
@@ -68,7 +68,7 @@ Verification applies three checks: signature validity, request-hash binding, and
 [done]     workflow complete
 ```
 
-End-of-incident authorization evidence:
+End-of-incident receipt chain:
 
 ```
 incident-warrant
@@ -84,7 +84,7 @@ incident-warrant
 
 That's the audit chain a regulator wants to see.
 
-The warrant is issuer-signed, each dispatch carries the holder's PoP signature, and every elevated action carries the operator's SignedApproval. Together, those artifacts let an auditor verify the authority presented for each protected dispatch. Worker authorization decisions are emitted separately as `TemporalAuditEvent` records.
+The warrant is issuer-signed, each dispatch carries the holder's PoP signature, and every elevated action carries the operator's SignedApproval. Each entry becomes an independently attested cryptographic receipt.
 
 The whole chain verifies offline with just a trusted-root pubkey. Temporal's event history is immutable and replayable, so every decision in the sequence can be reconstructed, not just recalled from logs. Every ALLOWED is provably tied to the provenance of authority.
 
@@ -155,7 +155,7 @@ Every authorized Activity gets a human-readable summary in the Event History:
 Temporal Event History with Tenuo Warrants.
 {: .image-caption}
 
-Authorized Activities receive Tenuo-prefixed summaries, while denials show up as non-retryable `ApplicationError` events with stable error codes `(CHAIN_INVALID, WARRANT_EXPIRED, POP_VERIFICATION_FAILED, CONSTRAINT_VIOLATED)`. Warrant, PoP, and approval material remains in the corresponding Event History headers for forensic verification; operational dashboards can consume the emitted audit events and metrics.
+Approvals are displayed with their cryptographic signatures. Denials show up as non-retryable `ApplicationError` events with stable error codes `(CHAIN_INVALID, WARRANT_EXPIRED, POP_VERIFICATION_FAILED, CONSTRAINT_VIOLATED`). Alerts and dashboards live on the same primitives Temporal users already use.
 
 ## From demo to production
 

--- a/docs/temporal_partnership.md
+++ b/docs/temporal_partnership.md
@@ -39,7 +39,7 @@ Durability sharpens the problem. An agent loop that pauses on a signal, resumes 
 
 Tenuo addresses this challenge with a task-scoped warrant: a cryptographic authorization layer that operates on top of your worker's existing credentials (service account or OAuth token) and is verified offline at the worker boundary before any Activity runs.
 
-This separate layer bounds a prompt-injected agent's actions, gates high-risk calls on cryptographically signed human approvals, and produces an attested receipt for every single action taken.
+This separate layer bounds a prompt-injected agent's actions, gates high-risk calls on cryptographically signed human approvals, and produces verifiable execution evidence for every protected action.
 
 This is achieved without touching your existing Activity code by leveraging Temporal primitives you already understand: interceptors enforce warrants, signals carry approvals, and event history provides a verifiable audit log.
 
@@ -68,7 +68,7 @@ Verification applies three checks: signature validity, request-hash binding, and
 [done]     workflow complete
 ```
 
-End-of-incident receipt chain:
+End-of-incident authorization evidence:
 
 ```
 incident-warrant
@@ -84,7 +84,7 @@ incident-warrant
 
 That's the audit chain a regulator wants to see.
 
-The warrant is issuer-signed, each dispatch carries the holder's PoP signature, and every elevated action carries the operator's SignedApproval. Each entry becomes an independently attested cryptographic receipt.
+The warrant is issuer-signed, each dispatch carries the holder's PoP signature, and every elevated action carries the operator's SignedApproval. Together, those artifacts let an auditor verify the authority presented for each protected dispatch. Worker authorization decisions are emitted separately as `TemporalAuditEvent` records.
 
 The whole chain verifies offline with just a trusted-root pubkey. Temporal's event history is immutable and replayable, so every decision in the sequence can be reconstructed, not just recalled from logs. Every ALLOWED is provably tied to the provenance of authority.
 
@@ -155,7 +155,7 @@ Every authorized Activity gets a human-readable summary in the Event History:
 Temporal Event History with Tenuo Warrants.
 {: .image-caption}
 
-Approvals are displayed with their cryptographic signatures. Denials show up as non-retryable `ApplicationError` events with stable error codes `(CHAIN_INVALID, WARRANT_EXPIRED, POP_VERIFICATION_FAILED, CONSTRAINT_VIOLATED`). Alerts and dashboards live on the same primitives Temporal users already use.
+Authorized Activities receive Tenuo-prefixed summaries, while denials show up as non-retryable `ApplicationError` events with stable error codes `(CHAIN_INVALID, WARRANT_EXPIRED, POP_VERIFICATION_FAILED, CONSTRAINT_VIOLATED)`. Warrant, PoP, and approval material remains in the corresponding Event History headers for forensic verification; operational dashboards can consume the emitted audit events and metrics.
 
 ## From demo to production
 

--- a/tenuo-core/src/error.rs
+++ b/tenuo-core/src/error.rs
@@ -320,6 +320,12 @@ pub enum Error {
     #[error("warrant revoked: {0}")]
     WarrantRevoked(String),
 
+    /// Signed revocation list version moved backwards.
+    #[error(
+        "SRL version rollback detected: current version {current}, attempted version {attempted}"
+    )]
+    SRLVersionRollback { current: u64, attempted: u64 },
+
     /// Warrant has expired.
     #[error("warrant '{warrant_id}' expired at {expired_at}")]
     WarrantExpired {
@@ -668,6 +674,7 @@ impl Error {
 
             // Warrant Lifecycle Errors
             Self::WarrantRevoked(_) => ErrorCode::WarrantRevoked,
+            Self::SRLVersionRollback { .. } => ErrorCode::SRLVersionRollback,
             Self::WarrantExpired { .. } => ErrorCode::WarrantExpired,
             Self::IssuedInFuture => ErrorCode::IssuedInFuture,
             Self::DepthExceeded(_, _) => ErrorCode::DepthExceeded,

--- a/tenuo-core/src/error.rs
+++ b/tenuo-core/src/error.rs
@@ -89,6 +89,7 @@ pub enum ErrorCode {
     WarrantRevoked = 1800,
     SRLInvalid = 1801,
     SRLVersionRollback = 1802,
+    SRLContentChanged = 1803,
 
     // Size limit errors (1900-1999)
     WarrantTooLarge = 1900,
@@ -176,6 +177,7 @@ impl ErrorCode {
             Self::WarrantRevoked => "warrant-revoked",
             Self::SRLInvalid => "srl-invalid",
             Self::SRLVersionRollback => "srl-version-rollback",
+            Self::SRLContentChanged => "srl-content-changed",
 
             // Size limit errors
             Self::WarrantTooLarge => "warrant-too-large",
@@ -275,6 +277,7 @@ impl ErrorCode {
             Self::WarrantRevoked => "Warrant has been revoked",
             Self::SRLInvalid => "Signature Revocation List is invalid",
             Self::SRLVersionRollback => "SRL version rollback detected",
+            Self::SRLContentChanged => "SRL revoked set changed at the same version",
 
             // Size limit errors
             Self::WarrantTooLarge => "Warrant size exceeds limit",
@@ -325,6 +328,12 @@ pub enum Error {
         "SRL version rollback detected: current version {current}, attempted version {attempted}"
     )]
     SRLVersionRollback { current: u64, attempted: u64 },
+
+    /// Same SRL version, but the revoked-ID set changed.
+    #[error(
+        "SRL revoked set changed at version {version}; bump the version when the revoked set changes"
+    )]
+    SRLContentChanged { version: u64 },
 
     /// Warrant has expired.
     #[error("warrant '{warrant_id}' expired at {expired_at}")]
@@ -675,6 +684,7 @@ impl Error {
             // Warrant Lifecycle Errors
             Self::WarrantRevoked(_) => ErrorCode::WarrantRevoked,
             Self::SRLVersionRollback { .. } => ErrorCode::SRLVersionRollback,
+            Self::SRLContentChanged { .. } => ErrorCode::SRLContentChanged,
             Self::WarrantExpired { .. } => ErrorCode::WarrantExpired,
             Self::IssuedInFuture => ErrorCode::IssuedInFuture,
             Self::DepthExceeded(_, _) => ErrorCode::DepthExceeded,
@@ -821,6 +831,7 @@ mod tests {
         // Revocation errors
         assert_eq!(ErrorCode::WarrantRevoked.code(), 1800);
         assert_eq!(ErrorCode::SRLVersionRollback.code(), 1802);
+        assert_eq!(ErrorCode::SRLContentChanged.code(), 1803);
 
         // Size limit errors
         assert_eq!(ErrorCode::WarrantTooLarge.code(), 1900);

--- a/tenuo-core/src/planes.rs
+++ b/tenuo-core/src/planes.rs
@@ -882,13 +882,17 @@ impl DataPlane {
             }
         }
 
-        // STRUCTURAL INVARIANT CHECK: Validate each warrant's structural consistency
-        // (version, type constraints, min_approvals, etc.) without clock-based checks.
-        // This catches malformed deserialized warrants that bypass builder-level checks.
-        // Temporal checks (expiry, clock-skew) are omitted here; they are either
-        // handled separately by the chain verifier or intentionally relaxed in
-        // offline/test contexts that use fixed future timestamps.
+        // Validate temporal validity and structural consistency for every
+        // warrant, including a single-element/root chain. Previously expiry
+        // was checked only while walking child links, so an expired root was
+        // accepted despite verify_chain's documented contract.
         for warrant in chain {
+            if warrant.is_expired_with_tolerance(self.clock_tolerance) {
+                return Err(Error::WarrantExpired {
+                    warrant_id: warrant.id().to_string(),
+                    expired_at: warrant.expires_at(),
+                });
+            }
             warrant.validate_structural().map_err(|e| {
                 Error::ChainVerificationFailed(format!(
                     "warrant '{}' failed structural validation: {}",
@@ -1708,6 +1712,24 @@ impl Authorizer {
         Ok(())
     }
 
+    /// Set a signed revocation list only when its issuer is already trusted.
+    ///
+    /// This is the safe one-argument form exposed to language bindings: the
+    /// SRL cannot choose an arbitrary self-asserted verification key because
+    /// its issuer must match one of this Authorizer's configured trust roots.
+    pub fn set_revocation_list_from_trusted_issuer(
+        &mut self,
+        srl: SignedRevocationList,
+    ) -> Result<()> {
+        let issuer = srl.issuer().clone();
+        if !self.trusted_keys.iter().any(|key| key == &issuer) {
+            return Err(Error::SignatureInvalid(
+                "revocation list issuer is not a trusted root".to_string(),
+            ));
+        }
+        self.set_revocation_list(srl, &issuer)
+    }
+
     /// Set the clock tolerance (mutable version).
     pub fn set_clock_tolerance(&mut self, tolerance: chrono::Duration) {
         self.clock_tolerance = tolerance;
@@ -2039,13 +2061,17 @@ impl Authorizer {
             }
         }
 
-        // STRUCTURAL INVARIANT CHECK: Validate each warrant's structural consistency
-        // (version, type constraints, min_approvals, etc.) without clock-based checks.
-        // This catches malformed deserialized warrants that bypass builder-level checks.
-        // Temporal checks (expiry, clock-skew) are omitted here; they are either
-        // handled separately by the chain verifier or intentionally relaxed in
-        // offline/test contexts that use fixed future timestamps.
+        // Validate temporal validity and structural consistency for every
+        // warrant, including a single-element/root chain. Previously expiry
+        // was checked only while walking child links, so an expired root was
+        // accepted despite verify_chain's documented contract.
         for warrant in chain {
+            if warrant.is_expired_with_tolerance(self.clock_tolerance) {
+                return Err(Error::WarrantExpired {
+                    warrant_id: warrant.id().to_string(),
+                    expired_at: warrant.expires_at(),
+                });
+            }
             warrant.validate_structural().map_err(|e| {
                 Error::ChainVerificationFailed(format!(
                     "warrant '{}' failed structural validation: {}",
@@ -2208,14 +2234,6 @@ impl Authorizer {
                 child.expires_at(),
                 parent.expires_at()
             )));
-        }
-
-        // Check expiration with clock tolerance
-        if child.is_expired_with_tolerance(self.clock_tolerance) {
-            return Err(Error::WarrantExpired {
-                warrant_id: child.id().to_string(),
-                expired_at: child.expires_at(),
-            });
         }
 
         // Validate monotonicity based on warrant type
@@ -2958,12 +2976,45 @@ mod tests {
             .build(&control_plane.keypair)
             .unwrap();
         authorizer
-            .set_revocation_list(srl, &control_plane.public_key())
+            .set_revocation_list_from_trusted_issuer(srl)
             .unwrap();
 
         let result = authorizer.verify_chain(&[root, child]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("revoked"));
+    }
+
+    #[test]
+    fn test_authorizer_rejects_expired_single_root_chain() {
+        let control_plane = ControlPlane::generate();
+        let warrant = control_plane
+            .issue_warrant("test", &[], Duration::from_secs(0))
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(1100));
+
+        let authorizer = Authorizer::new()
+            .with_trusted_root(control_plane.public_key())
+            .with_clock_tolerance(chrono::Duration::zero());
+
+        let error = authorizer.verify_chain(&[warrant]).unwrap_err();
+        assert!(matches!(error, Error::WarrantExpired { .. }));
+    }
+
+    #[test]
+    fn test_authorizer_rejects_srl_from_untrusted_issuer() {
+        let control_plane = ControlPlane::generate();
+        let attacker = ControlPlane::generate();
+        let srl = SignedRevocationList::builder()
+            .revoke("tnu_wrt_target")
+            .version(1)
+            .build(&attacker.keypair)
+            .unwrap();
+        let mut authorizer = Authorizer::new().with_trusted_root(control_plane.public_key());
+
+        let error = authorizer
+            .set_revocation_list_from_trusted_issuer(srl)
+            .unwrap_err();
+        assert!(error.to_string().contains("not a trusted root"));
     }
 
     // =========================================================================

--- a/tenuo-core/src/planes.rs
+++ b/tenuo-core/src/planes.rs
@@ -461,6 +461,25 @@ pub const DEFAULT_CLOCK_TOLERANCE_SECS: i64 = 30;
 
 use crate::revocation::SignedRevocationList;
 
+fn ensure_srl_not_replaced_or_rolled_back(
+    current: &SignedRevocationList,
+    attempted: &SignedRevocationList,
+) -> Result<()> {
+    if attempted.version() < current.version() {
+        return Err(Error::SRLVersionRollback {
+            current: current.version(),
+            attempted: attempted.version(),
+        });
+    }
+    if attempted.version() == current.version() && attempted.to_bytes()? != current.to_bytes()? {
+        return Err(Error::SRLVersionRollback {
+            current: current.version(),
+            attempted: attempted.version(),
+        });
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 pub struct DataPlane {
     /// Trusted issuer public keys, keyed by name.
@@ -553,12 +572,7 @@ impl DataPlane {
         // Verify signature
         srl.verify(expected_issuer)?;
         if let Some(current) = &self.revocation_list {
-            if srl.version() < current.version() {
-                return Err(Error::SRLVersionRollback {
-                    current: current.version(),
-                    attempted: srl.version(),
-                });
-            }
+            ensure_srl_not_replaced_or_rolled_back(current, &srl)?;
         }
         self.revocation_list = Some(srl);
         Ok(())
@@ -1717,12 +1731,7 @@ impl Authorizer {
     ) -> Result<()> {
         srl.verify(expected_issuer)?;
         if let Some(current) = &self.revocation_list {
-            if srl.version() < current.version() {
-                return Err(Error::SRLVersionRollback {
-                    current: current.version(),
-                    attempted: srl.version(),
-                });
-            }
+            ensure_srl_not_replaced_or_rolled_back(current, &srl)?;
         }
         self.revocation_list = Some(srl);
         Ok(())
@@ -1739,8 +1748,8 @@ impl Authorizer {
     ) -> Result<()> {
         let issuer = srl.issuer().clone();
         if !self.trusted_keys.iter().any(|key| key == &issuer) {
-            return Err(Error::SignatureInvalid(
-                "revocation list issuer is not a trusted root".to_string(),
+            return Err(Error::ConfigurationError(
+                "revocation list issuer is not a trusted root; configure the SRL signer as a trusted root or use the explicit issuer API".to_string(),
             ));
         }
         self.set_revocation_list(srl, &issuer)
@@ -3030,6 +3039,7 @@ mod tests {
         let error = authorizer
             .set_revocation_list_from_trusted_issuer(srl)
             .unwrap_err();
+        assert!(matches!(error, Error::ConfigurationError(_)));
         assert!(error.to_string().contains("not a trusted root"));
     }
 
@@ -3064,6 +3074,36 @@ mod tests {
     }
 
     #[test]
+    fn test_data_plane_rejects_same_version_srl_replacement() {
+        let control_plane = ControlPlane::generate();
+        let revoked_v2 = SignedRevocationList::builder()
+            .revoke("tnu_wrt_revoked")
+            .version(2)
+            .build(&control_plane.keypair)
+            .unwrap();
+        let empty_v2 = SignedRevocationList::builder()
+            .version(2)
+            .build(&control_plane.keypair)
+            .unwrap();
+        let mut data_plane = DataPlane::new();
+
+        data_plane
+            .set_revocation_list(revoked_v2, &control_plane.public_key())
+            .unwrap();
+        let error = data_plane
+            .set_revocation_list(empty_v2, &control_plane.public_key())
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::SRLVersionRollback {
+                current: 2,
+                attempted: 2
+            }
+        ));
+    }
+
+    #[test]
     fn test_authorizer_rejects_srl_version_rollback() {
         let control_plane = ControlPlane::generate();
         let v2 = SignedRevocationList::builder()
@@ -3089,6 +3129,54 @@ mod tests {
             Error::SRLVersionRollback {
                 current: 2,
                 attempted: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn test_authorizer_allows_idempotent_same_version_srl_refresh() {
+        let control_plane = ControlPlane::generate();
+        let srl = SignedRevocationList::builder()
+            .revoke("tnu_wrt_revoked")
+            .version(2)
+            .build(&control_plane.keypair)
+            .unwrap();
+        let mut authorizer = Authorizer::new().with_trusted_root(control_plane.public_key());
+
+        authorizer
+            .set_revocation_list_from_trusted_issuer(srl.clone())
+            .unwrap();
+        authorizer
+            .set_revocation_list_from_trusted_issuer(srl)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_authorizer_rejects_same_version_srl_replacement() {
+        let control_plane = ControlPlane::generate();
+        let revoked_v2 = SignedRevocationList::builder()
+            .revoke("tnu_wrt_revoked")
+            .version(2)
+            .build(&control_plane.keypair)
+            .unwrap();
+        let empty_v2 = SignedRevocationList::builder()
+            .version(2)
+            .build(&control_plane.keypair)
+            .unwrap();
+        let mut authorizer = Authorizer::new().with_trusted_root(control_plane.public_key());
+
+        authorizer
+            .set_revocation_list_from_trusted_issuer(revoked_v2)
+            .unwrap();
+        let error = authorizer
+            .set_revocation_list_from_trusted_issuer(empty_v2)
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::SRLVersionRollback {
+                current: 2,
+                attempted: 2
             }
         ));
     }

--- a/tenuo-core/src/planes.rs
+++ b/tenuo-core/src/planes.rs
@@ -552,6 +552,14 @@ impl DataPlane {
     ) -> Result<()> {
         // Verify signature
         srl.verify(expected_issuer)?;
+        if let Some(current) = &self.revocation_list {
+            if srl.version() < current.version() {
+                return Err(Error::SRLVersionRollback {
+                    current: current.version(),
+                    attempted: srl.version(),
+                });
+            }
+        }
         self.revocation_list = Some(srl);
         Ok(())
     }
@@ -1708,6 +1716,14 @@ impl Authorizer {
         expected_issuer: &PublicKey,
     ) -> Result<()> {
         srl.verify(expected_issuer)?;
+        if let Some(current) = &self.revocation_list {
+            if srl.version() < current.version() {
+                return Err(Error::SRLVersionRollback {
+                    current: current.version(),
+                    attempted: srl.version(),
+                });
+            }
+        }
         self.revocation_list = Some(srl);
         Ok(())
     }
@@ -3015,6 +3031,66 @@ mod tests {
             .set_revocation_list_from_trusted_issuer(srl)
             .unwrap_err();
         assert!(error.to_string().contains("not a trusted root"));
+    }
+
+    #[test]
+    fn test_data_plane_rejects_srl_version_rollback() {
+        let control_plane = ControlPlane::generate();
+        let v2 = SignedRevocationList::builder()
+            .revoke("tnu_wrt_revoked")
+            .version(2)
+            .build(&control_plane.keypair)
+            .unwrap();
+        let v1 = SignedRevocationList::builder()
+            .version(1)
+            .build(&control_plane.keypair)
+            .unwrap();
+        let mut data_plane = DataPlane::new();
+
+        data_plane
+            .set_revocation_list(v2, &control_plane.public_key())
+            .unwrap();
+        let error = data_plane
+            .set_revocation_list(v1, &control_plane.public_key())
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::SRLVersionRollback {
+                current: 2,
+                attempted: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn test_authorizer_rejects_srl_version_rollback() {
+        let control_plane = ControlPlane::generate();
+        let v2 = SignedRevocationList::builder()
+            .revoke("tnu_wrt_revoked")
+            .version(2)
+            .build(&control_plane.keypair)
+            .unwrap();
+        let v1 = SignedRevocationList::builder()
+            .version(1)
+            .build(&control_plane.keypair)
+            .unwrap();
+        let mut authorizer = Authorizer::new().with_trusted_root(control_plane.public_key());
+
+        authorizer
+            .set_revocation_list_from_trusted_issuer(v2)
+            .unwrap();
+        let error = authorizer
+            .set_revocation_list_from_trusted_issuer(v1)
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::SRLVersionRollback {
+                current: 2,
+                attempted: 1
+            }
+        ));
     }
 
     // =========================================================================

--- a/tenuo-core/src/planes.rs
+++ b/tenuo-core/src/planes.rs
@@ -461,6 +461,10 @@ pub const DEFAULT_CLOCK_TOLERANCE_SECS: i64 = 30;
 
 use crate::revocation::SignedRevocationList;
 
+fn srl_revoked_set(srl: &SignedRevocationList) -> HashSet<&str> {
+    srl.revoked_ids().iter().map(String::as_str).collect()
+}
+
 fn ensure_srl_not_replaced_or_rolled_back(
     current: &SignedRevocationList,
     attempted: &SignedRevocationList,
@@ -471,10 +475,14 @@ fn ensure_srl_not_replaced_or_rolled_back(
             attempted: attempted.version(),
         });
     }
-    if attempted.version() == current.version() && attempted.to_bytes()? != current.to_bytes()? {
-        return Err(Error::SRLVersionRollback {
-            current: current.version(),
-            attempted: attempted.version(),
+    // Version is the anti-rollback sequence number; issued_at/signature may
+    // change on a scheduled re-sign. Only a different revoked-ID set at the
+    // same version is a mutation.
+    if attempted.version() == current.version()
+        && srl_revoked_set(attempted) != srl_revoked_set(current)
+    {
+        return Err(Error::SRLContentChanged {
+            version: current.version(),
         });
     }
     Ok(())
@@ -904,26 +912,6 @@ impl DataPlane {
             }
         }
 
-        // Validate temporal validity and structural consistency for every
-        // warrant, including a single-element/root chain. Previously expiry
-        // was checked only while walking child links, so an expired root was
-        // accepted despite verify_chain's documented contract.
-        for warrant in chain {
-            if warrant.is_expired_with_tolerance(self.clock_tolerance) {
-                return Err(Error::WarrantExpired {
-                    warrant_id: warrant.id().to_string(),
-                    expired_at: warrant.expires_at(),
-                });
-            }
-            warrant.validate_structural().map_err(|e| {
-                Error::ChainVerificationFailed(format!(
-                    "warrant '{}' failed structural validation: {}",
-                    warrant.id(),
-                    e
-                ))
-            })?;
-        }
-
         let mut result = ChainVerificationResult {
             root_issuer: None,
             chain_length: chain.len(),
@@ -953,6 +941,25 @@ impl DataPlane {
             .map(|(w, msg)| (w.issuer(), msg.as_slice(), w.signature()))
             .collect();
         verify_batch_raw(&batch_items)?;
+
+        // Authenticity first, then semantics. Expiry/structural checks cover
+        // every warrant, including a singleton root — they used to run only
+        // while walking child links.
+        for warrant in chain {
+            if warrant.is_expired_with_tolerance(self.clock_tolerance) {
+                return Err(Error::WarrantExpired {
+                    warrant_id: warrant.id().to_string(),
+                    expired_at: warrant.expires_at(),
+                });
+            }
+            warrant.validate_structural().map_err(|e| {
+                Error::ChainVerificationFailed(format!(
+                    "warrant '{}' failed structural validation: {}",
+                    warrant.id(),
+                    e
+                ))
+            })?;
+        }
 
         result.root_issuer = Some(root.issuer().to_bytes());
         result.verified_steps.push(ChainStep {
@@ -2086,26 +2093,6 @@ impl Authorizer {
             }
         }
 
-        // Validate temporal validity and structural consistency for every
-        // warrant, including a single-element/root chain. Previously expiry
-        // was checked only while walking child links, so an expired root was
-        // accepted despite verify_chain's documented contract.
-        for warrant in chain {
-            if warrant.is_expired_with_tolerance(self.clock_tolerance) {
-                return Err(Error::WarrantExpired {
-                    warrant_id: warrant.id().to_string(),
-                    expired_at: warrant.expires_at(),
-                });
-            }
-            warrant.validate_structural().map_err(|e| {
-                Error::ChainVerificationFailed(format!(
-                    "warrant '{}' failed structural validation: {}",
-                    warrant.id(),
-                    e
-                ))
-            })?;
-        }
-
         let root = &chain[0];
         let mut result = ChainVerificationResult {
             root_issuer: None,
@@ -2135,6 +2122,25 @@ impl Authorizer {
             .map(|(w, msg)| (w.issuer(), msg.as_slice(), w.signature()))
             .collect();
         verify_batch_raw(&batch_items)?;
+
+        // Authenticity first, then semantics. Expiry/structural checks cover
+        // every warrant, including a singleton root — they used to run only
+        // while walking child links.
+        for warrant in chain {
+            if warrant.is_expired_with_tolerance(self.clock_tolerance) {
+                return Err(Error::WarrantExpired {
+                    warrant_id: warrant.id().to_string(),
+                    expired_at: warrant.expires_at(),
+                });
+            }
+            warrant.validate_structural().map_err(|e| {
+                Error::ChainVerificationFailed(format!(
+                    "warrant '{}' failed structural validation: {}",
+                    warrant.id(),
+                    e
+                ))
+            })?;
+        }
 
         result.root_issuer = Some(issuer.to_bytes());
         result.verified_steps.push(ChainStep {
@@ -3094,13 +3100,7 @@ mod tests {
             .set_revocation_list(empty_v2, &control_plane.public_key())
             .unwrap_err();
 
-        assert!(matches!(
-            error,
-            Error::SRLVersionRollback {
-                current: 2,
-                attempted: 2
-            }
-        ));
+        assert!(matches!(error, Error::SRLContentChanged { version: 2 }));
     }
 
     #[test]
@@ -3152,6 +3152,30 @@ mod tests {
     }
 
     #[test]
+    fn test_authorizer_allows_resigned_same_version_srl_refresh() {
+        let control_plane = ControlPlane::generate();
+        let first = SignedRevocationList::builder()
+            .revoke("tnu_wrt_revoked")
+            .version(2)
+            .build(&control_plane.keypair)
+            .unwrap();
+        let resigned = SignedRevocationList::builder()
+            .revoke("tnu_wrt_revoked")
+            .version(2)
+            .build(&control_plane.keypair)
+            .unwrap();
+        assert_ne!(first.to_bytes().unwrap(), resigned.to_bytes().unwrap());
+        let mut authorizer = Authorizer::new().with_trusted_root(control_plane.public_key());
+
+        authorizer
+            .set_revocation_list_from_trusted_issuer(first)
+            .unwrap();
+        authorizer
+            .set_revocation_list_from_trusted_issuer(resigned)
+            .unwrap();
+    }
+
+    #[test]
     fn test_authorizer_rejects_same_version_srl_replacement() {
         let control_plane = ControlPlane::generate();
         let revoked_v2 = SignedRevocationList::builder()
@@ -3172,13 +3196,7 @@ mod tests {
             .set_revocation_list_from_trusted_issuer(empty_v2)
             .unwrap_err();
 
-        assert!(matches!(
-            error,
-            Error::SRLVersionRollback {
-                current: 2,
-                attempted: 2
-            }
-        ));
+        assert!(matches!(error, Error::SRLContentChanged { version: 2 }));
     }
 
     // =========================================================================

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -60,6 +60,10 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
             crate::error::Error::WarrantRevoked(id) => {
                 ("RevokedError", PyTuple::new(py, [id.as_str()]))
             }
+            crate::error::Error::SRLVersionRollback { current, attempted } => (
+                "SrlVersionRollback",
+                PyTuple::new(py, [*current, *attempted]),
+            ),
             crate::error::Error::WarrantExpired {
                 warrant_id,
                 expired_at,

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -5336,6 +5336,16 @@ impl PyAuthorizer {
         self.inner.add_trusted_root(key.inner.clone());
     }
 
+    /// Install a signed revocation list from an already-trusted root.
+    ///
+    /// The Rust authorizer verifies both that the SRL issuer is in its trust
+    /// roots and that the SRL signature is valid before accepting it.
+    fn set_revocation_list(&mut self, srl: &PySignedRevocationList) -> PyResult<()> {
+        self.inner
+            .set_revocation_list_from_trusted_issuer(srl.inner.clone())
+            .map_err(to_py_err)
+    }
+
     /// Set the clock tolerance for expiration checks.
     ///
     /// Args:

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -64,6 +64,9 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
                 "SrlVersionRollback",
                 PyTuple::new(py, [*current, *attempted]),
             ),
+            crate::error::Error::SRLContentChanged { version } => {
+                ("SrlContentChanged", PyTuple::new(py, [*version]))
+            }
             crate::error::Error::WarrantExpired {
                 warrant_id,
                 expired_at,

--- a/tenuo-python/tenuo/exceptions.py
+++ b/tenuo-python/tenuo/exceptions.py
@@ -127,6 +127,7 @@ __all__ = [
     "PayloadTooLarge",
     # Revocation
     "RevokedError",
+    "SrlVersionRollback",
     # Validation errors
     "ValidationError",
     "MissingField",
@@ -1038,6 +1039,21 @@ class RevokedError(TenuoError):
         super().__init__(f"Warrant '{warrant_id}' has been revoked", details, hint=hint)
 
 
+@wire_code(ErrorCode.SRL_VERSION_ROLLBACK)
+class SrlVersionRollback(TenuoError):
+    """Signed revocation list version moved backwards."""
+
+    error_code = "srl_version_rollback"
+    rust_variant = "SRLVersionRollback"
+
+    def __init__(self, current: int, attempted: int, hint: Optional[str] = None):
+        super().__init__(
+            f"SRL version rollback detected: current version {current}, attempted version {attempted}",
+            {"current": current, "attempted": attempted},
+            hint=hint,
+        )
+
+
 # =============================================================================
 # Validation Errors (field/format validation)
 # =============================================================================
@@ -1457,4 +1473,3 @@ class AuthorizationDenied(ScopeViolation):
                 lines.append(f"  ✅ {result.name}: OK")
 
         return "\n".join(lines)
-

--- a/tenuo-python/tenuo/exceptions.py
+++ b/tenuo-python/tenuo/exceptions.py
@@ -128,6 +128,7 @@ __all__ = [
     # Revocation
     "RevokedError",
     "SrlVersionRollback",
+    "SrlContentChanged",
     # Validation errors
     "ValidationError",
     "MissingField",
@@ -249,6 +250,7 @@ class ErrorCode:
     WARRANT_REVOKED = 1800
     SRL_INVALID = 1801
     SRL_VERSION_ROLLBACK = 1802
+    SRL_CONTENT_CHANGED = 1803
 
     # Size limit errors (1900-1999)
     WARRANT_TOO_LARGE = 1900
@@ -311,6 +313,7 @@ class ErrorCode:
             1800: "warrant-revoked",
             1801: "srl-invalid",
             1802: "srl-version-rollback",
+            1803: "srl-content-changed",
             1900: "warrant-too-large",
             1901: "chain-too-large",
             1902: "too-many-tools",
@@ -1050,6 +1053,21 @@ class SrlVersionRollback(TenuoError):
         super().__init__(
             f"SRL version rollback detected: current version {current}, attempted version {attempted}",
             {"current": current, "attempted": attempted},
+            hint=hint,
+        )
+
+
+@wire_code(ErrorCode.SRL_CONTENT_CHANGED)
+class SrlContentChanged(TenuoError):
+    """Signed revocation list kept its version but changed the revoked set."""
+
+    error_code = "srl_content_changed"
+    rust_variant = "SRLContentChanged"
+
+    def __init__(self, version: int, hint: Optional[str] = None):
+        super().__init__(
+            f"SRL revoked set changed at version {version}; bump the version when the revoked set changes",
+            {"version": version},
             hint=hint,
         )
 

--- a/tenuo-python/tenuo/temporal/README.md
+++ b/tenuo-python/tenuo/temporal/README.md
@@ -32,7 +32,7 @@ Activity definitions require no changes. Authorization is transparent to user wo
 | `_observability.py` | `TemporalAuditEvent`, `TenuoMetrics`. |
 | `_constants.py` | Wire header names and encoding limits. |
 | `exceptions.py` | Public exception taxonomy with stable `error_code` attributes. |
-| `_warrant_source.py` | Internal helpers for warrant construction and chain encoding. |
+| `_warrant_source.py` | Public lazy warrant sources (`Literal`, `Env`, `CloudTrigger`) for workflow starts. |
 
 ## Invariants worth knowing before editing
 
@@ -43,6 +43,9 @@ These are non-obvious from the code alone; each has a corresponding test guard c
 - **Workflow-clock discipline.** All time-based checks inside the sandbox (warrant TTL, PoP time window) use `workflow.now()`. Using wall-clock time would make replay non-deterministic and crash long-running workflows on replay after the original warrant's `expires_at`. _Guard:_ `tests/e2e/test_temporal_replay.py::test_tenuo_plugin_replay_clock_boundary_crossing` (uses `WorkflowEnvironment.start_time_skipping()` to cross a PoP window boundary).
 - **Sandbox passthrough.** `tenuo` and `tenuo_core` must be passthrough modules (the PyO3 core can only initialize once per process). `TenuoTemporalPlugin` handles this; manual setup with a custom `SandboxedWorkflowRunner` must set it explicitly. _Guard:_ `tests/adapters/test_temporal_replay_safety.py::TestPassthroughModules`.
 - **Wire format.** `x-tenuo-warrant` is raw CBOR bytes (not base64, not JSON). `x-tenuo-compressed` is `b"0"` or `b"1"`. PoP (`x-tenuo-pop`) is base64-encoded bytes. _Guards:_ `tests/property/test_temporal_props.py::TestTemporalWireRoundtrip` (Hypothesis-based) and `tests/e2e/test_temporal_e2e.py::TestMalformedWarrantHeadersAtIngress` (adversarial).
+- **Per-Activity overrides are task-local.** `tenuo_execute_activity(warrant=...)`
+  stores override headers in a `ContextVar`, not a run-level "next dispatch"
+  slot, so concurrent workflow tasks cannot consume one another's warrants.
 - **Denial → non-retryable wire type.** Every denial surfaces as `ApplicationError(non_retryable=True, type=<error_code>)` where `error_code` is one of the stable codes in `exceptions.py` (`CHAIN_INVALID`, `WARRANT_EXPIRED`, `POP_VERIFICATION_FAILED`, `CONSTRAINT_VIOLATED`, `LOCAL_ACTIVITY_BLOCKED`, `CONTEXT_MISSING`, etc.). _Guards:_ `tests/adapters/test_temporal.py::TestNonRetryableWrapping`, `tests/e2e/test_temporal_e2e.py::TestChainDepthEnforcement`, `tests/property/test_temporal_props.py::TestWrapAsNonRetryable`.
 
 ## Tests

--- a/tenuo-python/tenuo/temporal/README.md
+++ b/tenuo-python/tenuo/temporal/README.md
@@ -32,7 +32,7 @@ Activity definitions require no changes. Authorization is transparent to user wo
 | `_observability.py` | `TemporalAuditEvent`, `TenuoMetrics`. |
 | `_constants.py` | Wire header names and encoding limits. |
 | `exceptions.py` | Public exception taxonomy with stable `error_code` attributes. |
-| `_warrant_source.py` | Public lazy warrant sources (`Literal`, `Env`, `CloudTrigger`) for workflow starts. |
+| `_warrant_source.py` | Internal helpers for warrant construction and chain encoding. |
 
 ## Invariants worth knowing before editing
 

--- a/tenuo-python/tenuo/temporal/__init__.py
+++ b/tenuo-python/tenuo/temporal/__init__.py
@@ -84,11 +84,6 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     # _client
     "TenuoWarrantContextPropagator": ("tenuo.temporal._client", "TenuoWarrantContextPropagator"),
     "tenuo_warrant_context": ("tenuo.temporal._client", "tenuo_warrant_context"),
-    # _warrant_source
-    "WarrantSource": ("tenuo.temporal._warrant_source", "WarrantSource"),
-    "LiteralWarrantSource": ("tenuo.temporal._warrant_source", "LiteralWarrantSource"),
-    "EnvWarrantSource": ("tenuo.temporal._warrant_source", "EnvWarrantSource"),
-    "CloudTriggerWarrantSource": ("tenuo.temporal._warrant_source", "CloudTriggerWarrantSource"),
     # _decorators
     "tool": ("tenuo.temporal._decorators", "tool"),
     "unprotected": ("tenuo.temporal._decorators", "unprotected"),

--- a/tenuo-python/tenuo/temporal/__init__.py
+++ b/tenuo-python/tenuo/temporal/__init__.py
@@ -75,6 +75,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "workflow_issue_execution": ("tenuo.temporal._workflow", "workflow_issue_execution"),
     "set_activity_approvals": ("tenuo.temporal._workflow", "set_activity_approvals"),
     "tenuo_continue_as_new": ("tenuo.temporal._workflow", "tenuo_continue_as_new"),
+    "create_scheduled_workflow_with_warrant": ("tenuo.temporal._workflow", "create_scheduled_workflow_with_warrant"),
+    "tenuo_complete_async_activity": ("tenuo.temporal._workflow", "tenuo_complete_async_activity"),
     # _state — public escape hatch for manual worker setup
     "register_worker_config": ("tenuo.temporal._state", "register_worker_config"),
     # _workflow — manual-setup helper: Tenuo-owned activities every worker must register
@@ -82,6 +84,11 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     # _client
     "TenuoWarrantContextPropagator": ("tenuo.temporal._client", "TenuoWarrantContextPropagator"),
     "tenuo_warrant_context": ("tenuo.temporal._client", "tenuo_warrant_context"),
+    # _warrant_source
+    "WarrantSource": ("tenuo.temporal._warrant_source", "WarrantSource"),
+    "LiteralWarrantSource": ("tenuo.temporal._warrant_source", "LiteralWarrantSource"),
+    "EnvWarrantSource": ("tenuo.temporal._warrant_source", "EnvWarrantSource"),
+    "CloudTriggerWarrantSource": ("tenuo.temporal._warrant_source", "CloudTriggerWarrantSource"),
     # _decorators
     "tool": ("tenuo.temporal._decorators", "tool"),
     "unprotected": ("tenuo.temporal._decorators", "unprotected"),

--- a/tenuo-python/tenuo/temporal/_config.py
+++ b/tenuo-python/tenuo/temporal/_config.py
@@ -430,14 +430,14 @@ class TenuoPluginConfig:
 
         # Trusted roots are mandatory: explicit list, provider, or global configure().
         if self.trusted_roots_provider is not None:
-            if self.trusted_roots:
+            if self.trusted_roots and not self._provider_snapshots_ready:
                 from tenuo.exceptions import ConfigurationError
                 raise ConfigurationError(
                     "TenuoPluginConfig: pass either trusted_roots= or "
                     "trusted_roots_provider=, not both."
                 )
             if self._provider_snapshots_ready:
-                roots = list(self.trusted_roots)
+                roots = list(self.trusted_roots or [])
             else:
                 roots = list(self.trusted_roots_provider())
         elif self.trusted_roots:

--- a/tenuo-python/tenuo/temporal/_config.py
+++ b/tenuo-python/tenuo/temporal/_config.py
@@ -399,6 +399,9 @@ class TenuoPluginConfig:
     _provider_state_lock: Any = field(
         default_factory=threading.RLock, init=False, repr=False, compare=False
     )
+    _provider_snapshots_ready: bool = field(
+        default=False, init=True, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
         if self.dry_run:
@@ -433,7 +436,10 @@ class TenuoPluginConfig:
                     "TenuoPluginConfig: pass either trusted_roots= or "
                     "trusted_roots_provider=, not both."
                 )
-            roots = list(self.trusted_roots_provider())
+            if self._provider_snapshots_ready:
+                roots = list(self.trusted_roots)
+            else:
+                roots = list(self.trusted_roots_provider())
         elif self.trusted_roots:
             roots = list(self.trusted_roots)
         else:
@@ -447,8 +453,9 @@ class TenuoPluginConfig:
                 "Pass trusted_roots=[control_key.public_key], trusted_roots_provider=..., "
                 "or call tenuo.configure(trusted_roots=[...]) at application startup."
             )
-        self.trusted_roots = roots  # type: ignore[assignment]
-        self._last_good_trusted_roots = list(roots)
+        if not self._provider_snapshots_ready:
+            self.trusted_roots = roots  # type: ignore[assignment]
+            self._last_good_trusted_roots = list(roots)
 
         if self.revocation_list is not None and self.revocation_list_provider is not None:
             from tenuo.exceptions import ConfigurationError
@@ -469,24 +476,26 @@ class TenuoPluginConfig:
                     "revocation_refresh_secs requires revocation_list_provider."
                 )
 
-        if self.revocation_list_provider is not None:
-            try:
-                initial_srl = self.revocation_list_provider()
-            except Exception as exc:
-                from tenuo.exceptions import ConfigurationError
+        if not self._provider_snapshots_ready:
+            if self.revocation_list_provider is not None:
+                try:
+                    initial_srl = self.revocation_list_provider()
+                except Exception as exc:
+                    from tenuo.exceptions import ConfigurationError
 
-                raise ConfigurationError(
-                    "TenuoPluginConfig: revocation_list_provider failed during "
-                    "startup. Provider-backed revocation is installed before the "
-                    "worker accepts work, so the provider must return a valid "
-                    "SignedRevocationList or None at worker construction. Check "
-                    "SRL endpoint availability, credentials, and timeout settings, "
-                    "or pass a static revocation_list for bootstrap."
-                ) from exc
-            if initial_srl is not None:
-                self._last_good_revocation_list = initial_srl
-        else:
-            self._last_good_revocation_list = self.revocation_list
+                    raise ConfigurationError(
+                        "TenuoPluginConfig: revocation_list_provider failed during "
+                        "startup. Provider-backed revocation is installed before the "
+                        "worker accepts work, so the provider must return a valid "
+                        "SignedRevocationList or None at worker construction. Check "
+                        "SRL endpoint availability, credentials, and timeout settings, "
+                        "or pass a static revocation_list for bootstrap."
+                    ) from exc
+                if initial_srl is not None:
+                    self._last_good_revocation_list = initial_srl
+            else:
+                self._last_good_revocation_list = self.revocation_list
+            self._provider_snapshots_ready = True
 
         if self.signing_key is not None and self.key_resolver is None:
 

--- a/tenuo-python/tenuo/temporal/_config.py
+++ b/tenuo-python/tenuo/temporal/_config.py
@@ -353,6 +353,12 @@ class TenuoPluginConfig:
     inbound authorization.  Warrants whose ID appears in the list are denied
     even when the chain is otherwise valid.
 
+    The SRL issuer must be one of ``trusted_roots``.  Python Temporal
+    integration currently uses the same trust roots for warrant issuance and
+    revocation-list signing; configure the revocation signer as a trusted root
+    or use the Rust authorizer API when you need an explicit separate
+    revocation authority.
+
     Mutually exclusive with ``revocation_list_provider`` (raises
     ``ConfigurationError`` if both are set).
 
@@ -369,6 +375,10 @@ class TenuoPluginConfig:
     Use this instead of ``revocation_list`` when you need periodic SRL
     refresh without redeploying workers.
 
+    The initial provider call is part of worker startup.  If it raises, worker
+    construction fails closed with ``ConfigurationError`` so a transient SRL
+    outage is visible before the worker accepts work.
+
     ``None`` (default) disables provider-based SRL refresh.
     """
 
@@ -380,9 +390,15 @@ class TenuoPluginConfig:
     Requires ``revocation_list_provider`` to be set.
     """
 
-    _last_good_trusted_roots: List[Any] = field(default_factory=list, init=False, repr=False)
-    _last_good_revocation_list: Optional[Any] = field(default=None, init=False, repr=False)
-    _provider_state_lock: Any = field(default_factory=threading.RLock, init=False, repr=False)
+    _last_good_trusted_roots: List[Any] = field(
+        default_factory=list, init=False, repr=False, compare=False
+    )
+    _last_good_revocation_list: Optional[Any] = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _provider_state_lock: Any = field(
+        default_factory=threading.RLock, init=False, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
         if self.dry_run:
@@ -454,7 +470,19 @@ class TenuoPluginConfig:
                 )
 
         if self.revocation_list_provider is not None:
-            initial_srl = self.revocation_list_provider()
+            try:
+                initial_srl = self.revocation_list_provider()
+            except Exception as exc:
+                from tenuo.exceptions import ConfigurationError
+
+                raise ConfigurationError(
+                    "TenuoPluginConfig: revocation_list_provider failed during "
+                    "startup. Provider-backed revocation is installed before the "
+                    "worker accepts work, so the provider must return a valid "
+                    "SignedRevocationList or None at worker construction. Check "
+                    "SRL endpoint availability, credentials, and timeout settings, "
+                    "or pass a static revocation_list for bootstrap."
+                ) from exc
             if initial_srl is not None:
                 self._last_good_revocation_list = initial_srl
         else:

--- a/tenuo-python/tenuo/temporal/_config.py
+++ b/tenuo-python/tenuo/temporal/_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import warnings
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence
@@ -376,8 +377,12 @@ class TenuoPluginConfig:
     How often (in seconds) to refresh the SRL via ``revocation_list_provider``.
     ``None`` means the provider is called once at startup and not again.
 
-    Requires ``revocation_list_provider`` to be set; ignored otherwise.
+    Requires ``revocation_list_provider`` to be set.
     """
+
+    _last_good_trusted_roots: List[Any] = field(default_factory=list, init=False, repr=False)
+    _last_good_revocation_list: Optional[Any] = field(default=None, init=False, repr=False)
+    _provider_state_lock: Any = field(default_factory=threading.RLock, init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.dry_run:
@@ -427,6 +432,33 @@ class TenuoPluginConfig:
                 "or call tenuo.configure(trusted_roots=[...]) at application startup."
             )
         self.trusted_roots = roots  # type: ignore[assignment]
+        self._last_good_trusted_roots = list(roots)
+
+        if self.revocation_list is not None and self.revocation_list_provider is not None:
+            from tenuo.exceptions import ConfigurationError
+            raise ConfigurationError(
+                "TenuoPluginConfig: pass either revocation_list= or "
+                "revocation_list_provider=, not both."
+            )
+
+        if self.revocation_refresh_secs is not None:
+            if self.revocation_refresh_secs <= 0:
+                from tenuo.exceptions import ConfigurationError
+                raise ConfigurationError(
+                    "revocation_refresh_secs must be positive when set."
+                )
+            if self.revocation_list_provider is None:
+                from tenuo.exceptions import ConfigurationError
+                raise ConfigurationError(
+                    "revocation_refresh_secs requires revocation_list_provider."
+                )
+
+        if self.revocation_list_provider is not None:
+            initial_srl = self.revocation_list_provider()
+            if initial_srl is not None:
+                self._last_good_revocation_list = initial_srl
+        else:
+            self._last_good_revocation_list = self.revocation_list
 
         if self.signing_key is not None and self.key_resolver is None:
 

--- a/tenuo-python/tenuo/temporal/_headers.py
+++ b/tenuo-python/tenuo/temporal/_headers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import binascii
 import gzip
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from tenuo.temporal._constants import (
     TENUO_COMPRESSED_HEADER,
@@ -87,6 +87,19 @@ def tenuo_headers(
         headers[TENUO_COMPRESSED_HEADER] = b"0"
 
     return headers
+
+
+def _validate_chain_ends_with_warrant(
+    chain: List[Any],
+    warrant: Any,
+    *,
+    operation: str,
+) -> None:
+    """Bind a separately supplied warrant to its asserted chain leaf."""
+    if not chain:
+        raise TenuoContextError(f"{operation}: warrant_chain must not be empty.")
+    if chain[-1].to_bytes() != warrant.to_bytes():
+        raise TenuoContextError(f"{operation}: warrant_chain must end with warrant.")
 
 
 def _extract_warrant_from_headers(headers: Dict[str, bytes]) -> Any:

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -760,26 +760,32 @@ class TenuoActivityInboundInterceptor:
             if (now2 - self._last_srl_refresh) < interval:
                 return
             try:
-                srl = provider()
-            except Exception as e:
-                logger.warning("revocation_list_provider failed during refresh: %s", e)
-                return
-            if srl is None:
-                logger.warning(
-                    "revocation_list_provider returned None during refresh; "
-                    "keeping prior revocation list"
-                )
-                return
-            try:
-                for auth in (self._authorizer, self._retry_authorizer):
-                    if auth is not None:
-                        auth.set_revocation_list(srl)
+                try:
+                    srl = provider()
+                except Exception as e:
+                    logger.warning("revocation_list_provider failed during refresh: %s", e)
+                    return
+                if srl is None:
+                    logger.warning(
+                        "revocation_list_provider returned None during refresh; "
+                        "keeping prior revocation list"
+                    )
+                    return
+                authorizers = [
+                    auth
+                    for auth in (self._authorizer, self._retry_authorizer)
+                    if auth is not None
+                ]
+                for auth in authorizers:
+                    auth.set_revocation_list(srl)
+                with self._config._provider_state_lock:
+                    self._config._last_good_revocation_list = srl
             except Exception as e:
                 logger.warning("SRL refresh failed: %s", e)
-                return
-            with self._config._provider_state_lock:
-                self._config._last_good_revocation_list = srl
-            self._last_srl_refresh = _time.monotonic()
+            finally:
+                # Advance on every attempt so a broken source retries on
+                # interval instead of on every subsequent activity.
+                self._last_srl_refresh = _time.monotonic()
 
     def init(self, outbound: Any) -> None:
         """Called by Temporal to initialize the interceptor with an outbound impl."""
@@ -901,6 +907,29 @@ class TenuoActivityInboundInterceptor:
 
         args = self._extract_arguments(input, headers)
 
+        # -- 6. Delegation Depth Limit --
+        chain_depth = warrant.depth if hasattr(warrant, "depth") else 0
+        if chain_depth > self._config.max_chain_depth:
+            self._emit_denial_event(
+                info=info,
+                warrant=warrant,
+                tool=tool_name,
+                args=args,
+                reason=f"Chain depth {chain_depth} exceeds max {self._config.max_chain_depth}",
+                constraint="max_chain_depth_exceeded",
+                start_ns=start_ns,
+            )
+            if self._config.on_denial == "raise" and not self._config.dry_run:
+                raise self._wrap_as_non_retryable(ChainValidationError(
+                    reason=f"Chain depth {chain_depth} exceeds max {self._config.max_chain_depth}",
+                    depth=chain_depth,
+                ))
+            return await _deny_or_continue(
+                tool=tool_name,
+                reason=f"Chain depth {chain_depth} exceeds max {self._config.max_chain_depth}",
+            )
+
+        # -- 6b. Warrant-Chain Leaf Binding --
         chain = None
         chain_header = headers.get(TENUO_CHAIN_HEADER)
         if chain_header:
@@ -930,28 +959,6 @@ class TenuoActivityInboundInterceptor:
                         depth=0,
                     )) from exc
                 return await _deny_or_continue(tool=tool_name, reason=reason)
-
-        # -- 6. Delegation Depth Limit --
-        chain_depth = warrant.depth if hasattr(warrant, "depth") else 0
-        if chain_depth > self._config.max_chain_depth:
-            self._emit_denial_event(
-                info=info,
-                warrant=warrant,
-                tool=tool_name,
-                args=args,
-                reason=f"Chain depth {chain_depth} exceeds max {self._config.max_chain_depth}",
-                constraint="max_chain_depth_exceeded",
-                start_ns=start_ns,
-            )
-            if self._config.on_denial == "raise" and not self._config.dry_run:
-                raise self._wrap_as_non_retryable(ChainValidationError(
-                    reason=f"Chain depth {chain_depth} exceeds max {self._config.max_chain_depth}",
-                    depth=chain_depth,
-                ))
-            return await _deny_or_continue(
-                tool=tool_name,
-                reason=f"Chain depth {chain_depth} exceeds max {self._config.max_chain_depth}",
-            )
 
         # -- 7. Trusted-Root & Revocation Refresh --
         self._maybe_refresh_trusted_roots()

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -78,6 +78,35 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("tenuo.temporal")
 
+_CONFIG_REVOCATION_LIST = object()
+
+
+def _build_authorizer(
+    authorizer_cls: Any,
+    trusted_roots: Any,
+    config: "TenuoPluginConfig",
+    *,
+    revocation_list: Any = _CONFIG_REVOCATION_LIST,
+    **kwargs: Any,
+) -> Any:
+    """Build an Authorizer with the worker's shared validation policy.
+
+    ``revocation_list`` can override the config snapshot after a provider
+    refresh. Missing core SRL support is an error, never a silent downgrade.
+    """
+    auth = authorizer_cls(trusted_roots=trusted_roots, **kwargs)
+    if config.clearance_requirements:
+        for tool, clearance in config.clearance_requirements.items():
+            auth.require_clearance(tool, clearance)
+    srl = (
+        config.revocation_list
+        if revocation_list is _CONFIG_REVOCATION_LIST
+        else revocation_list
+    )
+    if srl is not None:
+        auth.set_revocation_list(srl)
+    return auth
+
 # OTel is a soft dependency
 try:
     from opentelemetry import trace as _otel_trace
@@ -631,11 +660,11 @@ class TenuoActivityInboundInterceptor:
         self._retry_authorizer: Optional[Any] = None
         try:
             from tenuo_core import Authorizer
-            self._authorizer = self._build_authorizer(
+            self._authorizer = _build_authorizer(
                 Authorizer, config.trusted_roots, config
             )
             if config.retry_pop_max_windows is not None:
-                self._retry_authorizer = self._build_authorizer(
+                self._retry_authorizer = _build_authorizer(
                     Authorizer,
                     config.trusted_roots,
                     config,
@@ -648,24 +677,6 @@ class TenuoActivityInboundInterceptor:
                 "Install tenuo with the native extension, or ensure the "
                 "interpreter can import tenuo_core."
             ) from e
-
-    @staticmethod
-    def _build_authorizer(
-        authorizer_cls: Any,
-        trusted_roots: Any,
-        config: "TenuoPluginConfig",
-        **kwargs: Any,
-    ) -> Any:
-        """Build an Authorizer instance and apply config-level policies."""
-        auth = authorizer_cls(trusted_roots=trusted_roots, **kwargs)
-        if config.clearance_requirements:
-            for tool, clearance in config.clearance_requirements.items():
-                if hasattr(auth, "require_clearance"):
-                    auth.require_clearance(tool, clearance)
-        srl = config.revocation_list
-        if srl is not None and hasattr(auth, "set_revocation_list"):
-            auth.set_revocation_list(srl)
-        return auth
 
     def _maybe_refresh_trusted_roots(self) -> None:
         """Rebuild Authorizer from ``trusted_roots_provider`` on a fixed interval."""
@@ -702,11 +713,11 @@ class TenuoActivityInboundInterceptor:
                 # ``self._config.trusted_roots`` because ``dataclasses.replace``
                 # would re-run ``__post_init__`` and fail the either/or check
                 # when ``trusted_roots_provider=`` is set.
-                self._authorizer = self._build_authorizer(
+                self._authorizer = _build_authorizer(
                     Authorizer, roots, self._config
                 )
                 if self._config.retry_pop_max_windows is not None:
-                    self._retry_authorizer = self._build_authorizer(
+                    self._retry_authorizer = _build_authorizer(
                         Authorizer,
                         roots,
                         self._config,
@@ -758,7 +769,7 @@ class TenuoActivityInboundInterceptor:
                 # Authorizer instead; the snapshot is *not* resynced.
                 self._config = _dc.replace(self._config, revocation_list=srl)
                 for auth in (self._authorizer, self._retry_authorizer):
-                    if auth is not None and hasattr(auth, "set_revocation_list"):
+                    if auth is not None:
                         try:
                             auth.set_revocation_list(srl)
                         except Exception as e:

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -49,6 +49,8 @@ from tenuo.temporal._pop import (
     _warrant_tool_has_non_empty_field_constraints,
 )
 from tenuo.temporal._state import (
+    _activity_fn_override,
+    _activity_warrant_override,
     _current_run_key,
     _pending_activity_approvals,
     _pending_activity_fn,
@@ -169,8 +171,12 @@ class _TenuoWorkflowOutboundInterceptor:
             with _store_lock:
                 pending_approvals = _pending_activity_approvals.pop(run_key, None)
 
-            with _store_lock:
-                raw_headers = dict(_workflow_headers_store.get(run_key, {}))
+            override_headers = _activity_warrant_override.get()
+            if override_headers is not None:
+                raw_headers = dict(override_headers)
+            else:
+                with _store_lock:
+                    raw_headers = dict(_workflow_headers_store.get(run_key, {}))
 
             if raw_headers:
                 warrant = _extract_warrant_from_headers(raw_headers)
@@ -189,6 +195,8 @@ class _TenuoWorkflowOutboundInterceptor:
                     signer = self._config.key_resolver.resolve_sync(key_id)
 
                     activity_fn = getattr(input, "fn", None)
+                    if activity_fn is None:
+                        activity_fn = _activity_fn_override.get()
                     if activity_fn is None:
                         with _store_lock:
                             activity_fn = _pending_activity_fn.get(run_key)

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -663,11 +663,7 @@ class TenuoActivityInboundInterceptor:
         self._retry_authorizer: Optional[Any] = None
         try:
             from tenuo_core import Authorizer
-            initial_revocation_list = getattr(
-                config,
-                "_last_good_revocation_list",
-                config.revocation_list,
-            )
+            initial_revocation_list = config._last_good_revocation_list
             self._authorizer = _build_authorizer(
                 Authorizer,
                 config.trusted_roots,
@@ -729,22 +725,14 @@ class TenuoActivityInboundInterceptor:
                     Authorizer,
                     roots,
                     self._config,
-                    revocation_list=getattr(
-                        self._config,
-                        "_last_good_revocation_list",
-                        self._config.revocation_list,
-                    ),
+                    revocation_list=self._config._last_good_revocation_list,
                 )
                 if self._config.retry_pop_max_windows is not None:
                     self._retry_authorizer = _build_authorizer(
                         Authorizer,
                         roots,
                         self._config,
-                        revocation_list=getattr(
-                            self._config,
-                            "_last_good_revocation_list",
-                            self._config.revocation_list,
-                        ),
+                        revocation_list=self._config._last_good_revocation_list,
                         pop_max_windows=self._config.retry_pop_max_windows,
                     )
             except Exception as e:
@@ -944,8 +932,7 @@ class TenuoActivityInboundInterceptor:
                 return await _deny_or_continue(tool=tool_name, reason=reason)
 
         # -- 6. Delegation Depth Limit --
-        leaf = chain[-1] if chain else warrant
-        chain_depth = leaf.depth if hasattr(leaf, "depth") else 0
+        chain_depth = warrant.depth if hasattr(warrant, "depth") else 0
         if chain_depth > self._config.max_chain_depth:
             self._emit_denial_event(
                 info=info,

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -38,7 +38,10 @@ from tenuo.temporal._decorators import (
     _warrant_tool_name_for_activity_type,
     is_unprotected,
 )
-from tenuo.temporal._headers import _extract_warrant_from_headers
+from tenuo.temporal._headers import (
+    _extract_warrant_from_headers,
+    _validate_chain_ends_with_warrant,
+)
 from tenuo.temporal._observability import TemporalAuditEvent
 from tenuo.temporal._pop import (
     _args_dict_uses_only_positional_fallback_keys,
@@ -660,14 +663,23 @@ class TenuoActivityInboundInterceptor:
         self._retry_authorizer: Optional[Any] = None
         try:
             from tenuo_core import Authorizer
+            initial_revocation_list = getattr(
+                config,
+                "_last_good_revocation_list",
+                config.revocation_list,
+            )
             self._authorizer = _build_authorizer(
-                Authorizer, config.trusted_roots, config
+                Authorizer,
+                config.trusted_roots,
+                config,
+                revocation_list=initial_revocation_list,
             )
             if config.retry_pop_max_windows is not None:
                 self._retry_authorizer = _build_authorizer(
                     Authorizer,
                     config.trusted_roots,
                     config,
+                    revocation_list=initial_revocation_list,
                     pop_max_windows=config.retry_pop_max_windows,
                 )
         except ImportError as e:
@@ -714,13 +726,25 @@ class TenuoActivityInboundInterceptor:
                 # would re-run ``__post_init__`` and fail the either/or check
                 # when ``trusted_roots_provider=`` is set.
                 self._authorizer = _build_authorizer(
-                    Authorizer, roots, self._config
+                    Authorizer,
+                    roots,
+                    self._config,
+                    revocation_list=getattr(
+                        self._config,
+                        "_last_good_revocation_list",
+                        self._config.revocation_list,
+                    ),
                 )
                 if self._config.retry_pop_max_windows is not None:
                     self._retry_authorizer = _build_authorizer(
                         Authorizer,
                         roots,
                         self._config,
+                        revocation_list=getattr(
+                            self._config,
+                            "_last_good_revocation_list",
+                            self._config.revocation_list,
+                        ),
                         pop_max_windows=self._config.retry_pop_max_windows,
                     )
             except Exception as e:
@@ -728,6 +752,8 @@ class TenuoActivityInboundInterceptor:
                     "Authorizer rebuild failed during trusted root refresh: %s", e
                 )
                 return
+            with self._config._provider_state_lock:
+                self._config._last_good_trusted_roots = list(roots)
             self._last_trusted_roots_refresh = _time.monotonic()
 
     def _maybe_refresh_revocation_list(self) -> None:
@@ -756,29 +782,15 @@ class TenuoActivityInboundInterceptor:
                     "keeping prior revocation list"
                 )
                 return
-            import dataclasses as _dc
             try:
-                # ``self._config`` diverges from the ``TenuoPluginConfig`` held
-                # by ``TenuoWorkerInterceptor`` (and by any running workflow's
-                # ``_workflow_config_store[run_id]`` snapshot). Today that's
-                # benign because only the activity inbound path consults
-                # ``revocation_list`` — the workflow inbound path checks
-                # ``authorized_signals``/``authorized_updates`` only. If you
-                # add a future feature that consults ``revocation_list`` off
-                # the workflow-config snapshot, route it through the
-                # Authorizer instead; the snapshot is *not* resynced.
-                self._config = _dc.replace(self._config, revocation_list=srl)
                 for auth in (self._authorizer, self._retry_authorizer):
                     if auth is not None:
-                        try:
-                            auth.set_revocation_list(srl)
-                        except Exception as e:
-                            logger.warning(
-                                "set_revocation_list failed during SRL refresh: %s", e
-                            )
+                        auth.set_revocation_list(srl)
             except Exception as e:
                 logger.warning("SRL refresh failed: %s", e)
                 return
+            with self._config._provider_state_lock:
+                self._config._last_good_revocation_list = srl
             self._last_srl_refresh = _time.monotonic()
 
     def init(self, outbound: Any) -> None:
@@ -901,8 +913,39 @@ class TenuoActivityInboundInterceptor:
 
         args = self._extract_arguments(input, headers)
 
+        chain = None
+        chain_header = headers.get(TENUO_CHAIN_HEADER)
+        if chain_header:
+            try:
+                from tenuo_core import decode_warrant_stack_base64 as _decode_stack
+
+                chain = _decode_stack(chain_header.decode("utf-8"))
+                _validate_chain_ends_with_warrant(
+                    list(chain),
+                    warrant,
+                    operation="activity ingress",
+                )
+            except Exception as exc:
+                reason = f"Invalid warrant chain header: {exc}"
+                self._emit_denial_event(
+                    info=info,
+                    warrant=warrant,
+                    tool=tool_name,
+                    args=args,
+                    reason=reason,
+                    constraint="chain_header_invalid",
+                    start_ns=start_ns,
+                )
+                if self._config.on_denial == "raise" and not self._config.dry_run:
+                    raise self._wrap_as_non_retryable(ChainValidationError(
+                        reason=reason,
+                        depth=0,
+                    )) from exc
+                return await _deny_or_continue(tool=tool_name, reason=reason)
+
         # -- 6. Delegation Depth Limit --
-        chain_depth = warrant.depth if hasattr(warrant, "depth") else 0
+        leaf = chain[-1] if chain else warrant
+        chain_depth = leaf.depth if hasattr(leaf, "depth") else 0
         if chain_depth > self._config.max_chain_depth:
             self._emit_denial_event(
                 info=info,
@@ -954,8 +997,6 @@ class TenuoActivityInboundInterceptor:
         # Phases 9–13 run inside a single try/except so every failure path
         # funnels into phase 14 for unified fail-closed error mapping.
         try:
-            from tenuo_core import decode_warrant_stack_base64 as _decode_stack
-
             # -- 9. Retry-Aware Authorizer Selection --
             if info.attempt > 1 and self._retry_authorizer is not None:
                 authorizer = self._retry_authorizer
@@ -990,9 +1031,7 @@ class TenuoActivityInboundInterceptor:
             )
 
             # -- 12. Cryptographic Authorization Evaluation --
-            chain_header = headers.get(TENUO_CHAIN_HEADER)
-            if chain_header:
-                chain = _decode_stack(chain_header.decode("utf-8"))
+            if chain:
                 chain_result = authorizer.check_chain(
                     chain, tool_name, args,
                     signature=pop_bytes,

--- a/tenuo-python/tenuo/temporal/_state.py
+++ b/tenuo-python/tenuo/temporal/_state.py
@@ -192,6 +192,11 @@ def _get_only_worker_config() -> "Optional[TenuoPluginConfig]":
     return next(iter(_worker_configs.values()))
 
 
+def _worker_config_count() -> int:
+    """Return the number of registered worker configs for diagnostics."""
+    return len(_worker_configs)
+
+
 def _clear_worker_config(task_queue: Optional[str] = None) -> None:
     """Testing hook: clear the registered worker config(s).
 

--- a/tenuo-python/tenuo/temporal/_state.py
+++ b/tenuo-python/tenuo/temporal/_state.py
@@ -48,6 +48,22 @@ _active_tenuo_warrant: contextvars.ContextVar[Optional[tuple]] = contextvars.Con
     "tenuo_active_warrant", default=None
 )
 
+#: Per-Activity warrant override used by ``tenuo_execute_activity(warrant=...)``.
+#: A ContextVar is intentional: workflows can schedule Activities concurrently,
+#: so a run-id keyed "next headers" slot would let sibling asyncio tasks consume
+#: one another's warrant. The value is raw Tenuo headers and is scoped to the
+#: single call around ``workflow.execute_activity``.
+_activity_warrant_override: contextvars.ContextVar[Optional[Dict[str, bytes]]] = (
+    contextvars.ContextVar("tenuo_activity_warrant_override", default=None)
+)
+
+#: Function reference paired with the current ``tenuo_execute_activity`` call.
+#: The legacy run-id store remains as a compatibility fallback, but this value
+#: prevents concurrent workflow tasks from racing over argument-name mapping.
+_activity_fn_override: contextvars.ContextVar[Optional[Any]] = contextvars.ContextVar(
+    "tenuo_activity_fn_override", default=None
+)
+
 # _workflow_headers_store:    run_id → {warrant, key_id}
 # _pending_child_headers:     child_wf_id → attenuated headers
 #                              (keyed by workflow_id because the child's run_id

--- a/tenuo-python/tenuo/temporal/_state.py
+++ b/tenuo-python/tenuo/temporal/_state.py
@@ -178,6 +178,20 @@ def _get_worker_config(
     return _worker_configs.get(task_queue)
 
 
+def _get_only_worker_config() -> "Optional[TenuoPluginConfig]":
+    """Return the sole registered worker config, if it is unambiguous.
+
+    This exists only as a compatibility bridge for APIs that historically
+    allowed callers to omit ``task_queue``. Security-sensitive routing should
+    continue to use :func:`_get_worker_config` for exact matching. Returning
+    ``None`` for zero or multiple registrations keeps the bridge fail-closed
+    and prevents cross-queue/tenant config selection.
+    """
+    if len(_worker_configs) != 1:
+        return None
+    return next(iter(_worker_configs.values()))
+
+
 def _clear_worker_config(task_queue: Optional[str] = None) -> None:
     """Testing hook: clear the registered worker config(s).
 

--- a/tenuo-python/tenuo/temporal/_workflow.py
+++ b/tenuo-python/tenuo/temporal/_workflow.py
@@ -21,6 +21,8 @@ from tenuo.temporal._headers import (
 )
 from tenuo.temporal._observability import _MintRequest
 from tenuo.temporal._state import (
+    _activity_fn_override,
+    _activity_warrant_override,
     _current_run_key,
     _pending_activity_fn,
     _pending_child_headers,
@@ -183,6 +185,10 @@ async def tenuo_execute_activity(
     activity: Any,
     *,
     args: Optional[List[Any]] = None,
+    warrant: Any = None,
+    key_id: Optional[str] = None,
+    warrant_chain: Optional[List[Any]] = None,
+    compress: bool = True,
     start_to_close_timeout: Any = None,
     schedule_to_close_timeout: Any = None,
     schedule_to_start_timeout: Any = None,
@@ -194,10 +200,11 @@ async def tenuo_execute_activity(
 ) -> Any:
     """Execute an activity with automatic function-reference registration.
 
-    This is a wrapper around ``workflow.execute_activity()`` with one
-    additional behaviour: it stores the activity function reference in
-    ``_pending_activity_fn`` before dispatch, so the outbound interceptor
-    can resolve real Python parameter names for PoP signing.
+    This is a wrapper around ``workflow.execute_activity()`` that registers
+    the activity function for named-argument PoP signing. It can also apply a
+    warrant to this dispatch only. Per-dispatch warrants make
+    ``workflow_grant()`` and ``workflow_issue_execution()`` useful for
+    long-running workflows without replacing the workflow's base warrant.
 
     **When to use it:** if your warrant uses named field constraints
     (e.g. ``path=Subpath(...)``) and you have not set ``activity_fns``
@@ -209,6 +216,11 @@ async def tenuo_execute_activity(
     Args:
         activity: The activity function to execute
         args: Arguments to pass to the activity
+        warrant: Optional warrant for this Activity dispatch only.
+        key_id: Holder key ID for ``warrant``. Required with ``warrant``.
+        warrant_chain: Optional full root-to-leaf chain. When omitted, the
+            active workflow chain is extended with ``warrant``.
+        compress: Whether to compress the per-dispatch warrant header.
         start_to_close_timeout: Timeout for activity execution
         schedule_to_close_timeout: Timeout from schedule to completion
         schedule_to_start_timeout: Timeout from schedule to start
@@ -254,13 +266,56 @@ async def tenuo_execute_activity(
         }.items() if v is not None
     }
 
+    if (warrant is None) != (key_id is None):
+        raise TenuoContextError(
+            "tenuo_execute_activity: warrant and key_id must be provided together."
+        )
+
+    override_headers: Optional[Dict[str, bytes]] = None
+    if warrant is not None:
+        assert key_id is not None  # narrowed by the paired-argument check above
+        override_headers = tenuo_headers(warrant, key_id, compress=compress)
+
+        if warrant_chain is not None:
+            chain = list(warrant_chain)
+        else:
+            raw_current = _current_workflow_headers()
+            encoded_current = raw_current.get(TENUO_CHAIN_HEADER)
+            if encoded_current:
+                from tenuo_core import decode_warrant_stack_base64 as _decode_stack
+
+                chain = list(_decode_stack(encoded_current.decode("utf-8")))
+            else:
+                chain = [current_warrant()]
+            chain.append(warrant)
+
+        if not chain:
+            raise TenuoContextError(
+                "tenuo_execute_activity: warrant_chain must not be empty."
+            )
+        if chain[-1].to_bytes() != warrant.to_bytes():
+            raise TenuoContextError(
+                "tenuo_execute_activity: warrant_chain must end with warrant."
+            )
+        if len(chain) > 1:
+            from tenuo_core import encode_warrant_stack as _encode_stack
+
+            override_headers[TENUO_CHAIN_HEADER] = _encode_stack(chain).encode("utf-8")
+
     run_key = _current_run_key()
     with _store_lock:
         _pending_activity_fn[run_key] = activity
 
+    override_token = None
+    if override_headers is not None:
+        override_token = _activity_warrant_override.set(override_headers)
+    activity_fn_token = _activity_fn_override.set(activity)
     try:
         return await workflow.execute_activity(activity, **activity_kwargs)
     finally:
+        _activity_fn_override.reset(activity_fn_token)
+        if override_token is not None:
+            _activity_warrant_override.reset(override_token)
         with _store_lock:
             _pending_activity_fn.pop(run_key, None)
 
@@ -1086,26 +1141,40 @@ async def create_scheduled_workflow_with_warrant(
     workflow_args: Optional[list] = None,
     workflow_kwargs: Optional[dict] = None,
     task_queue: str = "default",
+    compress: bool = True,
+    memo: Optional[dict] = None,
     **schedule_kwargs: Any,
 ) -> Any:
-    """Create a Temporal Schedule that carries a Tenuo warrant in the schedule memo."""
-    import base64 as _b64
-    from temporalio.client import Schedule, ScheduleActionStartWorkflow
+    """Create a Temporal Schedule whose workflow starts carry Tenuo headers.
 
-    warrant_bytes = warrant.to_bytes()
-    memo = {
-        "tenuo_warrant": _b64.b64encode(warrant_bytes).decode(),
-        "tenuo_key_id": key_id,
-    }
+    The supplied warrant is embedded in the Schedule action and reused for
+    every trigger. Its TTL must therefore cover the intended Schedule lifetime.
+    For unbounded recurring Schedules, start a workflow under a longer-lived
+    issuer warrant and mint short-lived execution warrants per Activity.
+    """
+    from temporalio.client import Schedule, ScheduleActionStartWorkflow
+    from temporalio.api.common.v1 import Payload
+
+    if workflow_kwargs:
+        raise ValueError(
+            "Temporal workflow arguments are positional. Pass workflow_args=; "
+            "workflow_kwargs= is not supported."
+        )
+
+    raw_headers = tenuo_headers(warrant, key_id, compress=compress)
+    payload_headers = {name: Payload(data=value) for name, value in raw_headers.items()}
 
     action = ScheduleActionStartWorkflow(
         workflow,
-        *(workflow_args or []),
-        **(workflow_kwargs or {}),
+        args=workflow_args or [],
         id=f"{schedule_id}-run",
         task_queue=task_queue,
         memo=memo,
     )
+    # ``headers`` is a supported ScheduleActionStartWorkflow field but is not
+    # present in the temporalio 1.23 overload stubs. Assign after construction
+    # to preserve compatibility with our minimum SDK while remaining typed.
+    action.headers = payload_headers
 
     schedule = Schedule(action=action, spec=schedule_spec)
     return await client.create_schedule(schedule_id, schedule, **schedule_kwargs)
@@ -1119,31 +1188,67 @@ async def tenuo_complete_async_activity(
     *,
     client: Optional["Client"] = None,
     task_queue: Optional[str] = None,
+    warrant_chain: Optional[List[Any]] = None,
 ) -> None:
-    """Complete an async activity with Tenuo authorization headers.
+    """Complete an async Activity after fail-closed Tenuo validation.
 
-    PoP signing is best-effort and is skipped (with a debug log) when
-    no worker config can be located. To enable it, pass *task_queue*
-    to select the registered :class:`TenuoPluginConfig`; otherwise the
-    completion proceeds without a PoP signature.
+    Temporal's async-completion RPC has no user-header field, so authorization
+    cannot be transported to a second worker. This helper instead verifies the
+    warrant chain (including expiry/revocation) and proves that ``key_id``
+    resolves to the warrant holder before releasing the completion call.
+
+    ``task_queue`` is required so multi-worker processes cannot select another
+    tenant's key resolver. Supply ``warrant_chain`` for delegated warrants;
+    root warrants default to a one-element chain.
     """
-    import datetime as _datetime
 
     from tenuo.temporal._state import _get_worker_config
 
-    now = _datetime.datetime.now(_datetime.timezone.utc)
+    worker_cfg = _get_worker_config(task_queue)
+    if worker_cfg is None:
+        raise TenuoContextError(
+            "tenuo_complete_async_activity: no TenuoPluginConfig registered for "
+            f"task_queue={task_queue!r}. Pass the exact Activity task queue."
+        )
+    if worker_cfg.key_resolver is None:
+        raise TenuoContextError(
+            "tenuo_complete_async_activity: the registered worker config has no key_resolver."
+        )
+
+    roots = list(worker_cfg.trusted_roots or [])
+    if worker_cfg.trusted_roots_provider is not None:
+        roots = list(worker_cfg.trusted_roots_provider())
+    if not roots:
+        raise TenuoContextError(
+            "tenuo_complete_async_activity: trusted roots are required."
+        )
+
+    chain = list(warrant_chain) if warrant_chain is not None else [warrant]
+    if not chain or chain[-1].to_bytes() != warrant.to_bytes():
+        raise TenuoContextError(
+            "tenuo_complete_async_activity: warrant_chain must end with warrant."
+        )
 
     try:
-        worker_cfg = _get_worker_config(task_queue)
-        if worker_cfg is not None and worker_cfg.key_resolver is not None:
-            key = await worker_cfg.key_resolver.resolve(key_id)
-            if key is not None:
-                import json as _json
-                payload_str = _json.dumps({"result": str(result), "ts": now.isoformat()})
-                if hasattr(warrant, "sign_pop"):
-                    warrant.sign_pop(payload_str.encode(), key)
-    except Exception:
-        logger.debug("PoP signing skipped for async activity completion", exc_info=True)
+        from tenuo_core import Authorizer
+
+        authorizer = Authorizer(trusted_roots=roots)
+        revocations = worker_cfg.revocation_list
+        if worker_cfg.revocation_list_provider is not None:
+            revocations = worker_cfg.revocation_list_provider()
+        if revocations is not None and hasattr(authorizer, "set_revocation_list"):
+            authorizer.set_revocation_list(revocations)
+        authorizer.verify_chain(chain)
+    except Exception as exc:
+        raise TenuoContextError(
+            f"tenuo_complete_async_activity: warrant validation failed: {exc}"
+        ) from exc
+
+    key = await worker_cfg.key_resolver.resolve(key_id)
+    if key is None or key.public_key.to_bytes() != warrant.holder_key.to_bytes():
+        raise TenuoContextError(
+            "tenuo_complete_async_activity: key_id does not resolve to the warrant holder."
+        )
 
     if isinstance(handle_or_task_token, (bytes, bytearray)):
         if client is None:

--- a/tenuo-python/tenuo/temporal/_workflow.py
+++ b/tenuo-python/tenuo/temporal/_workflow.py
@@ -1198,18 +1198,15 @@ async def create_scheduled_workflow_with_warrant(
     raw_headers = tenuo_headers(warrant, key_id, compress=compress)
     payload_headers = {name: Payload(data=value) for name, value in raw_headers.items()}
 
-    action = ScheduleActionStartWorkflow(
+    action = ScheduleActionStartWorkflow(  # type: ignore[call-overload]
         workflow,
         args=workflow_args or [],
         id=f"{schedule_id}-run",
         task_queue=task_queue,
         memo=memo,
+        headers=payload_headers,
         **action_options,
     )
-    # ``headers`` is a supported ScheduleActionStartWorkflow field but is not
-    # present in the temporalio 1.23 overload stubs. Assign after construction
-    # to preserve compatibility with our minimum SDK while remaining typed.
-    action.headers = payload_headers
 
     schedule = Schedule(action=action, spec=schedule_spec)
     return await client.create_schedule(schedule_id, schedule, **schedule_kwargs)
@@ -1219,18 +1216,18 @@ async def tenuo_complete_async_activity(
     handle_or_task_token: Any,
     result: Any,
     warrant: "Warrant",
-    key_id: str,
+    key_id: Optional[str] = None,
     *,
     client: Optional["Client"] = None,
     task_queue: Optional[str] = None,
     warrant_chain: Optional[List[Any]] = None,
 ) -> None:
-    """Complete an async Activity after fail-closed Tenuo validation.
+    """Complete an async Activity after local Tenuo preflight validation.
 
     Temporal's async-completion RPC has no user-header field, so authorization
     cannot be transported to a second worker. This helper instead verifies the
-    warrant chain (including expiry/revocation) and proves that ``key_id``
-    resolves to the warrant holder before releasing the completion call.
+    warrant chain (including expiry/revocation) before releasing the completion
+    call through this helper.
 
     ``task_queue`` selects the exact worker config so multi-worker processes
     cannot select another tenant's key resolver. For compatibility, omission
@@ -1241,9 +1238,18 @@ async def tenuo_complete_async_activity(
     No completion PoP is returned or attached: Temporal's async-completion RPC
     has no user-header field. Older versions computed a signature and discarded
     it, so it could never be consumed by a downstream validator.
+
+    This is a caller-side guard, not a Temporal enforcement boundary: code with
+    direct access to ``AsyncActivityHandle.complete()`` can bypass it. ``key_id``
+    remains accepted for source compatibility but is not resolved because doing
+    so would load private key material without producing a verifiable proof.
     """
 
-    from tenuo.temporal._state import _get_only_worker_config, _get_worker_config
+    from tenuo.temporal._state import (
+        _get_only_worker_config,
+        _get_worker_config,
+        _worker_config_count,
+    )
 
     if task_queue is None:
         worker_cfg = _get_only_worker_config()
@@ -1258,15 +1264,21 @@ async def tenuo_complete_async_activity(
     else:
         worker_cfg = _get_worker_config(task_queue)
     if worker_cfg is None:
+        if task_queue is None:
+            config_count = _worker_config_count()
+            if config_count == 0:
+                detail = "no worker configs are registered"
+            else:
+                detail = (
+                    f"{config_count} worker configs are registered; task_queue is "
+                    "required to choose one safely"
+                )
+        else:
+            detail = f"no config is registered for task_queue={task_queue!r}"
         raise TenuoContextError(
-            "tenuo_complete_async_activity: no TenuoPluginConfig registered for "
-            f"task_queue={task_queue!r}. Pass the exact Activity task queue."
+            f"tenuo_complete_async_activity: {detail}. Pass the exact Activity "
+            "task queue used during Worker setup."
         )
-    if worker_cfg.key_resolver is None:
-        raise TenuoContextError(
-            "tenuo_complete_async_activity: the registered worker config has no key_resolver."
-        )
-
     # ``TenuoPluginConfig`` snapshots the provider's initial roots. Match the
     # worker interceptor's rotation behavior: a non-empty provider result
     # replaces that snapshot; failure/empty results retain the last good roots.
@@ -1337,27 +1349,19 @@ async def tenuo_complete_async_activity(
 
     try:
         from tenuo_core import Authorizer
+        from tenuo.temporal._interceptors import _build_authorizer
 
-        authorizer = Authorizer(trusted_roots=roots)
-        if revocations is not None and hasattr(authorizer, "set_revocation_list"):
-            authorizer.set_revocation_list(revocations)
+        authorizer = _build_authorizer(
+            Authorizer,
+            roots,
+            worker_cfg,
+            revocation_list=revocations,
+        )
         authorizer.verify_chain(chain)
     except Exception as exc:
         raise TenuoContextError(
             f"tenuo_complete_async_activity: warrant validation failed: {exc}"
         ) from exc
-
-    try:
-        key = await worker_cfg.key_resolver.resolve(key_id)
-    except Exception as exc:
-        raise TenuoContextError(
-            f"tenuo_complete_async_activity: key resolution failed for "
-            f"key_id={key_id!r}: {exc}"
-        ) from exc
-    if key is None or key.public_key.to_bytes() != warrant.holder_key.to_bytes():
-        raise TenuoContextError(
-            "tenuo_complete_async_activity: key_id does not resolve to the warrant holder."
-        )
 
     if isinstance(handle_or_task_token, (bytes, bytearray)):
         if client is None:

--- a/tenuo-python/tenuo/temporal/_workflow.py
+++ b/tenuo-python/tenuo/temporal/_workflow.py
@@ -5,6 +5,7 @@ internal mint activity, scheduled workflows, and async activity completion.
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from tenuo.temporal._constants import (
@@ -282,6 +283,10 @@ async def tenuo_execute_activity(
             raw_current = _current_workflow_headers()
             encoded_current = raw_current.get(TENUO_CHAIN_HEADER)
             if encoded_current:
+                # Keep tenuo_core localized: this module is imported inside the
+                # Temporal workflow sandbox, and the PyO3 extension must remain
+                # a passthrough module for deterministic replay. Python caches
+                # the import, so repeated dispatches do not reload the module.
                 from tenuo_core import decode_warrant_stack_base64 as _decode_stack
 
                 chain = list(_decode_stack(encoded_current.decode("utf-8")))
@@ -1143,6 +1148,7 @@ async def create_scheduled_workflow_with_warrant(
     task_queue: str = "default",
     compress: bool = True,
     memo: Optional[dict] = None,
+    action_options: Optional[dict] = None,
     **schedule_kwargs: Any,
 ) -> Any:
     """Create a Temporal Schedule whose workflow starts carry Tenuo headers.
@@ -1155,10 +1161,28 @@ async def create_scheduled_workflow_with_warrant(
     from temporalio.client import Schedule, ScheduleActionStartWorkflow
     from temporalio.api.common.v1 import Payload
 
-    if workflow_kwargs:
+    if workflow_kwargs is not None:
+        if action_options is not None:
+            raise ValueError(
+                "Pass either deprecated workflow_kwargs= or action_options=, not both."
+            )
+        warnings.warn(
+            "create_scheduled_workflow_with_warrant(workflow_kwargs=...) is "
+            "deprecated; these values have always been Temporal Schedule action "
+            "options, not workflow arguments. Use action_options= instead. "
+            "Workflow arguments remain positional via workflow_args=.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        action_options = workflow_kwargs
+
+    action_options = dict(action_options or {})
+    reserved_options = {"args", "id", "task_queue", "memo", "headers"}
+    conflicts = reserved_options.intersection(action_options)
+    if conflicts:
+        names = ", ".join(sorted(conflicts))
         raise ValueError(
-            "Temporal workflow arguments are positional. Pass workflow_args=; "
-            "workflow_kwargs= is not supported."
+            f"action_options cannot override helper-managed fields: {names}"
         )
 
     raw_headers = tenuo_headers(warrant, key_id, compress=compress)
@@ -1170,6 +1194,7 @@ async def create_scheduled_workflow_with_warrant(
         id=f"{schedule_id}-run",
         task_queue=task_queue,
         memo=memo,
+        **action_options,
     )
     # ``headers`` is a supported ScheduleActionStartWorkflow field but is not
     # present in the temporalio 1.23 overload stubs. Assign after construction
@@ -1197,14 +1222,31 @@ async def tenuo_complete_async_activity(
     warrant chain (including expiry/revocation) and proves that ``key_id``
     resolves to the warrant holder before releasing the completion call.
 
-    ``task_queue`` is required so multi-worker processes cannot select another
-    tenant's key resolver. Supply ``warrant_chain`` for delegated warrants;
-    root warrants default to a one-element chain.
+    ``task_queue`` selects the exact worker config so multi-worker processes
+    cannot select another tenant's key resolver. For compatibility, omission
+    is temporarily accepted only when exactly one config is registered and
+    emits a deprecation warning. Supply ``warrant_chain`` for delegated
+    warrants; root warrants default to a one-element chain.
+
+    No completion PoP is returned or attached: Temporal's async-completion RPC
+    has no user-header field. Older versions computed a signature and discarded
+    it, so it could never be consumed by a downstream validator.
     """
 
-    from tenuo.temporal._state import _get_worker_config
+    from tenuo.temporal._state import _get_only_worker_config, _get_worker_config
 
-    worker_cfg = _get_worker_config(task_queue)
+    if task_queue is None:
+        worker_cfg = _get_only_worker_config()
+        if worker_cfg is not None:
+            warnings.warn(
+                "Omitting task_queue from tenuo_complete_async_activity() is "
+                "deprecated. Pass the exact Activity task queue; implicit "
+                "selection is allowed only while one worker config is registered.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+    else:
+        worker_cfg = _get_worker_config(task_queue)
     if worker_cfg is None:
         raise TenuoContextError(
             "tenuo_complete_async_activity: no TenuoPluginConfig registered for "
@@ -1215,15 +1257,44 @@ async def tenuo_complete_async_activity(
             "tenuo_complete_async_activity: the registered worker config has no key_resolver."
         )
 
+    # ``TenuoPluginConfig`` snapshots the provider's initial roots. Match the
+    # worker interceptor's rotation behavior: a non-empty provider result
+    # replaces that snapshot; failure/empty results retain the last good roots.
     roots = list(worker_cfg.trusted_roots or [])
     if worker_cfg.trusted_roots_provider is not None:
-        roots = list(worker_cfg.trusted_roots_provider())
+        try:
+            refreshed_roots = list(worker_cfg.trusted_roots_provider() or [])
+        except Exception as exc:
+            logger.warning(
+                "trusted_roots_provider failed during async completion; "
+                "retaining configured roots: %s",
+                exc,
+            )
+        else:
+            if refreshed_roots:
+                roots = refreshed_roots
+            else:
+                logger.warning(
+                    "trusted_roots_provider returned empty during async completion; "
+                    "retaining configured roots"
+                )
     if not roots:
         raise TenuoContextError(
             "tenuo_complete_async_activity: trusted roots are required."
         )
 
-    chain = list(warrant_chain) if warrant_chain is not None else [warrant]
+    if warrant_chain is None:
+        if getattr(warrant, "parent_hash", None) is not None:
+            raise TenuoContextError(
+                "tenuo_complete_async_activity: delegated warrants require an "
+                "explicit root-to-leaf warrant_chain."
+            )
+        chain = [warrant]
+    else:
+        chain = list(warrant_chain)
+    # Authorizer validates signatures, linkage, attenuation, and policy. This
+    # separate check binds the caller's ``warrant`` argument (used below for
+    # holder-key verification) to the verified chain leaf.
     if not chain or chain[-1].to_bytes() != warrant.to_bytes():
         raise TenuoContextError(
             "tenuo_complete_async_activity: warrant_chain must end with warrant."
@@ -1244,7 +1315,13 @@ async def tenuo_complete_async_activity(
             f"tenuo_complete_async_activity: warrant validation failed: {exc}"
         ) from exc
 
-    key = await worker_cfg.key_resolver.resolve(key_id)
+    try:
+        key = await worker_cfg.key_resolver.resolve(key_id)
+    except Exception as exc:
+        raise TenuoContextError(
+            f"tenuo_complete_async_activity: key resolution failed for "
+            f"key_id={key_id!r}: {exc}"
+        ) from exc
     if key is None or key.public_key.to_bytes() != warrant.holder_key.to_bytes():
         raise TenuoContextError(
             "tenuo_complete_async_activity: key_id does not resolve to the warrant holder."

--- a/tenuo-python/tenuo/temporal/_workflow.py
+++ b/tenuo-python/tenuo/temporal/_workflow.py
@@ -18,6 +18,7 @@ from tenuo.temporal._headers import (
     _current_workflow_headers,
     _extract_key_id_from_headers,
     _extract_warrant_from_headers,
+    _validate_chain_ends_with_warrant,
     tenuo_headers,
 )
 from tenuo.temporal._observability import _MintRequest
@@ -45,19 +46,7 @@ if TYPE_CHECKING:
     from tenuo.temporal._config import TenuoPluginConfig
 
 logger = logging.getLogger("tenuo.temporal")
-
-
-def _validate_chain_ends_with_warrant(
-    chain: List[Any],
-    warrant: Any,
-    *,
-    operation: str,
-) -> None:
-    """Bind a separately supplied warrant to its asserted chain leaf."""
-    if not chain:
-        raise TenuoContextError(f"{operation}: warrant_chain must not be empty.")
-    if chain[-1].to_bytes() != warrant.to_bytes():
-        raise TenuoContextError(f"{operation}: warrant_chain must end with warrant.")
+_MISSING_REVOCATION_LIST = object()
 
 
 def _fail_workflow_non_retryable(exc: Exception) -> Exception:
@@ -1279,31 +1268,32 @@ async def tenuo_complete_async_activity(
             f"tenuo_complete_async_activity: {detail}. Pass the exact Activity "
             "task queue used during Worker setup."
         )
-    # ``TenuoPluginConfig`` snapshots the provider's initial roots. Match the
-    # worker interceptor's rotation behavior: a non-empty provider result
-    # replaces that snapshot; failure/empty results retain the last good roots.
+    refreshed_roots: Optional[List[Any]] = None
     roots_provider = worker_cfg.trusted_roots_provider
     if roots_provider is not None:
         try:
-            refreshed_roots = list(roots_provider() or [])
+            candidate_roots = list(roots_provider() or [])
         except Exception as exc:
             logger.warning(
                 "trusted_roots_provider failed during async completion; "
-                "retaining configured roots: %s",
+                "retaining last good roots: %s",
                 exc,
             )
-            roots = list(worker_cfg.trusted_roots or [])
         else:
-            if refreshed_roots:
-                roots = refreshed_roots
+            if candidate_roots:
+                refreshed_roots = candidate_roots
             else:
                 logger.warning(
                     "trusted_roots_provider returned empty during async completion; "
-                    "retaining configured roots"
+                    "retaining last good roots"
                 )
-                roots = list(worker_cfg.trusted_roots or [])
-    else:
-        roots = list(worker_cfg.trusted_roots or [])
+    with worker_cfg._provider_state_lock:
+        roots = list(
+            refreshed_roots
+            or worker_cfg._last_good_trusted_roots
+            or worker_cfg.trusted_roots
+            or []
+        )
     if not roots:
         raise TenuoContextError(
             "tenuo_complete_async_activity: trusted roots are required."
@@ -1327,25 +1317,31 @@ async def tenuo_complete_async_activity(
         operation="tenuo_complete_async_activity",
     )
 
-    revocations = worker_cfg.revocation_list
+    refreshed_revocations: Any = _MISSING_REVOCATION_LIST
     revocation_provider = worker_cfg.revocation_list_provider
     if revocation_provider is not None:
         try:
-            refreshed_revocations = revocation_provider()
+            candidate_revocations = revocation_provider()
         except Exception as exc:
             logger.warning(
                 "revocation_list_provider failed during async completion; "
-                "retaining configured revocation list: %s",
+                "retaining last good revocation list: %s",
                 exc,
             )
         else:
-            if refreshed_revocations is not None:
-                revocations = refreshed_revocations
+            if candidate_revocations is not None:
+                refreshed_revocations = candidate_revocations
             else:
                 logger.warning(
                     "revocation_list_provider returned None during async completion; "
-                    "retaining configured revocation list"
+                    "retaining last good revocation list"
                 )
+    with worker_cfg._provider_state_lock:
+        revocations = (
+            refreshed_revocations
+            if refreshed_revocations is not _MISSING_REVOCATION_LIST
+            else worker_cfg._last_good_revocation_list
+        )
 
     try:
         from tenuo_core import Authorizer
@@ -1357,6 +1353,11 @@ async def tenuo_complete_async_activity(
             worker_cfg,
             revocation_list=revocations,
         )
+        with worker_cfg._provider_state_lock:
+            if refreshed_roots is not None:
+                worker_cfg._last_good_trusted_roots = list(refreshed_roots)
+            if refreshed_revocations is not _MISSING_REVOCATION_LIST:
+                worker_cfg._last_good_revocation_list = refreshed_revocations
         authorizer.verify_chain(chain)
     except Exception as exc:
         raise TenuoContextError(

--- a/tenuo-python/tenuo/temporal/_workflow.py
+++ b/tenuo-python/tenuo/temporal/_workflow.py
@@ -58,11 +58,13 @@ def _srl_version(srl: Any) -> Optional[int]:
     return int(version)
 
 
-def _srl_bytes(srl: Any) -> Optional[bytes]:
-    to_bytes = getattr(srl, "to_bytes", None)
-    if not callable(to_bytes):
+def _srl_revoked_ids(srl: Any) -> Optional[set]:
+    ids = getattr(srl, "revoked_ids", None)
+    if callable(ids):
+        ids = ids()
+    if ids is None:
         return None
-    return bytes(to_bytes())
+    return set(ids)
 
 
 def _ensure_srl_refresh_not_rolled_back(current: Any, candidate: Any) -> None:
@@ -76,18 +78,18 @@ def _ensure_srl_refresh_not_rolled_back(current: Any, candidate: Any) -> None:
             f"completion (current={current_version}, attempted={candidate_version})."
         )
     if candidate_version == current_version:
-        current_bytes = _srl_bytes(current)
-        candidate_bytes = _srl_bytes(candidate)
+        current_ids = _srl_revoked_ids(current)
+        candidate_ids = _srl_revoked_ids(candidate)
         if (
-            current_bytes is not None
-            and candidate_bytes is not None
-            and current_bytes != candidate_bytes
+            current_ids is not None
+            and candidate_ids is not None
+            and current_ids != candidate_ids
         ):
             raise TenuoContextError(
-                "revocation_list_provider returned a different SRL with the same "
-                f"version during async completion (version={candidate_version}). "
-                "Publish revocation-list updates with a monotonically increasing "
-                "version."
+                "revocation_list_provider returned a different revoked set at the "
+                f"same SRL version during async completion (version={candidate_version}). "
+                "Re-signing the same set is allowed; change the revoked IDs only "
+                "with a higher version."
             )
 
 
@@ -323,6 +325,8 @@ async def tenuo_execute_activity(
 
         if warrant_chain is not None:
             chain = list(warrant_chain)
+        elif getattr(warrant, "parent_hash", None) is None:
+            chain = [warrant]
         else:
             raw_current = _current_workflow_headers()
             encoded_current = raw_current.get(TENUO_CHAIN_HEADER)
@@ -1256,9 +1260,10 @@ async def tenuo_complete_async_activity(
     """Complete an async Activity after local Tenuo preflight validation.
 
     Temporal's async-completion RPC has no user-header field, so authorization
-    cannot be transported to a second worker. This helper instead verifies the
-    warrant chain (including expiry/revocation) before releasing the completion
-    call through this helper.
+    cannot be transported to a second worker. This helper checks warrant
+    liveness — trust, linkage, expiry, and revocation — not capability scope.
+    It does not evaluate whether the warrant authorizes completing this
+    Activity; the completion RPC does not carry the activity type or arguments.
 
     ``task_queue`` selects the exact worker config so multi-worker processes
     cannot select another tenant's key resolver. For compatibility, omission
@@ -1402,21 +1407,31 @@ async def tenuo_complete_async_activity(
             else worker_cfg._last_good_revocation_list
         )
 
-    try:
-        from tenuo_core import Authorizer
-        from tenuo.temporal._interceptors import _build_authorizer
+    from tenuo.exceptions import ConfigurationError
+    from tenuo_core import Authorizer
+    from tenuo.temporal._interceptors import _build_authorizer
 
+    try:
         authorizer = _build_authorizer(
             Authorizer,
             roots,
             worker_cfg,
             revocation_list=revocations,
         )
-        with worker_cfg._provider_state_lock:
-            if refreshed_roots is not None:
-                worker_cfg._last_good_trusted_roots = list(refreshed_roots)
-            if refreshed_revocations is not _MISSING_REVOCATION_LIST:
-                worker_cfg._last_good_revocation_list = refreshed_revocations
+    except ConfigurationError:
+        raise
+    except AttributeError as exc:
+        raise ConfigurationError(
+            "tenuo_complete_async_activity: Authorizer is missing "
+            "set_revocation_list; upgrade tenuo_core to a build that exposes "
+            "revocation-list installation."
+        ) from exc
+    with worker_cfg._provider_state_lock:
+        if refreshed_roots is not None:
+            worker_cfg._last_good_trusted_roots = list(refreshed_roots)
+        if refreshed_revocations is not _MISSING_REVOCATION_LIST:
+            worker_cfg._last_good_revocation_list = refreshed_revocations
+    try:
         authorizer.verify_chain(chain)
     except Exception as exc:
         raise TenuoContextError(

--- a/tenuo-python/tenuo/temporal/_workflow.py
+++ b/tenuo-python/tenuo/temporal/_workflow.py
@@ -47,6 +47,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger("tenuo.temporal")
 
 
+def _validate_chain_ends_with_warrant(
+    chain: List[Any],
+    warrant: Any,
+    *,
+    operation: str,
+) -> None:
+    """Bind a separately supplied warrant to its asserted chain leaf."""
+    if not chain:
+        raise TenuoContextError(f"{operation}: warrant_chain must not be empty.")
+    if chain[-1].to_bytes() != warrant.to_bytes():
+        raise TenuoContextError(f"{operation}: warrant_chain must end with warrant.")
+
+
 def _fail_workflow_non_retryable(exc: Exception) -> Exception:
     """Wrap *exc* as a non-retryable ``ApplicationError``.
 
@@ -294,14 +307,11 @@ async def tenuo_execute_activity(
                 chain = [current_warrant()]
             chain.append(warrant)
 
-        if not chain:
-            raise TenuoContextError(
-                "tenuo_execute_activity: warrant_chain must not be empty."
-            )
-        if chain[-1].to_bytes() != warrant.to_bytes():
-            raise TenuoContextError(
-                "tenuo_execute_activity: warrant_chain must end with warrant."
-            )
+        _validate_chain_ends_with_warrant(
+            chain,
+            warrant,
+            operation="tenuo_execute_activity",
+        )
         if len(chain) > 1:
             from tenuo_core import encode_warrant_stack as _encode_stack
 
@@ -1260,16 +1270,17 @@ async def tenuo_complete_async_activity(
     # ``TenuoPluginConfig`` snapshots the provider's initial roots. Match the
     # worker interceptor's rotation behavior: a non-empty provider result
     # replaces that snapshot; failure/empty results retain the last good roots.
-    roots = list(worker_cfg.trusted_roots or [])
-    if worker_cfg.trusted_roots_provider is not None:
+    roots_provider = worker_cfg.trusted_roots_provider
+    if roots_provider is not None:
         try:
-            refreshed_roots = list(worker_cfg.trusted_roots_provider() or [])
+            refreshed_roots = list(roots_provider() or [])
         except Exception as exc:
             logger.warning(
                 "trusted_roots_provider failed during async completion; "
                 "retaining configured roots: %s",
                 exc,
             )
+            roots = list(worker_cfg.trusted_roots or [])
         else:
             if refreshed_roots:
                 roots = refreshed_roots
@@ -1278,6 +1289,9 @@ async def tenuo_complete_async_activity(
                     "trusted_roots_provider returned empty during async completion; "
                     "retaining configured roots"
                 )
+                roots = list(worker_cfg.trusted_roots or [])
+    else:
+        roots = list(worker_cfg.trusted_roots or [])
     if not roots:
         raise TenuoContextError(
             "tenuo_complete_async_activity: trusted roots are required."
@@ -1295,18 +1309,36 @@ async def tenuo_complete_async_activity(
     # Authorizer validates signatures, linkage, attenuation, and policy. This
     # separate check binds the caller's ``warrant`` argument (used below for
     # holder-key verification) to the verified chain leaf.
-    if not chain or chain[-1].to_bytes() != warrant.to_bytes():
-        raise TenuoContextError(
-            "tenuo_complete_async_activity: warrant_chain must end with warrant."
-        )
+    _validate_chain_ends_with_warrant(
+        chain,
+        warrant,
+        operation="tenuo_complete_async_activity",
+    )
+
+    revocations = worker_cfg.revocation_list
+    revocation_provider = worker_cfg.revocation_list_provider
+    if revocation_provider is not None:
+        try:
+            refreshed_revocations = revocation_provider()
+        except Exception as exc:
+            logger.warning(
+                "revocation_list_provider failed during async completion; "
+                "retaining configured revocation list: %s",
+                exc,
+            )
+        else:
+            if refreshed_revocations is not None:
+                revocations = refreshed_revocations
+            else:
+                logger.warning(
+                    "revocation_list_provider returned None during async completion; "
+                    "retaining configured revocation list"
+                )
 
     try:
         from tenuo_core import Authorizer
 
         authorizer = Authorizer(trusted_roots=roots)
-        revocations = worker_cfg.revocation_list
-        if worker_cfg.revocation_list_provider is not None:
-            revocations = worker_cfg.revocation_list_provider()
         if revocations is not None and hasattr(authorizer, "set_revocation_list"):
             authorizer.set_revocation_list(revocations)
         authorizer.verify_chain(chain)

--- a/tenuo-python/tenuo/temporal/_workflow.py
+++ b/tenuo-python/tenuo/temporal/_workflow.py
@@ -49,6 +49,48 @@ logger = logging.getLogger("tenuo.temporal")
 _MISSING_REVOCATION_LIST = object()
 
 
+def _srl_version(srl: Any) -> Optional[int]:
+    version = getattr(srl, "version", None)
+    if callable(version):
+        version = version()
+    if version is None:
+        return None
+    return int(version)
+
+
+def _srl_bytes(srl: Any) -> Optional[bytes]:
+    to_bytes = getattr(srl, "to_bytes", None)
+    if not callable(to_bytes):
+        return None
+    return bytes(to_bytes())
+
+
+def _ensure_srl_refresh_not_rolled_back(current: Any, candidate: Any) -> None:
+    current_version = _srl_version(current)
+    candidate_version = _srl_version(candidate)
+    if current_version is None or candidate_version is None:
+        return
+    if candidate_version < current_version:
+        raise TenuoContextError(
+            "revocation_list_provider returned an older SRL version during async "
+            f"completion (current={current_version}, attempted={candidate_version})."
+        )
+    if candidate_version == current_version:
+        current_bytes = _srl_bytes(current)
+        candidate_bytes = _srl_bytes(candidate)
+        if (
+            current_bytes is not None
+            and candidate_bytes is not None
+            and current_bytes != candidate_bytes
+        ):
+            raise TenuoContextError(
+                "revocation_list_provider returned a different SRL with the same "
+                f"version during async completion (version={candidate_version}). "
+                "Publish revocation-list updates with a monotonically increasing "
+                "version."
+            )
+
+
 def _fail_workflow_non_retryable(exc: Exception) -> Exception:
     """Wrap *exc* as a non-retryable ``ApplicationError``.
 
@@ -1240,6 +1282,15 @@ async def tenuo_complete_async_activity(
         _worker_config_count,
     )
 
+    if key_id is not None:
+        warnings.warn(
+            "key_id is ignored by tenuo_complete_async_activity() because "
+            "Temporal async-completion RPCs cannot carry a verifiable Tenuo "
+            "proof-of-possession signature.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if task_queue is None:
         worker_cfg = _get_only_worker_config()
         if worker_cfg is not None:
@@ -1337,6 +1388,14 @@ async def tenuo_complete_async_activity(
                     "retaining last good revocation list"
                 )
     with worker_cfg._provider_state_lock:
+        if (
+            refreshed_revocations is not _MISSING_REVOCATION_LIST
+            and worker_cfg._last_good_revocation_list is not None
+        ):
+            _ensure_srl_refresh_not_rolled_back(
+                worker_cfg._last_good_revocation_list,
+                refreshed_revocations,
+            )
         revocations = (
             refreshed_revocations
             if refreshed_revocations is not _MISSING_REVOCATION_LIST

--- a/tenuo-python/tenuo/temporal_plugin.py
+++ b/tenuo-python/tenuo/temporal_plugin.py
@@ -349,14 +349,15 @@ class TenuoTemporalPlugin(SimplePlugin):
         worker's signing key.
         """
         task_queue = _extract_task_queue(config)
-        if task_queue:
-            _set_worker_config(self._tenuo_config, task_queue=task_queue)
-        # Silently skip when no queue is discoverable (e.g. SDK plumbing
-        # that merges runner/interceptor config before the Worker has its
-        # task_queue set, or test fixtures that pass a bare ``{}``). The
-        # mint activity will fire a targeted ``TenuoContextError`` with
-        # remediation steps if delegation is attempted without a
-        # registration, so there's no silent-failure risk.
+        if task_queue is None:
+            raise ConfigurationError(
+                "TenuoTemporalPlugin.configure_worker requires a non-empty "
+                "task_queue in the Temporal Worker config. Construct Worker(..., "
+                "task_queue=<queue>) before plugin configuration; this queue is "
+                "required to route async completion and minting to the correct "
+                "TenuoPluginConfig."
+            )
+        _set_worker_config(self._tenuo_config, task_queue=task_queue)
         return super().configure_worker(config)
 
     def _preload_keys(self) -> None:

--- a/tenuo-python/tenuo/temporal_plugin.py
+++ b/tenuo-python/tenuo/temporal_plugin.py
@@ -265,7 +265,13 @@ class TenuoTemporalPlugin(SimplePlugin):
         """
         # Work on a copy so we never mutate the user's config object. This
         # isolates two workers that happen to share a ``TenuoPluginConfig``.
-        self._tenuo_config = dataclasses.replace(config)
+        self._tenuo_config = dataclasses.replace(config, _provider_snapshots_ready=True)
+        self._tenuo_config._last_good_trusted_roots = list(
+            config._last_good_trusted_roots
+        )
+        self._tenuo_config._last_good_revocation_list = (
+            config._last_good_revocation_list
+        )
         if self._tenuo_config.activity_fns is not None:
             self._tenuo_config.activity_fns = list(self._tenuo_config.activity_fns)
         # The activity registry is rebuilt from our copy; any later auto-discovery

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -890,6 +890,10 @@ class TestTenuoPluginConfig:
         assert ai._config._last_good_revocation_list is None, (
             "a failed refresh must not poison the last-good SRL snapshot"
         )
+        assert ai._last_srl_refresh > 0, (
+            "a failed refresh must still advance the interval so the provider "
+            "is not re-invoked on every subsequent activity"
+        )
 
     def test_retry_authorizer_selected_on_retry_attempt(self):
         """``_retry_authorizer`` must be used for ``info.attempt > 1``."""
@@ -2754,7 +2758,7 @@ async def test_async_completion_rejects_same_version_revocation_replacement():
     _set_worker_config(cfg, task_queue="async-completion-srl-same-version")
     handle = AsyncMock()
 
-    with pytest.raises(TenuoContextError, match="different SRL with the same version"):
+    with pytest.raises(TenuoContextError, match="different revoked set at the same SRL version"):
         await tenuo_complete_async_activity(
             handle,
             "result",
@@ -2766,6 +2770,53 @@ async def test_async_completion_rejects_same_version_revocation_replacement():
     assert calls == 2
     assert cfg._last_good_revocation_list is revoked_v2
     handle.complete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_completion_accepts_resigned_same_version_revocation_list():
+    from tenuo_core import SignedRevocationList, SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    root_key = SigningKey.generate()
+    warrant = Warrant.issue(
+        root_key,
+        capabilities={"external_job": {}},
+        holder=root_key.public_key,
+    )
+    first_builder = SignedRevocationList.builder()
+    first_builder.version(2)
+    first = first_builder.build(root_key)
+    resigned_builder = SignedRevocationList.builder()
+    resigned_builder.version(2)
+    resigned = resigned_builder.build(root_key)
+    assert first.to_bytes() != resigned.to_bytes()
+    calls = 0
+
+    def provider():
+        nonlocal calls
+        calls += 1
+        return first if calls == 1 else resigned
+
+    cfg = TenuoPluginConfig(
+        key_resolver=AsyncMock(),
+        trusted_roots=[root_key.public_key],
+        revocation_list_provider=provider,
+    )
+    _set_worker_config(cfg, task_queue="async-completion-srl-resign")
+    handle = AsyncMock()
+
+    await tenuo_complete_async_activity(
+        handle,
+        "result",
+        warrant,
+        "root-key",
+        task_queue="async-completion-srl-resign",
+    )
+
+    assert calls == 2
+    assert cfg._last_good_revocation_list is resigned
+    handle.complete.assert_awaited_once_with("result")
 
 
 @pytest.mark.asyncio

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -2223,7 +2223,10 @@ async def test_create_scheduled_workflow_carries_tenuo_headers_not_warrant_memo(
 
 
 @pytest.mark.asyncio
-async def test_scheduled_workflow_rejects_keyword_workflow_arguments():
+async def test_scheduled_workflow_preserves_deprecated_workflow_kwargs():
+    """Legacy workflow_kwargs are action options and remain compatible."""
+    from datetime import timedelta
+
     from temporalio.client import ScheduleSpec
     from tenuo_core import SigningKey, Warrant
     from tenuo.temporal import create_scheduled_workflow_with_warrant
@@ -2231,7 +2234,33 @@ async def test_scheduled_workflow_rejects_keyword_workflow_arguments():
     holder = SigningKey.generate()
     warrant = Warrant.issue(holder, capabilities={"x": {}}, holder=holder.public_key)
 
-    with pytest.raises(ValueError, match="positional"):
+    client = AsyncMock()
+    timeout = timedelta(minutes=5)
+    with pytest.warns(DeprecationWarning, match="action_options"):
+        await create_scheduled_workflow_with_warrant(
+            client,
+            "schedule-id",
+            "Workflow",
+            warrant,
+            "holder",
+            ScheduleSpec(),
+            workflow_kwargs={"execution_timeout": timeout},
+        )
+
+    schedule = client.create_schedule.await_args.args[1]
+    assert schedule.action.execution_timeout == timeout
+
+
+@pytest.mark.asyncio
+async def test_scheduled_workflow_rejects_managed_action_option_override():
+    from temporalio.client import ScheduleSpec
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import create_scheduled_workflow_with_warrant
+
+    holder = SigningKey.generate()
+    warrant = Warrant.issue(holder, capabilities={"x": {}}, holder=holder.public_key)
+
+    with pytest.raises(ValueError, match="helper-managed fields: task_queue"):
         await create_scheduled_workflow_with_warrant(
             AsyncMock(),
             "schedule-id",
@@ -2239,7 +2268,7 @@ async def test_scheduled_workflow_rejects_keyword_workflow_arguments():
             warrant,
             "holder",
             ScheduleSpec(),
-            workflow_kwargs={"unsupported": True},
+            action_options={"task_queue": "other"},
         )
 
 
@@ -2316,6 +2345,209 @@ async def test_async_activity_completion_rejects_wrong_holder_key():
         )
 
     handle.complete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_activity_completion_wraps_key_resolver_failure():
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    holder = SigningKey.generate()
+    warrant = Warrant.issue(
+        holder,
+        capabilities={"external_job": {}},
+        holder=holder.public_key,
+    )
+    resolver = AsyncMock()
+    resolver.resolve.side_effect = TimeoutError("resolver timed out")
+    _set_worker_config(
+        TenuoPluginConfig(
+            key_resolver=resolver,
+            trusted_roots=[holder.public_key],
+        ),
+        task_queue="async-completion-resolver-error",
+    )
+
+    with pytest.raises(TenuoContextError, match="key resolution failed") as exc_info:
+        await tenuo_complete_async_activity(
+            AsyncMock(),
+            "result",
+            warrant,
+            "holder-key",
+            task_queue="async-completion-resolver-error",
+        )
+
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_async_activity_completion_requires_chain_for_delegated_warrant():
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    root_key = SigningKey.generate()
+    leaf_key = SigningKey.generate()
+    root = Warrant.issue(
+        root_key,
+        capabilities={"external_job": {}},
+        holder=root_key.public_key,
+    )
+    leaf = root.attenuate(
+        signing_key=root_key,
+        holder=leaf_key.public_key,
+        capabilities={"external_job": {}},
+    )
+    resolver = AsyncMock()
+    resolver.resolve.return_value = leaf_key
+    _set_worker_config(
+        TenuoPluginConfig(
+            key_resolver=resolver,
+            trusted_roots=[root_key.public_key],
+        ),
+        task_queue="async-completion-delegated",
+    )
+    handle = AsyncMock()
+
+    with pytest.raises(TenuoContextError, match="explicit root-to-leaf"):
+        await tenuo_complete_async_activity(
+            handle,
+            "result",
+            leaf,
+            "leaf-key",
+            task_queue="async-completion-delegated",
+        )
+    handle.complete.assert_not_awaited()
+
+    await tenuo_complete_async_activity(
+        handle,
+        "result",
+        leaf,
+        "leaf-key",
+        task_queue="async-completion-delegated",
+        warrant_chain=[root, leaf],
+    )
+    handle.complete.assert_awaited_once_with("result")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_outcome", ["raises", "empty"])
+async def test_async_activity_completion_provider_failure_keeps_snapshot(
+    caplog, provider_outcome
+):
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    root_key = SigningKey.generate()
+    warrant = Warrant.issue(
+        root_key,
+        capabilities={"external_job": {}},
+        holder=root_key.public_key,
+    )
+    calls = 0
+
+    def provider():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return [root_key.public_key]
+        if provider_outcome == "raises":
+            raise TimeoutError("root provider timed out")
+        return None
+
+    resolver = AsyncMock()
+    resolver.resolve.return_value = root_key
+    _set_worker_config(
+        TenuoPluginConfig(
+            key_resolver=resolver,
+            trusted_roots_provider=provider,
+        ),
+        task_queue="async-completion-provider-fallback",
+    )
+    handle = AsyncMock()
+
+    await tenuo_complete_async_activity(
+        handle,
+        "result",
+        warrant,
+        "root-key",
+        task_queue="async-completion-provider-fallback",
+    )
+
+    handle.complete.assert_awaited_once_with("result")
+    assert "retaining configured roots" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_activity_completion_legacy_single_config_fallback():
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _clear_worker_config, _set_worker_config
+
+    _clear_worker_config()
+    root_key = SigningKey.generate()
+    warrant = Warrant.issue(
+        root_key,
+        capabilities={"external_job": {}},
+        holder=root_key.public_key,
+    )
+    resolver = AsyncMock()
+    resolver.resolve.return_value = root_key
+    _set_worker_config(
+        TenuoPluginConfig(
+            key_resolver=resolver,
+            trusted_roots=[root_key.public_key],
+        ),
+        task_queue="only-queue",
+    )
+    handle = AsyncMock()
+
+    try:
+        with pytest.warns(DeprecationWarning, match="Omitting task_queue"):
+            await tenuo_complete_async_activity(
+                handle,
+                "result",
+                warrant,
+                "root-key",
+            )
+    finally:
+        _clear_worker_config()
+
+    handle.complete.assert_awaited_once_with("result")
+
+
+@pytest.mark.asyncio
+async def test_async_activity_completion_legacy_fallback_rejects_multiple_configs():
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _clear_worker_config, _set_worker_config
+
+    _clear_worker_config()
+    root_key = SigningKey.generate()
+    warrant = Warrant.issue(
+        root_key,
+        capabilities={"external_job": {}},
+        holder=root_key.public_key,
+    )
+    config = TenuoPluginConfig(
+        key_resolver=AsyncMock(),
+        trusted_roots=[root_key.public_key],
+    )
+    _set_worker_config(config, task_queue="queue-a")
+    _set_worker_config(config, task_queue="queue-b")
+
+    try:
+        with pytest.raises(TenuoContextError, match="no TenuoPluginConfig"):
+            await tenuo_complete_async_activity(
+                AsyncMock(),
+                "result",
+                warrant,
+                "root-key",
+            )
+    finally:
+        _clear_worker_config()
 
 
 @pytest.mark.asyncio

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -19,6 +19,7 @@ import pytest
 pytest.importorskip("temporalio")
 
 from tenuo.temporal._constants import (  # noqa: E402 - must be after importorskip
+    TENUO_CHAIN_HEADER,
     TENUO_COMPRESSED_HEADER,
     TENUO_KEY_ID_HEADER,
     TENUO_POP_HEADER,
@@ -2188,6 +2189,7 @@ async def test_create_scheduled_workflow_carries_tenuo_headers_not_warrant_memo(
     from datetime import timedelta
 
     from temporalio.client import ScheduleIntervalSpec, ScheduleSpec
+    from temporalio.converter import DataConverter
     from tenuo_core import SigningKey, Warrant
     from tenuo.temporal import create_scheduled_workflow_with_warrant
 
@@ -2197,8 +2199,10 @@ async def test_create_scheduled_workflow_carries_tenuo_headers_not_warrant_memo(
         capabilities={"read_file": {}},
         holder=holder.public_key,
     )
-    client = AsyncMock()
-    client.create_schedule.return_value = "schedule-handle"
+    client = MagicMock()
+    client.data_converter = DataConverter.default
+    client.namespace = "default"
+    client.create_schedule = AsyncMock(return_value="schedule-handle")
 
     result = await create_scheduled_workflow_with_warrant(
         client,
@@ -2220,6 +2224,14 @@ async def test_create_scheduled_workflow_carries_tenuo_headers_not_warrant_memo(
     assert schedule.action.memo == {"purpose": "nightly report"}
     assert "tenuo_warrant" not in schedule.action.memo
     assert schedule.action.args
+
+    # Assert the SDK's wire conversion, not only the local dataclass. A dead
+    # or renamed attribute would otherwise make this test pass while dropping
+    # authorization headers from the actual Schedule RPC.
+    wire_action = await schedule.action._to_proto(client)
+    start = wire_action.start_workflow
+    assert start.header.fields[TENUO_KEY_ID_HEADER].data == b"report-agent"
+    assert TENUO_WARRANT_HEADER in start.header.fields
 
 
 @pytest.mark.asyncio
@@ -2278,7 +2290,7 @@ async def test_scheduled_workflow_rejects_managed_action_option_override():
 
 
 @pytest.mark.asyncio
-async def test_async_activity_completion_validates_chain_and_holder_key():
+async def test_async_activity_completion_validates_chain_without_loading_private_key():
     from tenuo_core import SigningKey, Warrant
     from tenuo.temporal import tenuo_complete_async_activity
     from tenuo.temporal._state import _set_worker_config
@@ -2309,47 +2321,64 @@ async def test_async_activity_completion_validates_chain_and_holder_key():
     )
 
     handle.complete.assert_awaited_once_with({"status": "done"})
+    resolver.resolve.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_async_activity_completion_rejects_wrong_holder_key():
+async def test_async_activity_completion_rejects_expired_warrant(monkeypatch):
+    import time
+
+    import tenuo_core
     from tenuo_core import SigningKey, Warrant
     from tenuo.temporal import tenuo_complete_async_activity
     from tenuo.temporal._state import _set_worker_config
 
     holder = SigningKey.generate()
-    wrong_holder = SigningKey.generate()
     warrant = Warrant.issue(
         holder,
         capabilities={"external_job": {}},
         holder=holder.public_key,
+        ttl_seconds=0,
     )
+    # Make the test deterministic and fast while still exercising the core
+    # Authorizer expiry path used by the helper.
+    real_authorizer = tenuo_core.Authorizer
+    monkeypatch.setattr(
+        tenuo_core,
+        "Authorizer",
+        lambda *, trusted_roots, **kwargs: real_authorizer(
+            trusted_roots=trusted_roots,
+            clock_tolerance_secs=0,
+            **kwargs,
+        ),
+    )
+    time.sleep(1.01)
+
     resolver = AsyncMock()
-    resolver.resolve.return_value = wrong_holder
+    resolver.resolve.return_value = holder
     _set_worker_config(
         TenuoPluginConfig(
             key_resolver=resolver,
             trusted_roots=[holder.public_key],
         ),
-        task_queue="async-completion-wrong-holder",
+        task_queue="async-completion-expired",
     )
     handle = AsyncMock()
 
-    with pytest.raises(TenuoContextError, match="warrant holder"):
+    with pytest.raises(TenuoContextError, match="expired"):
         await tenuo_complete_async_activity(
             handle,
             "result",
             warrant,
-            "wrong-key",
-            task_queue="async-completion-wrong-holder",
+            "holder-key",
+            task_queue="async-completion-expired",
         )
-
     handle.complete.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_async_activity_completion_wraps_key_resolver_failure():
-    from tenuo_core import SigningKey, Warrant
+async def test_async_activity_completion_rejects_revoked_warrant():
+    from tenuo_core import SignedRevocationList, SigningKey, Warrant
     from tenuo.temporal import tenuo_complete_async_activity
     from tenuo.temporal._state import _set_worker_config
 
@@ -2359,26 +2388,32 @@ async def test_async_activity_completion_wraps_key_resolver_failure():
         capabilities={"external_job": {}},
         holder=holder.public_key,
     )
+    builder = SignedRevocationList.builder()
+    builder.revoke(warrant.id)
+    revocations = builder.build(holder)
+    assert revocations.is_revoked(warrant.id)
+
     resolver = AsyncMock()
-    resolver.resolve.side_effect = TimeoutError("resolver timed out")
+    resolver.resolve.return_value = holder
     _set_worker_config(
         TenuoPluginConfig(
             key_resolver=resolver,
             trusted_roots=[holder.public_key],
+            revocation_list=revocations,
         ),
-        task_queue="async-completion-resolver-error",
+        task_queue="async-completion-revoked",
     )
+    handle = AsyncMock()
 
-    with pytest.raises(TenuoContextError, match="key resolution failed") as exc_info:
+    with pytest.raises(TenuoContextError, match="revoked"):
         await tenuo_complete_async_activity(
-            AsyncMock(),
+            handle,
             "result",
             warrant,
             "holder-key",
-            task_queue="async-completion-resolver-error",
+            task_queue="async-completion-revoked",
         )
-
-    assert isinstance(exc_info.value.__cause__, TimeoutError)
+    handle.complete.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -2584,7 +2619,7 @@ async def test_async_activity_completion_legacy_fallback_rejects_multiple_config
     _set_worker_config(config, task_queue="queue-b")
 
     try:
-        with pytest.raises(TenuoContextError, match="no TenuoPluginConfig"):
+        with pytest.raises(TenuoContextError, match="2 worker configs are registered"):
             await tenuo_complete_async_activity(
                 AsyncMock(),
                 "result",
@@ -2596,43 +2631,103 @@ async def test_async_activity_completion_legacy_fallback_rejects_multiple_config
 
 
 @pytest.mark.asyncio
-async def test_per_activity_warrant_override_is_task_local_and_cleared():
+async def test_per_activity_override_reaches_interceptor_and_extends_chain():
+    """The wrapper must drive the real outbound header and PoP branch."""
+    from types import SimpleNamespace
+
     from temporalio import workflow
-    from tenuo_core import SigningKey, Warrant
+    from tenuo_core import SigningKey, Warrant, decode_warrant_stack_base64
     from tenuo.temporal import tenuo_execute_activity
-    from tenuo.temporal._state import _activity_warrant_override
+    from tenuo.temporal._headers import _extract_warrant_from_headers
+    from tenuo.temporal._interceptors import _TenuoWorkflowOutboundInterceptor
+    from tenuo.temporal._state import (
+        _activity_warrant_override,
+        _store_lock,
+        _workflow_headers_store,
+    )
 
     holder = SigningKey.generate()
-    warrant = Warrant.issue(
+    base_warrant = Warrant.issue(
         holder,
         capabilities={"read_file": {}},
         holder=holder.public_key,
     )
-    seen_headers = None
+    dispatch_warrant = base_warrant.attenuate(
+        signing_key=holder,
+        holder=holder.public_key,
+        capabilities={"read_file": {}},
+    )
 
-    async def capture_dispatch(*_args, **_kwargs):
-        nonlocal seen_headers
-        seen_headers = _activity_warrant_override.get()
-        return "ok"
+    resolver = MagicMock()
+    resolver.resolve_sync.return_value = holder
+    config = TenuoPluginConfig(
+        key_resolver=resolver,
+        trusted_roots=[holder.public_key],
+    )
+    next_interceptor = MagicMock()
+    next_interceptor.start_activity.side_effect = lambda value: value
+    outbound = _TenuoWorkflowOutboundInterceptor(next_interceptor, config)
 
-    info = MagicMock(run_id="run-per-dispatch", workflow_id="wf-per-dispatch")
-    with (
-        patch.object(workflow, "info", return_value=info),
-        patch.object(workflow, "execute_activity", side_effect=capture_dispatch),
-    ):
-        result = await tenuo_execute_activity(
-            "read_file",
-            args=["/data/report.txt"],
-            warrant=warrant,
-            key_id="holder-key",
-            warrant_chain=[warrant],
-            start_to_close_timeout=1,
+    def read_file(path):
+        return path
+
+    async def execute_through_outbound(activity, **kwargs):
+        outbound_input = SimpleNamespace(
+            fn=activity,
+            activity="read_file",
+            args=tuple(kwargs["args"]),
+            headers={},
         )
+        return outbound.start_activity(outbound_input)
 
-    assert result == "ok"
-    assert seen_headers is not None
-    assert seen_headers[TENUO_KEY_ID_HEADER] == b"holder-key"
-    assert TENUO_WARRANT_HEADER in seen_headers
+    base_headers = tenuo_headers(base_warrant, "holder-key")
+    info = MagicMock(
+        run_id="run-per-dispatch",
+        workflow_id="wf-per-dispatch",
+        headers=base_headers,
+    )
+    with _store_lock:
+        _workflow_headers_store[info.run_id] = base_headers
+    try:
+        with (
+            patch.object(workflow, "info", return_value=info),
+            patch.object(
+                workflow,
+                "now",
+                return_value=datetime.now(timezone.utc),
+            ),
+            patch.object(
+                workflow,
+                "execute_activity",
+                side_effect=execute_through_outbound,
+            ),
+        ):
+            result = await tenuo_execute_activity(
+                read_file,
+                args=["/data/report.txt"],
+                warrant=dispatch_warrant,
+                key_id="holder-key",
+                start_to_close_timeout=1,
+            )
+    finally:
+        with _store_lock:
+            _workflow_headers_store.pop(info.run_id, None)
+
+    raw_headers = {
+        name: payload.data for name, payload in result.headers.items()
+    }
+    sent_warrant = _extract_warrant_from_headers(raw_headers)
+    sent_chain = decode_warrant_stack_base64(
+        raw_headers[TENUO_CHAIN_HEADER].decode("utf-8")
+    )
+
+    assert sent_warrant.to_bytes() == dispatch_warrant.to_bytes()
+    assert [item.to_bytes() for item in sent_chain] == [
+        base_warrant.to_bytes(),
+        dispatch_warrant.to_bytes(),
+    ]
+    assert TENUO_POP_HEADER in result.headers
+    resolver.resolve_sync.assert_called_once_with("holder-key")
     assert _activity_warrant_override.get() is None
 
 

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -30,6 +30,7 @@ from tenuo.temporal.exceptions import (  # noqa: E402
     LocalActivityError,
     PopVerificationError,
     TemporalConstraintViolation,
+    TenuoContextError,
     WarrantExpired,
 )
 from tenuo.temporal._resolvers import EnvKeyResolver, KeyResolver  # noqa: E402
@@ -2181,11 +2182,65 @@ def test_tenuo_continue_as_new_in_all():
     assert callable(tenuo_continue_as_new)
 
 
-def test_create_scheduled_workflow_with_warrant_exists():
-    """Verify the scheduled workflow helper is exported."""
-    from tenuo.temporal._workflow import create_scheduled_workflow_with_warrant
-    import inspect
-    assert inspect.iscoroutinefunction(create_scheduled_workflow_with_warrant)
+@pytest.mark.asyncio
+async def test_create_scheduled_workflow_carries_tenuo_headers_not_warrant_memo():
+    """Scheduled starts must use workflow headers, which the worker reads."""
+    from datetime import timedelta
+
+    from temporalio.client import ScheduleIntervalSpec, ScheduleSpec
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import create_scheduled_workflow_with_warrant
+
+    holder = SigningKey.generate()
+    warrant = Warrant.issue(
+        holder,
+        capabilities={"read_file": {}},
+        holder=holder.public_key,
+    )
+    client = AsyncMock()
+    client.create_schedule.return_value = "schedule-handle"
+
+    result = await create_scheduled_workflow_with_warrant(
+        client,
+        "nightly-report",
+        "ReportWorkflow",
+        warrant,
+        "report-agent",
+        ScheduleSpec(
+            intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]
+        ),
+        workflow_args=["tenant-a"],
+        memo={"purpose": "nightly report"},
+    )
+
+    assert result == "schedule-handle"
+    schedule = client.create_schedule.await_args.args[1]
+    assert schedule.action.headers[TENUO_KEY_ID_HEADER].data == b"report-agent"
+    assert TENUO_WARRANT_HEADER in schedule.action.headers
+    assert schedule.action.memo == {"purpose": "nightly report"}
+    assert "tenuo_warrant" not in schedule.action.memo
+    assert schedule.action.args
+
+
+@pytest.mark.asyncio
+async def test_scheduled_workflow_rejects_keyword_workflow_arguments():
+    from temporalio.client import ScheduleSpec
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import create_scheduled_workflow_with_warrant
+
+    holder = SigningKey.generate()
+    warrant = Warrant.issue(holder, capabilities={"x": {}}, holder=holder.public_key)
+
+    with pytest.raises(ValueError, match="positional"):
+        await create_scheduled_workflow_with_warrant(
+            AsyncMock(),
+            "schedule-id",
+            "Workflow",
+            warrant,
+            "holder",
+            ScheduleSpec(),
+            workflow_kwargs={"unsupported": True},
+        )
 
 
 # =============================================================================
@@ -2193,11 +2248,115 @@ def test_create_scheduled_workflow_with_warrant_exists():
 # =============================================================================
 
 
-def test_tenuo_complete_async_activity_exists():
-    """Verify the async activity completion wrapper is exported."""
-    from tenuo.temporal._workflow import tenuo_complete_async_activity
-    import inspect
-    assert inspect.iscoroutinefunction(tenuo_complete_async_activity)
+@pytest.mark.asyncio
+async def test_async_activity_completion_validates_chain_and_holder_key():
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    holder = SigningKey.generate()
+    warrant = Warrant.issue(
+        holder,
+        capabilities={"external_job": {}},
+        holder=holder.public_key,
+    )
+    resolver = AsyncMock()
+    resolver.resolve.return_value = holder
+    _set_worker_config(
+        TenuoPluginConfig(
+            key_resolver=resolver,
+            trusted_roots=[holder.public_key],
+        ),
+        task_queue="async-completion-valid",
+    )
+    handle = AsyncMock()
+
+    await tenuo_complete_async_activity(
+        handle,
+        {"status": "done"},
+        warrant,
+        "holder-key",
+        task_queue="async-completion-valid",
+    )
+
+    handle.complete.assert_awaited_once_with({"status": "done"})
+
+
+@pytest.mark.asyncio
+async def test_async_activity_completion_rejects_wrong_holder_key():
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    holder = SigningKey.generate()
+    wrong_holder = SigningKey.generate()
+    warrant = Warrant.issue(
+        holder,
+        capabilities={"external_job": {}},
+        holder=holder.public_key,
+    )
+    resolver = AsyncMock()
+    resolver.resolve.return_value = wrong_holder
+    _set_worker_config(
+        TenuoPluginConfig(
+            key_resolver=resolver,
+            trusted_roots=[holder.public_key],
+        ),
+        task_queue="async-completion-wrong-holder",
+    )
+    handle = AsyncMock()
+
+    with pytest.raises(TenuoContextError, match="warrant holder"):
+        await tenuo_complete_async_activity(
+            handle,
+            "result",
+            warrant,
+            "wrong-key",
+            task_queue="async-completion-wrong-holder",
+        )
+
+    handle.complete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_per_activity_warrant_override_is_task_local_and_cleared():
+    from temporalio import workflow
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import tenuo_execute_activity
+    from tenuo.temporal._state import _activity_warrant_override
+
+    holder = SigningKey.generate()
+    warrant = Warrant.issue(
+        holder,
+        capabilities={"read_file": {}},
+        holder=holder.public_key,
+    )
+    seen_headers = None
+
+    async def capture_dispatch(*_args, **_kwargs):
+        nonlocal seen_headers
+        seen_headers = _activity_warrant_override.get()
+        return "ok"
+
+    info = MagicMock(run_id="run-per-dispatch", workflow_id="wf-per-dispatch")
+    with (
+        patch.object(workflow, "info", return_value=info),
+        patch.object(workflow, "execute_activity", side_effect=capture_dispatch),
+    ):
+        result = await tenuo_execute_activity(
+            "read_file",
+            args=["/data/report.txt"],
+            warrant=warrant,
+            key_id="holder-key",
+            warrant_chain=[warrant],
+            start_to_close_timeout=1,
+        )
+
+    assert result == "ok"
+    assert seen_headers is not None
+    assert seen_headers[TENUO_KEY_ID_HEADER] == b"holder-key"
+    assert TENUO_WARRANT_HEADER in seen_headers
+    assert _activity_warrant_override.get() is None
 
 
 # =============================================================================

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -861,11 +861,19 @@ class TestTenuoPluginConfig:
 
         root = SigningKey.generate().public_key
         srl_value = {"revoked": ["warrant-xyz"]}
+        provider_calls = 0
+
+        def provider():
+            nonlocal provider_calls
+            provider_calls += 1
+            if provider_calls == 1:
+                return None
+            return srl_value
 
         cfg = TenuoPluginConfig(
             key_resolver=EnvKeyResolver(),
             trusted_roots=[root],
-            revocation_list_provider=lambda: srl_value,
+            revocation_list_provider=provider,
             revocation_refresh_secs=1.0,
         )
         ai = TenuoActivityInboundInterceptor(
@@ -876,9 +884,11 @@ class TestTenuoPluginConfig:
         ai._maybe_refresh_revocation_list()
 
         assert ai._authorizer.srl_attempts == 1
-        assert ai._config.revocation_list == srl_value, (
-            "config.revocation_list should be updated even if the Authorizer "
-            "call failed — the next refresh tick must be able to retry."
+        assert ai._config.revocation_list is None, (
+            "provider-backed SRLs must not be copied into the static config field"
+        )
+        assert ai._config._last_good_revocation_list is None, (
+            "a failed refresh must not poison the last-good SRL snapshot"
         )
 
     def test_retry_authorizer_selected_on_retry_attempt(self):
@@ -2512,7 +2522,7 @@ async def test_async_activity_completion_provider_failure_keeps_snapshot(
     )
 
     handle.complete.assert_awaited_once_with("result")
-    assert "retaining configured roots" in caplog.text
+    assert "retaining last good roots" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -2531,7 +2541,13 @@ async def test_async_activity_completion_revocation_provider_failure_falls_back(
         holder=root_key.public_key,
     )
 
+    calls = 0
+
     def provider():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return None
         if provider_outcome == "raises":
             raise TimeoutError("revocation provider timed out")
         return None
@@ -2557,7 +2573,103 @@ async def test_async_activity_completion_revocation_provider_failure_falls_back(
     )
 
     handle.complete.assert_awaited_once_with("result")
-    assert "retaining configured revocation list" in caplog.text
+    assert "retaining last good revocation list" in caplog.text
+
+
+def test_revocation_provider_installs_startup_snapshot():
+    from tenuo_core import SignedRevocationList, SigningKey, Warrant
+    from tenuo.temporal._interceptors import TenuoActivityInboundInterceptor
+
+    root_key = SigningKey.generate()
+    warrant = Warrant.issue(
+        root_key,
+        capabilities={"read_file": {}},
+        holder=root_key.public_key,
+    )
+    builder = SignedRevocationList.builder()
+    builder.revoke(warrant.id)
+    builder.version(1)
+    revocations = builder.build(root_key)
+    calls = 0
+
+    def provider():
+        nonlocal calls
+        calls += 1
+        return revocations
+
+    resolver = AsyncMock()
+    resolver.resolve.return_value = root_key
+    cfg = TenuoPluginConfig(
+        key_resolver=resolver,
+        trusted_roots=[root_key.public_key],
+        revocation_list_provider=provider,
+    )
+    ai = TenuoActivityInboundInterceptor(MagicMock(), cfg, "test")
+
+    assert calls == 1
+    with pytest.raises(Exception, match="revoked"):
+        ai._authorizer.verify_chain([warrant])
+
+
+@pytest.mark.asyncio
+async def test_async_completion_provider_failure_uses_last_good_revocation_snapshot():
+    from tenuo_core import SignedRevocationList, SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    root_key = SigningKey.generate()
+    warrant = Warrant.issue(
+        root_key,
+        capabilities={"external_job": {}},
+        holder=root_key.public_key,
+    )
+    empty_builder = SignedRevocationList.builder()
+    empty_builder.version(1)
+    srl_v1 = empty_builder.build(root_key)
+    revoked_builder = SignedRevocationList.builder()
+    revoked_builder.revoke(warrant.id)
+    revoked_builder.version(2)
+    srl_v2 = revoked_builder.build(root_key)
+    calls = 0
+
+    def provider():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return srl_v1
+        if calls == 2:
+            return srl_v2
+        raise TimeoutError("revocation provider timed out")
+
+    resolver = AsyncMock()
+    resolver.resolve.return_value = root_key
+    cfg = TenuoPluginConfig(
+        key_resolver=resolver,
+        trusted_roots=[root_key.public_key],
+        revocation_list_provider=provider,
+    )
+    _set_worker_config(cfg, task_queue="async-completion-last-good-srl")
+    handle = AsyncMock()
+
+    with pytest.raises(TenuoContextError, match="revoked"):
+        await tenuo_complete_async_activity(
+            handle,
+            "result",
+            warrant,
+            "root-key",
+            task_queue="async-completion-last-good-srl",
+        )
+    with pytest.raises(TenuoContextError, match="revoked"):
+        await tenuo_complete_async_activity(
+            handle,
+            "result",
+            warrant,
+            "root-key",
+            task_queue="async-completion-last-good-srl",
+        )
+
+    assert calls == 3
+    handle.complete.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -2729,6 +2841,96 @@ async def test_per_activity_override_reaches_interceptor_and_extends_chain():
     assert TENUO_POP_HEADER in result.headers
     resolver.resolve_sync.assert_called_once_with("holder-key")
     assert _activity_warrant_override.get() is None
+
+
+@pytest.mark.asyncio
+async def test_activity_ingress_rejects_mismatched_warrant_and_chain_leaf():
+    """Raw headers must not let a shallow warrant mask a deeper chain."""
+    import time as _time
+    from dataclasses import dataclass
+
+    from temporalio.exceptions import ApplicationError
+    from tenuo_core import SigningKey, Warrant, encode_warrant_stack
+    from tenuo.temporal._interceptors import TenuoWorkerInterceptor
+    from tenuo.temporal._resolvers import KeyResolver
+
+    @dataclass
+    class FakePayload:
+        data: bytes
+
+    class StaticResolver(KeyResolver):
+        def __init__(self, key):
+            self._key = key
+
+        async def resolve(self, key_id):  # noqa: ARG002
+            return self._key
+
+        def resolve_sync(self, key_id):  # noqa: ARG002
+            return self._key
+
+    root_key = SigningKey.generate()
+    mid_key = SigningKey.generate()
+    leaf_key = SigningKey.generate()
+    root = Warrant.issue(
+        root_key,
+        capabilities={"read_file": {}},
+        holder=mid_key.public_key,
+    )
+    child = root.attenuate(
+        signing_key=mid_key,
+        holder=leaf_key.public_key,
+        capabilities={"read_file": {}},
+    )
+    grandchild = child.attenuate(
+        signing_key=leaf_key,
+        holder=leaf_key.public_key,
+        capabilities={"read_file": {}},
+    )
+    assert root.depth == 0
+    assert grandchild.depth >= 2
+
+    raw = tenuo_headers(root, "leaf-key")
+    raw[TENUO_CHAIN_HEADER] = encode_warrant_stack([root, child, grandchild]).encode("utf-8")
+    pop = grandchild.sign(
+        leaf_key,
+        "read_file",
+        {"path": "/tmp/demo/f.txt"},
+        int(_time.time()),
+    )
+    raw[TENUO_POP_HEADER] = base64.b64encode(bytes(pop))
+
+    cfg = TenuoPluginConfig(
+        key_resolver=StaticResolver(leaf_key),
+        trusted_roots=[root_key.public_key],
+        max_chain_depth=1,
+        on_denial="raise",
+    )
+    nxt = MagicMock()
+    nxt.execute_activity = AsyncMock(return_value="ALLOWED")
+    ti = TenuoWorkerInterceptor(cfg)
+    inbound = ti.intercept_activity(nxt)
+    info = MagicMock(
+        activity_type="read_file",
+        activity_id="1",
+        workflow_id="wf-mismatch",
+        workflow_run_id="run-mismatch",
+        workflow_type="W",
+        task_queue="q",
+        is_local=False,
+        attempt=1,
+    )
+    inp = MagicMock()
+    inp.fn = lambda path: path
+    inp.args = ("/tmp/demo/f.txt",)
+    inp.headers = {k: FakePayload(v) for k, v in raw.items()}
+
+    with patch("temporalio.activity.info", return_value=info):
+        with pytest.raises(ApplicationError) as exc_info:
+            await inbound.execute_activity(inp)
+
+    assert exc_info.value.non_retryable is True
+    assert exc_info.value.type == "CHAIN_INVALID"
+    nxt.execute_activity.assert_not_awaited()
 
 
 # =============================================================================

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -2481,6 +2481,51 @@ async def test_async_activity_completion_provider_failure_keeps_snapshot(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("provider_outcome", ["raises", "none"])
+async def test_async_activity_completion_revocation_provider_failure_falls_back(
+    caplog, provider_outcome
+):
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    root_key = SigningKey.generate()
+    warrant = Warrant.issue(
+        root_key,
+        capabilities={"external_job": {}},
+        holder=root_key.public_key,
+    )
+
+    def provider():
+        if provider_outcome == "raises":
+            raise TimeoutError("revocation provider timed out")
+        return None
+
+    resolver = AsyncMock()
+    resolver.resolve.return_value = root_key
+    _set_worker_config(
+        TenuoPluginConfig(
+            key_resolver=resolver,
+            trusted_roots=[root_key.public_key],
+            revocation_list_provider=provider,
+        ),
+        task_queue="async-completion-revocation-fallback",
+    )
+    handle = AsyncMock()
+
+    await tenuo_complete_async_activity(
+        handle,
+        "result",
+        warrant,
+        "root-key",
+        task_queue="async-completion-revocation-fallback",
+    )
+
+    handle.complete.assert_awaited_once_with("result")
+    assert "retaining configured revocation list" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_async_activity_completion_legacy_single_config_fallback():
     from tenuo_core import SigningKey, Warrant
     from tenuo.temporal import tenuo_complete_async_activity

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -2673,6 +2673,135 @@ async def test_async_completion_provider_failure_uses_last_good_revocation_snaps
 
 
 @pytest.mark.asyncio
+async def test_async_completion_rejects_revocation_provider_version_rollback():
+    from tenuo_core import SignedRevocationList, SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    root_key = SigningKey.generate()
+    warrant = Warrant.issue(
+        root_key,
+        capabilities={"external_job": {}},
+        holder=root_key.public_key,
+    )
+    empty_builder = SignedRevocationList.builder()
+    empty_builder.version(1)
+    empty_v1 = empty_builder.build(root_key)
+    revoked_builder = SignedRevocationList.builder()
+    revoked_builder.revoke(warrant.id)
+    revoked_builder.version(2)
+    revoked_v2 = revoked_builder.build(root_key)
+    calls = 0
+
+    def provider():
+        nonlocal calls
+        calls += 1
+        return revoked_v2 if calls == 1 else empty_v1
+
+    cfg = TenuoPluginConfig(
+        key_resolver=AsyncMock(),
+        trusted_roots=[root_key.public_key],
+        revocation_list_provider=provider,
+    )
+    _set_worker_config(cfg, task_queue="async-completion-srl-rollback")
+    handle = AsyncMock()
+
+    with pytest.raises(TenuoContextError, match="older SRL version"):
+        await tenuo_complete_async_activity(
+            handle,
+            "result",
+            warrant,
+            "root-key",
+            task_queue="async-completion-srl-rollback",
+        )
+
+    assert calls == 2
+    assert cfg._last_good_revocation_list is revoked_v2
+    handle.complete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_completion_rejects_same_version_revocation_replacement():
+    from tenuo_core import SignedRevocationList, SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    root_key = SigningKey.generate()
+    warrant = Warrant.issue(
+        root_key,
+        capabilities={"external_job": {}},
+        holder=root_key.public_key,
+    )
+    empty_builder = SignedRevocationList.builder()
+    empty_builder.version(2)
+    empty_v2 = empty_builder.build(root_key)
+    revoked_builder = SignedRevocationList.builder()
+    revoked_builder.revoke(warrant.id)
+    revoked_builder.version(2)
+    revoked_v2 = revoked_builder.build(root_key)
+    calls = 0
+
+    def provider():
+        nonlocal calls
+        calls += 1
+        return revoked_v2 if calls == 1 else empty_v2
+
+    cfg = TenuoPluginConfig(
+        key_resolver=AsyncMock(),
+        trusted_roots=[root_key.public_key],
+        revocation_list_provider=provider,
+    )
+    _set_worker_config(cfg, task_queue="async-completion-srl-same-version")
+    handle = AsyncMock()
+
+    with pytest.raises(TenuoContextError, match="different SRL with the same version"):
+        await tenuo_complete_async_activity(
+            handle,
+            "result",
+            warrant,
+            "root-key",
+            task_queue="async-completion-srl-same-version",
+        )
+
+    assert calls == 2
+    assert cfg._last_good_revocation_list is revoked_v2
+    handle.complete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_completion_warns_when_key_id_is_passed():
+    from tenuo_core import SigningKey, Warrant
+    from tenuo.temporal import tenuo_complete_async_activity
+    from tenuo.temporal._state import _set_worker_config
+
+    root_key = SigningKey.generate()
+    warrant = Warrant.issue(
+        root_key,
+        capabilities={"external_job": {}},
+        holder=root_key.public_key,
+    )
+    _set_worker_config(
+        TenuoPluginConfig(
+            key_resolver=AsyncMock(),
+            trusted_roots=[root_key.public_key],
+        ),
+        task_queue="async-completion-key-id-warning",
+    )
+    handle = AsyncMock()
+
+    with pytest.warns(DeprecationWarning, match="key_id is ignored"):
+        await tenuo_complete_async_activity(
+            handle,
+            "result",
+            warrant,
+            "root-key",
+            task_queue="async-completion-key-id-warning",
+        )
+
+    handle.complete.assert_awaited_once_with("result")
+
+
+@pytest.mark.asyncio
 async def test_async_activity_completion_legacy_single_config_fallback():
     from tenuo_core import SigningKey, Warrant
     from tenuo.temporal import tenuo_complete_async_activity

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -492,6 +492,43 @@ def test_revocation_list_provider_accepted() -> None:
     assert config.revocation_refresh_secs == 60
 
 
+def test_config_private_provider_state_is_excluded_from_equality() -> None:
+    """Provider caches and locks must not make identical configs compare unequal."""
+    sk = SigningKey.generate()
+    resolver = EnvKeyResolver()
+
+    config_a = TenuoPluginConfig(
+        key_resolver=resolver,
+        trusted_roots=[sk.public_key],
+    )
+    config_b = TenuoPluginConfig(
+        key_resolver=resolver,
+        trusted_roots=[sk.public_key],
+    )
+
+    assert config_a == config_b
+
+
+def test_revocation_list_provider_startup_failure_is_configuration_error() -> None:
+    """Startup SRL provider failures fail closed with remediation text."""
+    from tenuo.exceptions import ConfigurationError
+
+    sk = SigningKey.generate()
+
+    def provider():
+        raise TimeoutError("srl endpoint timed out")
+
+    with pytest.raises(ConfigurationError, match="failed during startup") as exc_info:
+        TenuoPluginConfig(
+            key_resolver=EnvKeyResolver(),
+            trusted_roots=[sk.public_key],
+            revocation_list_provider=provider,
+        )
+
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+    assert "worker accepts work" in str(exc_info.value)
+
+
 def test_revocation_list_provider_excludes_static_revocation_list() -> None:
     """Static and provider-backed SRLs cannot both own revocation state."""
     from tenuo.exceptions import ConfigurationError

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -492,6 +492,33 @@ def test_revocation_list_provider_accepted() -> None:
     assert config.revocation_refresh_secs == 60
 
 
+def test_revocation_list_provider_excludes_static_revocation_list() -> None:
+    """Static and provider-backed SRLs cannot both own revocation state."""
+    from tenuo.exceptions import ConfigurationError
+
+    sk = SigningKey.generate()
+    with pytest.raises(ConfigurationError, match="revocation_list_provider"):
+        TenuoPluginConfig(
+            signing_key=sk,
+            trusted_roots=[sk.public_key],
+            revocation_list=object(),
+            revocation_list_provider=lambda: None,
+        )
+
+
+def test_revocation_refresh_secs_requires_provider() -> None:
+    """A refresh interval without a provider is a configuration error."""
+    from tenuo.exceptions import ConfigurationError
+
+    sk = SigningKey.generate()
+    with pytest.raises(ConfigurationError, match="revocation_refresh_secs"):
+        TenuoPluginConfig(
+            signing_key=sk,
+            trusted_roots=[sk.public_key],
+            revocation_refresh_secs=60,
+        )
+
+
 def test_revocation_refresh_secs_none_by_default() -> None:
     """revocation_refresh_secs defaults to None."""
     sk = SigningKey.generate()

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -509,6 +509,29 @@ def test_config_private_provider_state_is_excluded_from_equality() -> None:
     assert config_a == config_b
 
 
+def test_plugin_copy_does_not_refetch_revocation_provider() -> None:
+    """Worker plugin copies must inherit last-good SRL state, not re-fetch."""
+    from tenuo.temporal_plugin import TenuoTemporalPlugin
+
+    sk = SigningKey.generate()
+    calls = 0
+
+    def provider():
+        nonlocal calls
+        calls += 1
+        return None
+
+    config = TenuoPluginConfig(
+        key_resolver=EnvKeyResolver(),
+        trusted_roots=[sk.public_key],
+        revocation_list_provider=provider,
+    )
+    assert calls == 1
+    TenuoTemporalPlugin(config)
+    assert calls == 1
+    assert config._last_good_revocation_list is None
+
+
 def test_revocation_list_provider_startup_failure_is_configuration_error() -> None:
     """Startup SRL provider failures fail closed with remediation text."""
     from tenuo.exceptions import ConfigurationError

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -532,6 +532,27 @@ def test_plugin_copy_does_not_refetch_revocation_provider() -> None:
     assert config._last_good_revocation_list is None
 
 
+def test_plugin_copy_does_not_refetch_trusted_roots_provider() -> None:
+    """Worker plugin copies must not re-call trusted_roots_provider."""
+    from tenuo.temporal_plugin import TenuoTemporalPlugin
+
+    sk = SigningKey.generate()
+    calls = 0
+
+    def provider():
+        nonlocal calls
+        calls += 1
+        return [sk.public_key]
+
+    config = TenuoPluginConfig(
+        key_resolver=EnvKeyResolver(),
+        trusted_roots_provider=provider,
+    )
+    assert calls == 1
+    TenuoTemporalPlugin(config)
+    assert calls == 1
+
+
 def test_revocation_list_provider_startup_failure_is_configuration_error() -> None:
     """Startup SRL provider failures fail closed with remediation text."""
     from tenuo.exceptions import ConfigurationError

--- a/tenuo-python/tests/adapters/test_temporal_plugin.py
+++ b/tenuo-python/tests/adapters/test_temporal_plugin.py
@@ -63,13 +63,25 @@ def test_configure_worker_merges_interceptor_and_runner() -> None:
     # Unified ``interceptors=`` SimplePlugin reads the client's interceptor list when merging.
     mock_client = MagicMock()
     mock_client.config.return_value = {"interceptors": [ci]}
-    cfg: dict = {"client": mock_client}
+    cfg: dict = {"client": mock_client, "task_queue": "plugin-test-queue"}
     out = p.configure_worker(cfg)
     inters = out.get("interceptors") or []
     assert len(inters) == 1
     assert isinstance(inters[0], TenuoWorkerInterceptor)
     wr = out.get("workflow_runner")
     assert isinstance(wr, SandboxedWorkflowRunner)
+
+
+def test_configure_worker_rejects_missing_task_queue() -> None:
+    """Missing queue configuration must fail during Worker setup."""
+    from tenuo.exceptions import ConfigurationError
+
+    p = TenuoTemporalPlugin(_minimal_config())
+    mock_client = MagicMock()
+    mock_client.config.return_value = {"interceptors": [p.client_interceptor]}
+
+    with pytest.raises(ConfigurationError, match="requires a non-empty task_queue"):
+        p.configure_worker({"client": mock_client})
 
 
 def test_configure_client_merges_client_interceptors() -> None:

--- a/tenuo-python/tests/adapters/test_tenant_isolation.py
+++ b/tenuo-python/tests/adapters/test_tenant_isolation.py
@@ -511,17 +511,35 @@ class TestManualSetupRegistrationPaths:
 
     def test_async_completion_honors_task_queue_kwarg(self):
         """``tenuo_complete_async_activity`` dropped its singleton
-        lookup; callers must pass ``task_queue=`` to get PoP signing.
-        Verify the resolver is actually hit when the queue matches.
+        lookup; callers must pass ``task_queue=`` for fail-closed chain and
+        holder validation. Verify completion succeeds for the exact queue.
         """
+        from tenuo import SigningKey, Warrant
+        from tenuo.temporal import KeyResolver, TenuoPluginConfig
         from tenuo.temporal._workflow import tenuo_complete_async_activity
 
-        config = self._make_config()
+        root = SigningKey.generate()
+        holder = SigningKey.generate()
+
+        class _Resolver(KeyResolver):
+            async def resolve(self, key_id: str) -> Any:
+                return holder
+
+            def resolve_sync(self, key_id: str) -> Any:
+                return holder
+
+        config = TenuoPluginConfig(
+            key_resolver=_Resolver(),
+            trusted_roots=[root.public_key],
+        )
         _set_worker_config(config, task_queue="async-complete-q")
 
         handle = AsyncMock()
-        warrant = MagicMock()
-        warrant.sign_pop = MagicMock()
+        warrant = Warrant.issue(
+            root,
+            capabilities={"external_job": {}},
+            holder=holder.public_key,
+        )
 
         import asyncio as _asyncio
 
@@ -539,5 +557,4 @@ class TestManualSetupRegistrationPaths:
         finally:
             loop.close()
 
-        warrant.sign_pop.assert_called_once()
         handle.complete.assert_awaited_once_with("result-payload")


### PR DESCRIPTION
## Summary

This PR makes Tenuo's Temporal integration carry and enforce authorization data on the surfaces that actually reach workers:

- Temporal Schedule creation now writes Tenuo warrant headers into the Schedule action's workflow headers instead of memo fields that workers do not consume.
- Workflows can pass a task-local warrant override to `tenuo_execute_activity(..., warrant=..., key_id=...)`, allowing long-running workflows to mint and use fresh execution or delegated warrants without replacing the workflow's base warrant or leaking state across concurrent workflow tasks.
- Async Activity completion now performs caller-side Tenuo preflight before calling Temporal's completion handle, validating trusted roots, signatures, chain linkage, current-time expiry, explicit delegated chains, and signed revocation lists.
- Python now exposes `Authorizer.set_revocation_list()` through the trusted-issuer-only Rust path, so Temporal no longer silently skips revocation enforcement when a native binding is present.
- `verify_chain()` now enforces expiry for every chain element, including singleton/root warrants.

## Security and compatibility decisions

- Async completion remains a caller-side guard, not a Temporal enforcement boundary. Temporal's async-completion RPC has no user-header field, so code that calls `AsyncActivityHandle.complete()` directly can bypass this helper.
- The previous async-completion PoP logic was not restored because it computed a signature and discarded it; no downstream validator could observe or verify it. `key_id` remains accepted for source compatibility, but now emits a `DeprecationWarning` because it is ignored.
- Delegated async completions must provide an explicit root-to-leaf `warrant_chain`; a delegated leaf no longer defaults to a one-element/root chain.
- `task_queue` is validated at worker setup and completion lookup. Omission is temporarily supported only when exactly one worker config is registered, with a deprecation warning.
- Deprecated Schedule `workflow_kwargs` are still forwarded as action options; `action_options` is the replacement.
- Provider-backed trusted roots and revocation lists use last-known-good snapshots for refresh failures. Revocation providers fail closed during worker construction if the initial provider call raises.
- SRL refresh is monotonic: lower-version SRLs are rejected, and same-version changes to the revoked-ID set are rejected; re-signed SRLs with the same revoked-ID set are accepted.
- Python Temporal config currently requires SRLs to be signed by one of `trusted_roots`. A separate revocation authority is a future product-surface decision; Rust already has the explicit issuer API.
- Archival, signature-and-linkage-only chain verification is intentionally not added here. Runtime `verify_chain()` now enforces current-time expiry; an audit-only verifier should be a clearly named separate API.

## Test plan

- [x] `cargo fmt --manifest-path tenuo-core/Cargo.toml --check`
- [x] `cargo check --manifest-path tenuo-core/Cargo.toml`
- [x] `cargo test --manifest-path tenuo-core/Cargo.toml --lib` — 420 passed, 1 ignored
- [x] Built the local Python wheel with `maturin`
- [x] `PYTHONPATH=/private/tmp/tenuo-temporal-pr-pytest-site python3 -m pytest tenuo-python/tests/adapters/test_temporal_plugin.py tenuo-python/tests/adapters/test_temporal.py -q` — 213 passed, 1 skipped
- [x] `python3 -m compileall -q tenuo-python/tenuo/temporal`
- [x] `git diff --check`

Broader adapter sweep note: a local sandbox run reached 1428 passed / 18 skipped before hitting environment issues unrelated to this PR: CrewAI import-time writes under `~/Library/Application Support`, an MCP smoke test looking for a `python` executable, and Temporal dev-server startup denied by sandbox policy. GitHub CI is the source of truth for those environment-dependent checks.
