### PR TITLE
Add optional display message on approval gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Optional approval-gate display message.** `ToolApprovalGate` accepts
+  `message` (max 200 UTF-8 characters). When a gate fires, Rust resolves the
+  string once onto `ApprovalRequest.message` (default:
+  `Approval required for tool '{tool}'`) and every adapter copies that field:
+  `ApprovalRequired` / `ApprovalGateTriggered`, FastAPI 409 `detail.message`,
+  MCP `denial_reason`, Temporal `ApplicationError` body, authorizer JSON
+  `message`, A2A error data, and control-plane request JSON. Not part of
+  `request_hash`, receipts, or error codes. Retry wording stays in the docs.
 - **Temporal Nexus authorization.**
   Added `tenuo_execute_nexus_operation()`,
   `tenuo_start_nexus_operation()`, `tenuo_nexus_headers()`,

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -89,6 +89,12 @@ A2A, control-plane request). It is not part of `request_hash` or receipts.
 Empty strings are omitted; values longer than 200 characters are truncated.
 There is no argument interpolation.
 
+Because the message is not a security property, approval UIs should treat it as
+context, not authority. A delegated child can replace display text, so approvers
+and automated workflows should make decisions from the signed request fields
+(`tool`, `arguments`, `request_hash`, `warrant_id`, approver threshold) rather
+than from the wording alone.
+
 MCP clients still retry by attaching signatures in `_meta.tenuo.approvals`;
 that instruction is documented here rather than rewritten into the denial
 reason.

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -20,7 +20,9 @@ approver_key = SigningKey.generate()
 # 1. Warrant: capabilities, gates, approvers, threshold
 warrant = (Warrant.mint_builder()
     .capability("transfer")
-    .approval_gates({"transfer": None})       # this tool needs approval
+    .approval_gates({
+        "transfer": {"args": None, "message": "A human must confirm this transfer."},
+    })
     .required_approvers([approver_key.public_key])
     .min_approvals(1)
     .holder(agent_key.public_key)
@@ -69,7 +71,8 @@ warrant = (Warrant.mint_builder()
     .capability("restart_service")
     .approval_gates({
         "restart_service": {"environment": Exact("production")},  # prod only
-        # whole-tool gate: "transfer": None
+        # whole-tool + display text:
+        # "transfer": {"args": None, "message": "A human must confirm this transfer."}
     })
     .required_approvers([approver_key.public_key])
     .min_approvals(1)
@@ -78,6 +81,17 @@ warrant = (Warrant.mint_builder()
     .mint(control_key)
 )
 ```
+
+An optional `message` on a gate is display text only. It is resolved once when
+the gate fires and copied onto every adapter (`ApprovalRequired`, FastAPI 409
+`message`, MCP `denial_reason`, Temporal `ApplicationError`, authorizer JSON,
+A2A, control-plane request). It is not part of `request_hash` or receipts.
+Empty strings are omitted; values longer than 200 characters are truncated.
+There is no argument interpolation.
+
+MCP clients still retry by attaching signatures in `_meta.tenuo.approvals`;
+that instruction is documented here rather than rewritten into the denial
+reason.
 
 ---
 

--- a/tenuo-core/src/approval.rs
+++ b/tenuo-core/src/approval.rs
@@ -601,6 +601,14 @@ pub struct ApprovalRequest {
 
     /// When this request was created (Unix seconds).
     pub created_at: u64,
+
+    /// Resolved display text for this request. Not part of `request_hash`.
+    ///
+    /// Set when the gate fires (custom gate `message`, or the default
+    /// `Approval required for tool '{tool}'`). Adapters copy this field;
+    /// they must not invent a different sentence.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub message: String,
 }
 
 impl ApprovalRequest {
@@ -627,7 +635,15 @@ impl ApprovalRequest {
             min_approvals,
             warrant_expires_at,
             created_at: now,
+            message: crate::approval_gate::resolve_approval_required_message(tool, None),
         }
+    }
+
+    /// Overlay the resolved display message from the firing gate (if any).
+    pub fn with_resolved_message(mut self, gate_message: Option<&str>) -> Self {
+        self.message =
+            crate::approval_gate::resolve_approval_required_message(&self.tool, gate_message);
+        self
     }
 }
 

--- a/tenuo-core/src/approval_gate.rs
+++ b/tenuo-core/src/approval_gate.rs
@@ -32,6 +32,9 @@ use std::fmt;
 /// Extension key for approval gate data in the warrant payload.
 pub const APPROVAL_GATE_EXTENSION_KEY: &str = "tenuo.approval_gates";
 
+/// Maximum UTF-8 characters stored on a gate `message`. Longer values are truncated.
+pub const APPROVAL_GATE_MESSAGE_MAX_CHARS: usize = 200;
+
 /// Top-level approval gate map: tool name → gate specification.
 ///
 /// Only tools present in the map are subject to approval gate evaluation.
@@ -81,26 +84,66 @@ impl Default for ApprovalGateMap {
 ///
 /// - `args: None` — entire tool is gated (all invocations require approval)
 /// - `args: Some(map)` — only invocations where a gated argument matches
+/// - `message` — optional display text copied onto `ApprovalRequest` when the
+///   gate fires. Not part of `request_hash`, receipts, or monotonicity.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ToolApprovalGate {
     pub args: Option<BTreeMap<String, ArgApprovalGate>>,
+    /// Optional human-facing reason. Empty / whitespace is stored as `None`.
+    pub message: Option<String>,
 }
 
 impl ToolApprovalGate {
     /// Create a whole-tool gate (all invocations require approval).
     pub fn whole_tool() -> Self {
-        Self { args: None }
+        Self {
+            args: None,
+            message: None,
+        }
     }
 
     /// Create a per-argument gate.
     pub fn with_args(args: BTreeMap<String, ArgApprovalGate>) -> Self {
-        Self { args: Some(args) }
+        Self {
+            args: Some(args),
+            message: None,
+        }
+    }
+
+    /// Attach a display message. Empty / whitespace is omitted; longer than
+    /// [`APPROVAL_GATE_MESSAGE_MAX_CHARS`] is truncated.
+    pub fn with_message(mut self, message: impl AsRef<str>) -> Self {
+        self.message = normalize_approval_gate_message(Some(message.as_ref()));
+        self
     }
 
     /// Returns true if this is a whole-tool gate.
     pub fn is_whole_tool(&self) -> bool {
         self.args.is_none()
     }
+}
+
+/// Trim, omit empty, and cap a gate display message.
+pub fn normalize_approval_gate_message(raw: Option<&str>) -> Option<String> {
+    let trimmed = raw?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(
+        trimmed
+            .chars()
+            .take(APPROVAL_GATE_MESSAGE_MAX_CHARS)
+            .collect(),
+    )
+}
+
+/// Resolve the string adapters copy when a gate fires.
+///
+/// Uses the stored gate message when present; otherwise the historical default
+/// `Approval required for tool '{tool}'`.
+pub fn resolve_approval_required_message(tool: &str, gate_message: Option<&str>) -> String {
+    normalize_approval_gate_message(gate_message)
+        .unwrap_or_else(|| format!("Approval required for tool '{}'", tool))
 }
 
 /// Approval gate specification for a single argument.
@@ -184,10 +227,14 @@ impl Serialize for ToolApprovalGate {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(Some(1))?;
+        let n = if self.message.is_some() { 2 } else { 1 };
+        let mut map = serializer.serialize_map(Some(n))?;
         match &self.args {
             None => map.serialize_entry("args", &Option::<()>::None)?,
             Some(args) => map.serialize_entry("args", args)?,
+        }
+        if let Some(ref message) = self.message {
+            map.serialize_entry("message", message)?;
         }
         map.end()
     }
@@ -212,21 +259,34 @@ impl<'de> Deserialize<'de> for ToolApprovalGate {
                 M: MapAccess<'de>,
             {
                 let mut args: Option<Option<BTreeMap<String, ArgApprovalGate>>> = None;
+                let mut message: Option<String> = None;
 
                 while let Some(key) = map.next_key::<String>()? {
-                    if key == "args" {
-                        if args.is_some() {
-                            return Err(de::Error::duplicate_field("args"));
+                    match key.as_str() {
+                        "args" => {
+                            if args.is_some() {
+                                return Err(de::Error::duplicate_field("args"));
+                            }
+                            // Deserialize Option<Map> — null means whole-tool gate
+                            args = Some(map.next_value()?);
                         }
-                        // Deserialize Option<Map> — null means whole-tool gate
-                        args = Some(map.next_value()?);
-                    } else {
-                        let _: de::IgnoredAny = map.next_value()?;
+                        "message" => {
+                            if message.is_some() {
+                                return Err(de::Error::duplicate_field("message"));
+                            }
+                            message = Some(map.next_value()?);
+                        }
+                        _ => {
+                            let _: de::IgnoredAny = map.next_value()?;
+                        }
                     }
                 }
 
                 let args = args.ok_or_else(|| de::Error::missing_field("args"))?;
-                Ok(ToolApprovalGate { args })
+                Ok(ToolApprovalGate {
+                    args,
+                    message: normalize_approval_gate_message(message.as_deref()),
+                })
             }
         }
 
@@ -463,7 +523,10 @@ pub fn merge_approval_gate_maps(
 /// the base gate is the parent's established gate; the additional gate cannot
 /// loosen it. Swapping the argument order would silently flip this security property.
 fn take_stricter_approval_gate(a: &ToolApprovalGate, b: &ToolApprovalGate) -> ToolApprovalGate {
-    match (&a.args, &b.args) {
+    // Display text is not a security property. Child (`b`) wins when set;
+    // otherwise keep the parent's message.
+    let message = b.message.clone().or_else(|| a.message.clone());
+    let mut gate = match (&a.args, &b.args) {
         // Either is whole-tool → whole-tool wins (strictest possible)
         (None, _) | (_, None) => ToolApprovalGate::whole_tool(),
         // Both per-arg → union of argument keys (more args gated = stricter).
@@ -477,7 +540,9 @@ fn take_stricter_approval_gate(a: &ToolApprovalGate, b: &ToolApprovalGate) -> To
             }
             ToolApprovalGate::with_args(merged_args)
         }
-    }
+    };
+    gate.message = message;
+    gate
 }
 
 // ---------------------------------------------------------------------------
@@ -1593,5 +1658,97 @@ mod tests {
             Err(ApprovalGateError::ArgApprovalGateConstraintChanged),
             "Constraint↔Constraint: widening must be rejected"
         );
+    }
+
+    // -- Optional display message --
+
+    #[test]
+    fn test_gate_without_message_still_parses() {
+        let mut gm = ApprovalGateMap::new();
+        gm.insert("email.delete".into(), ToolApprovalGate::whole_tool());
+        let encoded = encode_approval_gate_map(&gm).unwrap();
+        let decoded = parse_approval_gate_map(Some(&encoded)).unwrap().unwrap();
+        assert_eq!(decoded.get("email.delete").unwrap().message, None);
+    }
+
+    #[test]
+    fn test_gate_message_roundtrip_and_cap() {
+        let long: String = "é".repeat(APPROVAL_GATE_MESSAGE_MAX_CHARS + 20);
+        let gate = ToolApprovalGate::whole_tool().with_message(&long);
+        assert_eq!(
+            gate.message.as_ref().unwrap().chars().count(),
+            APPROVAL_GATE_MESSAGE_MAX_CHARS
+        );
+
+        let mut gm = ApprovalGateMap::new();
+        gm.insert("email.delete".into(), gate);
+        let encoded = encode_approval_gate_map(&gm).unwrap();
+        let decoded = parse_approval_gate_map(Some(&encoded)).unwrap().unwrap();
+        assert_eq!(
+            decoded
+                .get("email.delete")
+                .unwrap()
+                .message
+                .as_ref()
+                .unwrap()
+                .chars()
+                .count(),
+            APPROVAL_GATE_MESSAGE_MAX_CHARS
+        );
+    }
+
+    #[test]
+    fn test_empty_message_omitted() {
+        assert_eq!(
+            ToolApprovalGate::whole_tool().with_message("   ").message,
+            None
+        );
+        assert_eq!(
+            resolve_approval_required_message("exec", Some("  ")),
+            "Approval required for tool 'exec'"
+        );
+    }
+
+    #[test]
+    fn test_merge_inherits_parent_message_when_child_unset() {
+        let parent = ToolApprovalGate::whole_tool().with_message("parent text");
+        let child = ToolApprovalGate::whole_tool();
+        let merged = take_stricter_approval_gate(&parent, &child);
+        assert_eq!(merged.message.as_deref(), Some("parent text"));
+    }
+
+    #[test]
+    fn test_merge_child_message_wins_when_set() {
+        let parent = ToolApprovalGate::whole_tool().with_message("parent text");
+        let child = ToolApprovalGate::whole_tool().with_message("child text");
+        let merged = take_stricter_approval_gate(&parent, &child);
+        assert_eq!(merged.message.as_deref(), Some("child text"));
+    }
+
+    #[test]
+    fn test_merge_message_does_not_weaken_gate() {
+        let mut parent_args = BTreeMap::new();
+        parent_args.insert("path".into(), ArgApprovalGate::All);
+        let parent = ToolApprovalGate::with_args(parent_args).with_message("parent");
+
+        let child = ToolApprovalGate::whole_tool().with_message("different child text");
+        let merged = take_stricter_approval_gate(&parent, &child);
+        assert!(merged.is_whole_tool(), "whole-tool child must still win");
+        assert_eq!(merged.message.as_deref(), Some("different child text"));
+    }
+
+    #[test]
+    fn test_unknown_cbor_key_ignored() {
+        use ciborium::value::Value;
+        let gate = Value::Map(vec![
+            (Value::Text("args".into()), Value::Null),
+            (Value::Text("unknown".into()), Value::Integer(1.into())),
+        ]);
+        let gm = Value::Map(vec![(Value::Text("exec".into()), gate)]);
+        let mut buf = Vec::new();
+        ciborium::into_writer(&gm, &mut buf).unwrap();
+        let decoded = parse_approval_gate_map(Some(&buf)).unwrap().unwrap();
+        assert!(decoded.get("exec").unwrap().is_whole_tool());
+        assert_eq!(decoded.get("exec").unwrap().message, None);
     }
 }

--- a/tenuo-core/src/bin/authorizer.rs
+++ b/tenuo-core/src/bin/authorizer.rs
@@ -1597,6 +1597,7 @@ async fn handle_request(
             match &e {
                 tenuo::Error::ApprovalRequired { request, .. } => {
                     if let Some(obj) = body.as_object_mut() {
+                        obj.insert("message".to_string(), json!(request.message.clone()));
                         obj.insert(
                             "request_hash".to_string(),
                             json!(hex::encode(request.request_hash)),
@@ -2071,6 +2072,53 @@ routes:
             approvers[0].as_str().unwrap(),
             hex::encode(approver_key.public_key().to_bytes())
         );
+        assert_eq!(body["message"], "Approval required for tool 'deploy'");
+    }
+
+    #[tokio::test]
+    async fn approval_required_response_copies_gate_message() {
+        let root_key = SigningKey::generate();
+        let approver_key = SigningKey::generate();
+        let authorizer = Authorizer::new().with_trusted_root(root_key.public_key());
+        let app = build_test_app(authorizer);
+
+        let mut gates = ApprovalGateMap::new();
+        gates.insert(
+            "deploy".to_string(),
+            ToolApprovalGate::whole_tool().with_message("A human must confirm this deploy."),
+        );
+        let warrant = tenuo::Warrant::builder()
+            .capability("deploy", ConstraintSet::new())
+            .ttl(std::time::Duration::from_secs(300))
+            .required_approvers(vec![approver_key.public_key()])
+            .min_approvals(1)
+            .holder(root_key.public_key())
+            .extension(
+                "tenuo.approval_gates",
+                encode_approval_gate_map(&gates).unwrap(),
+            )
+            .build(&root_key)
+            .unwrap();
+
+        let args: HashMap<String, ConstraintValue> = [(
+            "service".to_string(),
+            ConstraintValue::String("api".to_string()),
+        )]
+        .into();
+        let pop = warrant.sign(&root_key, "deploy", &args).unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/deploy/api")
+            .header("X-Tenuo-Warrant", encode_warrant_header(&warrant))
+            .header("X-Tenuo-PoP", encode_pop_header(&pop))
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = parse_body(resp).await;
+        assert_eq!(body["error"], "approval-required");
+        assert_eq!(body["message"], "A human must confirm this deploy.");
     }
 
     #[tokio::test]

--- a/tenuo-core/src/error.rs
+++ b/tenuo-core/src/error.rs
@@ -624,7 +624,7 @@ pub enum Error {
     ///
     /// Contains the `ApprovalRequest` with all context needed by the
     /// approval engine to obtain human approval.
-    #[error("approval required for tool '{tool}'")]
+    #[error("{}", .request.message)]
     ApprovalRequired {
         tool: String,
         request: Box<crate::approval::ApprovalRequest>,

--- a/tenuo-core/src/lib.rs
+++ b/tenuo-core/src/lib.rs
@@ -107,8 +107,9 @@ pub use wire::MAX_WARRANT_SIZE;
 // Re-export approval gate types
 pub use approval_gate::{
     encode_approval_gate_map, evaluate_approval_gates, merge_approval_gate_maps,
-    parse_approval_gate_map, propagate_approval_gates, ApprovalGateError, ApprovalGateMap,
-    ArgApprovalGate, ToolApprovalGate,
+    normalize_approval_gate_message, parse_approval_gate_map, propagate_approval_gates,
+    resolve_approval_required_message, ApprovalGateError, ApprovalGateMap, ArgApprovalGate,
+    ToolApprovalGate, APPROVAL_GATE_MESSAGE_MAX_CHARS,
 };
 
 // Re-export approval request

--- a/tenuo-core/src/mcp.rs
+++ b/tenuo-core/src/mcp.rs
@@ -362,9 +362,10 @@ pub fn auth_error_to_jsonrpc(error: &crate::error::Error) -> (i32, String) {
     use crate::error::Error;
 
     match error {
-        Error::ToolNotAuthorized { tool } => {
-            (-32001, format!("Access denied: Tool '{}' not authorized", tool))
-        }
+        Error::ToolNotAuthorized { tool } => (
+            -32001,
+            format!("Access denied: Tool '{}' not authorized", tool),
+        ),
         Error::ConstraintNotSatisfied { field, reason } => (
             -32001,
             format!(
@@ -375,13 +376,7 @@ pub fn auth_error_to_jsonrpc(error: &crate::error::Error) -> (i32, String) {
         Error::WarrantExpired { .. } => (-32001, "Access denied: Warrant expired".to_string()),
         Error::SignatureInvalid(_) => (-32001, "Access denied: Invalid signature".to_string()),
         Error::ToolMismatch { .. } => (-32001, "Access denied: Tool not authorized".to_string()),
-        Error::ApprovalRequired { tool, .. } => (
-            -32002,
-            format!(
-                "Approval required for tool '{}'. Supply approvals in params._meta.tenuo.approvals.",
-                tool
-            ),
-        ),
+        Error::ApprovalRequired { request, .. } => (-32002, request.message.clone()),
         _ => (-32001, format!("Access denied: {}", error)),
     }
 }
@@ -413,6 +408,22 @@ mod tests {
             message,
             "Access denied: Constraint 'path' not satisfied: outside allowed prefix"
         );
+    }
+
+    #[test]
+    fn test_auth_error_copies_approval_request_message() {
+        use crate::approval::ApprovalRequest;
+        use std::collections::HashMap;
+
+        let request =
+            ApprovalRequest::new("wrt_1", "deploy", &HashMap::new(), [0u8; 32], vec![], 1, 0)
+                .with_resolved_message(Some("A human must confirm this deploy."));
+        let (code, message) = auth_error_to_jsonrpc(&crate::error::Error::ApprovalRequired {
+            tool: "deploy".to_string(),
+            request: Box::new(request),
+        });
+        assert_eq!(code, -32002);
+        assert_eq!(message, "A human must confirm this deploy.");
     }
 
     #[test]

--- a/tenuo-core/src/planes.rs
+++ b/tenuo-core/src/planes.rs
@@ -2530,6 +2530,10 @@ impl Authorizer {
                         Some(leaf.authorized_holder()),
                     );
                     let threshold = leaf.approval_threshold();
+                    let gate_message = approval_gate_map
+                        .as_ref()
+                        .and_then(|m| m.get(tool))
+                        .and_then(|g| g.message.as_deref());
                     let request = crate::approval::ApprovalRequest::new(
                         &leaf.id().to_string(),
                         tool,
@@ -2538,7 +2542,8 @@ impl Authorizer {
                         approvers,
                         threshold,
                         leaf.payload.expires_at,
-                    );
+                    )
+                    .with_resolved_message(gate_message);
                     return Err(Error::ApprovalRequired {
                         tool: tool.to_string(),
                         request: Box::new(request),
@@ -3274,7 +3279,9 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            err.to_string().contains("approval required"),
+            err.to_string()
+                .to_ascii_lowercase()
+                .contains("approval required"),
             "expected ApprovalRequired error, got: {}",
             err,
         );
@@ -4783,6 +4790,47 @@ mod tests {
             assert_eq!(request.tool, "email.delete");
             assert_eq!(request.min_approvals, 1);
             assert_eq!(request.required_approvers.len(), 1);
+            assert_eq!(request.message, "Approval required for tool 'email.delete'");
+        } else {
+            panic!("expected ApprovalRequired, got: {}", err);
+        }
+    }
+
+    #[test]
+    fn test_approval_gate_custom_message_on_request() {
+        use crate::approval_gate::{encode_approval_gate_map, ApprovalGateMap, ToolApprovalGate};
+
+        let root_key = SigningKey::generate();
+        let approver_key = SigningKey::generate();
+
+        let mut approval_gates = ApprovalGateMap::new();
+        approval_gates.insert(
+            "email.delete".into(),
+            ToolApprovalGate::whole_tool().with_message("A human must confirm this deletion."),
+        );
+
+        let warrant = Warrant::builder()
+            .capability("email.delete", ConstraintSet::new())
+            .ttl(Duration::from_secs(300))
+            .required_approvers(vec![approver_key.public_key()])
+            .min_approvals(1)
+            .holder(root_key.public_key())
+            .extension(
+                "tenuo.approval_gates",
+                encode_approval_gate_map(&approval_gates).unwrap(),
+            )
+            .build(&root_key)
+            .unwrap();
+
+        let authorizer = Authorizer::new().with_trusted_root(root_key.public_key());
+        let args = HashMap::new();
+        let sig = warrant.sign(&root_key, "email.delete", &args).unwrap();
+        let err = authorizer
+            .authorize_one(&warrant, "email.delete", &args, Some(&sig), &[])
+            .unwrap_err();
+        if let Error::ApprovalRequired { request, .. } = &err {
+            assert_eq!(request.message, "A human must confirm this deletion.");
+            assert_eq!(err.to_string(), request.message);
         } else {
             panic!("expected ApprovalRequired, got: {}", err);
         }

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -2566,7 +2566,7 @@ fn py_dict_to_approval_gate_map(
                         if args_val.is_none() {
                             ToolApprovalGate::whole_tool()
                         } else if let Ok(inner) = args_val.cast::<PyDict>() {
-                            ToolApprovalGate::with_args(py_dict_to_arg_approval_gates(&inner)?)
+                            ToolApprovalGate::with_args(py_dict_to_arg_approval_gates(inner)?)
                         } else {
                             return Err(py_validation_err(format!(
                                 "approval gate for '{}': 'args' must be None or a dict of arg gates",
@@ -2581,7 +2581,7 @@ fn py_dict_to_approval_gate_map(
                     continue;
                 }
             }
-            let args = py_dict_to_arg_approval_gates(&args_dict)?;
+            let args = py_dict_to_arg_approval_gates(args_dict)?;
             gm.insert(tool, ToolApprovalGate::with_args(args));
         } else {
             return Err(py_validation_err(format!(

--- a/tenuo-core/src/python.rs
+++ b/tenuo-core/src/python.rs
@@ -444,10 +444,26 @@ fn to_py_err(e: crate::error::Error) -> PyErr {
             Ok(cls) => {
                 // Call constructor with the tuple of arguments
                 // Note: call1 takes a tuple of arguments. Our 'args' IS that tuple.
-                PyErr::from_value(cls.call1(args).unwrap_or_else(|e| {
+                let value = cls.call1(args).unwrap_or_else(|e| {
                     // Fallback if constructor fails
                     py_validation_err(e.to_string()).value(py).as_any().clone()
-                }))
+                });
+                // Keep the ApprovalGateTriggered 4-tuple (positional unpack). Overlay
+                // the resolved display message after construct.
+                if let crate::error::Error::ApprovalRequired { ref request, .. } = e {
+                    if !request.message.is_empty() {
+                        let _ = value.setattr("message", request.message.as_str());
+                        if let Ok(details) = value.getattr("details") {
+                            if let Ok(dict) = details.cast::<PyDict>() {
+                                let _ = dict.set_item("message", request.message.as_str());
+                            }
+                        }
+                        if let Ok(new_args) = PyTuple::new(py, [request.message.as_str()]) {
+                            let _ = value.setattr("args", new_args);
+                        }
+                    }
+                }
+                PyErr::from_value(value)
             }
             Err(e) => py_validation_err(e.to_string()),
         }
@@ -2507,10 +2523,24 @@ fn py_to_arg_approval_gate(
 ///     },
 /// }
 /// ```
+fn py_dict_to_arg_approval_gates(
+    args_dict: &Bound<'_, PyDict>,
+) -> PyResult<std::collections::BTreeMap<String, crate::approval_gate::ArgApprovalGate>> {
+    let mut args = std::collections::BTreeMap::new();
+    for (ak, av) in args_dict.iter() {
+        let arg_name: String = ak.extract()?;
+        let gate = py_to_arg_approval_gate(&arg_name, &av)?;
+        args.insert(arg_name, gate);
+    }
+    Ok(args)
+}
+
 fn py_dict_to_approval_gate_map(
     dict: &Bound<'_, PyDict>,
 ) -> PyResult<crate::approval_gate::ApprovalGateMap> {
-    use crate::approval_gate::{ApprovalGateMap, ToolApprovalGate};
+    use crate::approval_gate::{
+        normalize_approval_gate_message, ApprovalGateMap, ToolApprovalGate,
+    };
 
     let mut gm = ApprovalGateMap::new();
     for (key, value) in dict.iter() {
@@ -2518,12 +2548,40 @@ fn py_dict_to_approval_gate_map(
         if value.is_none() {
             gm.insert(tool, ToolApprovalGate::whole_tool());
         } else if let Ok(args_dict) = value.cast::<PyDict>() {
-            let mut args = std::collections::BTreeMap::new();
-            for (ak, av) in args_dict.iter() {
-                let arg_name: String = ak.extract()?;
-                let gate = py_to_arg_approval_gate(&arg_name, &av)?;
-                args.insert(arg_name, gate);
+            // Structured form: `{"args": None|dict, "message": str}`.
+            // Detected only when `message` is a Python str so an argument
+            // named "message" (constraint / None / exempt dict) stays per-arg.
+            if let Ok(Some(msg_obj)) = args_dict.get_item("message") {
+                if let Ok(msg) = msg_obj.extract::<String>() {
+                    for (k, _) in args_dict.iter() {
+                        let ks: String = k.extract()?;
+                        if ks != "args" && ks != "message" {
+                            return Err(py_validation_err(format!(
+                                "approval gate for '{}' with a string 'message' may only include 'args' and 'message'",
+                                tool
+                            )));
+                        }
+                    }
+                    let mut gate = if let Ok(Some(args_val)) = args_dict.get_item("args") {
+                        if args_val.is_none() {
+                            ToolApprovalGate::whole_tool()
+                        } else if let Ok(inner) = args_val.cast::<PyDict>() {
+                            ToolApprovalGate::with_args(py_dict_to_arg_approval_gates(&inner)?)
+                        } else {
+                            return Err(py_validation_err(format!(
+                                "approval gate for '{}': 'args' must be None or a dict of arg gates",
+                                tool
+                            )));
+                        }
+                    } else {
+                        ToolApprovalGate::whole_tool()
+                    };
+                    gate.message = normalize_approval_gate_message(Some(&msg));
+                    gm.insert(tool, gate);
+                    continue;
+                }
             }
+            let args = py_dict_to_arg_approval_gates(&args_dict)?;
             gm.insert(tool, ToolApprovalGate::with_args(args));
         } else {
             return Err(py_validation_err(format!(
@@ -4157,6 +4215,17 @@ impl PyWarrant {
         self.inner.approval_threshold()
     }
 
+    /// Return the stored display message for `tool`'s approval gate, if any.
+    fn approval_gate_message(&self, tool: &str) -> Option<String> {
+        let map = crate::approval_gate::parse_approval_gate_map(
+            self.inner
+                .extension(crate::approval_gate::APPROVAL_GATE_EXTENSION_KEY),
+        )
+        .ok()
+        .flatten()?;
+        map.get(tool).and_then(|g| g.message.clone())
+    }
+
     /// Get all custom extensions as a dict of name -> bytes.
     fn extensions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
@@ -5211,6 +5280,12 @@ fn py_evaluate_approval_gates(
         .map_err(to_py_err)
 }
 
+/// Resolve the display string adapters copy when an approval gate fires.
+#[pyfunction(name = "resolve_approval_required_message")]
+fn py_resolve_approval_required_message(tool: &str, gate_message: Option<&str>) -> String {
+    crate::approval_gate::resolve_approval_required_message(tool, gate_message)
+}
+
 /// Unsigned metadata for an approval (NOT part of the signed payload).
 ///
 /// Provider and reason are metadata, not part of the approval semantics.
@@ -6176,6 +6251,7 @@ pub fn tenuo_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_compute_request_hash, m)?)?;
     m.add_function(wrap_pyfunction!(py_verify_approvals, m)?)?;
     m.add_function(wrap_pyfunction!(py_evaluate_approval_gates, m)?)?;
+    m.add_function(wrap_pyfunction!(py_resolve_approval_required_message, m)?)?;
 
     Ok(())
 }

--- a/tenuo-python/tenuo/a2a/errors.py
+++ b/tenuo-python/tenuo/a2a/errors.py
@@ -381,14 +381,17 @@ class ApprovalRequiredError(A2AError):
         request_hash: str = "",
         required_approvers: Optional[list[str]] = None,
         min_approvals: int = 1,
+        message: Optional[str] = None,
     ) -> None:
+        text = message or f"Approval required for skill '{skill}'"
         super().__init__(
-            f"Approval required for skill '{skill}'",
+            text,
             {
                 "skill": skill,
                 "request_hash": request_hash,
                 "required_approvers": required_approvers or [],
                 "min_approvals": min_approvals,
+                "message": text,
             },
         )
 

--- a/tenuo-python/tenuo/a2a/server.py
+++ b/tenuo-python/tenuo/a2a/server.py
@@ -1177,6 +1177,7 @@ class A2AServer:
                         skill_id,
                         request_hash=getattr(e, "request_hash", "") or e.details.get("request_hash", ""),
                         min_approvals=getattr(e, "min_approvals", 1) or e.details.get("min_approvals", 1),
+                        message=getattr(e, "message", None),
                     ) from e
                 if isinstance(e, _InsufficientApprovals):
                     _details = getattr(e, "details", {}) or {}

--- a/tenuo-python/tenuo/approval.py
+++ b/tenuo-python/tenuo/approval.py
@@ -91,6 +91,7 @@ class ApprovalRequest:
         min_approvals: Effective m-of-n threshold when known (optional).
         warrant_expires_at_unix: Warrant expiry as Unix seconds when known (optional).
         created_at_unix: When this request was constructed (optional).
+        message: Resolved display text copied by adapters (optional).
     """
 
     tool: str
@@ -103,6 +104,7 @@ class ApprovalRequest:
     min_approvals: Optional[int] = None
     warrant_expires_at_unix: Optional[int] = None
     created_at_unix: Optional[int] = None
+    message: Optional[str] = None
 
     @staticmethod
     def for_warrant_gate(
@@ -113,6 +115,8 @@ class ApprovalRequest:
         holder_key: Optional[Any] = None,
     ) -> "ApprovalRequest":
         """Build a request aligned with Rust ``approval::ApprovalRequest`` context."""
+        from tenuo_core import resolve_approval_required_message as _resolve
+
         warrant_id = getattr(warrant, "id", None) or ""
         req_approvers = getattr(warrant, "required_approvers", None)
         approvers_list: Optional[List[Any]] = None
@@ -124,6 +128,10 @@ class ApprovalRequest:
         min_approvals: Optional[int] = None
         if callable(min_ap):
             min_approvals = int(min_ap())
+        raw_message = None
+        getter = getattr(warrant, "approval_gate_message", None)
+        if callable(getter):
+            raw_message = getter(tool)
         return ApprovalRequest(
             tool=tool,
             arguments=arguments,
@@ -135,6 +143,7 @@ class ApprovalRequest:
             min_approvals=min_approvals,
             warrant_expires_at_unix=warrant_expires_at_unix(warrant),
             created_at_unix=int(time.time()),
+            message=_resolve(tool, raw_message),
         )
 
 
@@ -155,10 +164,10 @@ class ApprovalRequired(Exception):
 
     def __init__(self, request: ApprovalRequest):
         self.request = request
-        super().__init__(
-            f"Approval required for '{request.tool}' "
-            f"(warrant: {request.warrant_id})"
-        )
+        from tenuo_core import resolve_approval_required_message as _resolve
+
+        text = request.message or _resolve(request.tool, None)
+        super().__init__(text)
 
 
 class ApprovalDenied(Exception):
@@ -318,6 +327,8 @@ def cli_prompt(
         print(f"\n{'=' * 60}", file=sys.stderr)
         print("  APPROVAL REQUIRED", file=sys.stderr)
         print(f"{'=' * 60}", file=sys.stderr)
+        if request.message:
+            print(f"  {request.message}", file=sys.stderr)
         print(f"  Tool:    {request.tool}", file=sys.stderr)
         if show_args and request.arguments:
             for k, v in request.arguments.items():

--- a/tenuo-python/tenuo/builder.py
+++ b/tenuo-python/tenuo/builder.py
@@ -262,8 +262,10 @@ class MintBuilder:
     def approval_gates(self, approval_gate_map: Dict[str, Any]) -> "MintBuilder":
         """Add approval gates to the warrant.
 
-        Keys are tool names. Values are ``None`` (whole-tool gate) or a dict of
-        per-argument gate specifications.
+        Keys are tool names. Values are ``None`` (whole-tool gate), a dict of
+        per-argument gate specifications, or
+        ``{"args": None | {...}, "message": "..."}`` for an optional display
+        message (copied onto approval errors; not part of ``request_hash``).
         """
         self._approval_gates = approval_gate_map
         return self
@@ -623,8 +625,11 @@ class GrantBuilder:
     def approval_gates(self, approval_gate_map: Dict[str, Any]) -> "GrantBuilder":
         """Add or merge approval gates into the attenuated warrant.
 
-        Keys are tool names. Values are ``None`` (whole-tool gate) or a dict of
-        per-argument gate specifications. Gates merge with any inherited from the parent.
+        Keys are tool names. Values are ``None`` (whole-tool gate), a dict of
+        per-argument gate specifications, or
+        ``{"args": None | {...}, "message": "..."}``. Gates merge with any
+        inherited from the parent. Display ``message`` is not a security
+        property: child text wins when set, otherwise the parent text is kept.
         """
         self._rust_builder.with_approval_gates(approval_gate_map)
         return self
@@ -937,8 +942,10 @@ class IssuanceBuilder:
     def approval_gates(self, approval_gate_map: Dict[str, Any]) -> "IssuanceBuilder":
         """Add or merge approval gates into the issued execution warrant.
 
-        Keys are tool names. Values are ``None`` (whole-tool gate) or a dict of
-        per-argument gate specifications. Gates merge with any inherited from the issuer warrant.
+        Keys are tool names. Values are ``None`` (whole-tool gate), a dict of
+        per-argument gate specifications, or
+        ``{"args": None | {...}, "message": "..."}``. Gates merge with any
+        inherited from the issuer warrant.
         """
         self._rust_builder.with_approval_gates(approval_gate_map)
         return self

--- a/tenuo-python/tenuo/cp_approval.py
+++ b/tenuo-python/tenuo/cp_approval.py
@@ -63,6 +63,7 @@ class ControlPlaneApprovalRequestV1:
     created_at_unix: int
     attestation: Optional[Dict[str, Any]] = None
     temporal: Optional[Dict[str, str]] = None
+    message: Optional[str] = None
 
     def to_json_dict(self) -> Dict[str, Any]:
         d = asdict(self)
@@ -70,6 +71,8 @@ class ControlPlaneApprovalRequestV1:
             d.pop("attestation", None)
         if d.get("temporal") is None:
             d.pop("temporal", None)
+        if not d.get("message"):
+            d.pop("message", None)
         return d
 
     @staticmethod
@@ -91,6 +94,7 @@ class ControlPlaneApprovalRequestV1:
             created_at_unix=int(data["created_at_unix"]),
             attestation=dict(data["attestation"]) if data.get("attestation") is not None else None,
             temporal=dict(data["temporal"]) if data.get("temporal") is not None else None,
+            message=(str(data["message"]) if data.get("message") else None),
         )
 
 
@@ -163,6 +167,7 @@ def build_control_plane_approval_request_v1(
         created_at_unix=created,
         attestation=att,
         temporal=dict(temporal) if temporal else None,
+        message=req.message or None,
     )
 
 

--- a/tenuo-python/tenuo/exceptions.py
+++ b/tenuo-python/tenuo/exceptions.py
@@ -1292,13 +1292,16 @@ class ApprovalGateTriggered(ApprovalError):
         request_hash: str = "",
         min_approvals: int = 1,
         hint: Optional[str] = None,
+        *,
+        message: Optional[str] = None,
     ):
         self.tool = tool
         self.request_id = request_id
         self.request_hash = request_hash
         self.min_approvals = min_approvals
+        text = message or f"Approval required for tool '{tool}'"
         super().__init__(
-            f"Approval required for tool '{tool}'",
+            text,
             hint=hint,
         )
         self.details = {
@@ -1306,6 +1309,7 @@ class ApprovalGateTriggered(ApprovalError):
             "request_id": request_id,
             "request_hash": request_hash,
             "min_approvals": min_approvals,
+            "message": text,
         }
 
 

--- a/tenuo-python/tenuo/fastapi.py
+++ b/tenuo-python/tenuo/fastapi.py
@@ -523,7 +523,7 @@ class TenuoGuard:
                 status_code=status.HTTP_409_CONFLICT,
                 detail={
                     "error": "approval_required",
-                    "message": str(approval_required),
+                    "message": req.message or str(approval_required),
                     "tool": req.tool,
                     "request_hash": req.request_hash.hex(),
                     "min_approvals": req.min_approvals or 1,
@@ -534,7 +534,7 @@ class TenuoGuard:
                 status_code=status.HTTP_409_CONFLICT,
                 detail={
                     "error": "approval_required",
-                    "message": str(gate),
+                    "message": gate.message,
                     "tool": gate.tool,
                     "request_id": gate.request_id,
                     "request_hash": gate.request_hash,

--- a/tenuo-python/tenuo/mcp/server.py
+++ b/tenuo-python/tenuo/mcp/server.py
@@ -788,10 +788,7 @@ class MCPVerifier:
                 constraints=constraints,
                 warrant_id=warrant_id,
                 request_hash=gate_exc.request_hash or None,
-                denial_reason=(
-                    f"Approval required for '{tool_name}'. "
-                    "Re-submit the call with approvals in _meta.tenuo.approvals."
-                ),
+                denial_reason=gate_exc.message,
                 jsonrpc_error_code=-32002,
             )
         except InsufficientApprovals as insuf_exc:

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -1224,22 +1224,22 @@ class TenuoActivityInboundInterceptor:
                     f"Malformed x-tenuo-approvals header: {exc}",
                 ) from exc
 
+        from tenuo_core import py_compute_request_hash as _compute_hash
+        from tenuo.approval import ApprovalRequest
+
+        holder_key = getattr(warrant, "holder_key", None)
+        warrant_id = getattr(warrant, "id", "") or ""
+        request_hash = _compute_hash(warrant_id, tool_name, args, holder_key)
+        request = ApprovalRequest.for_warrant_gate(
+            tool_name,
+            args,
+            warrant,
+            request_hash,
+            holder_key=holder_key,
+        )
+
         handler = self._config.approval_handler if self._config else None
         if handler is not None:
-            from tenuo_core import py_compute_request_hash as _compute_hash
-            from tenuo.approval import ApprovalRequest
-
-            holder_key = getattr(warrant, "holder_key", None)
-            warrant_id = getattr(warrant, "id", "") or ""
-            request_hash = _compute_hash(warrant_id, tool_name, args, holder_key)
-            request = ApprovalRequest.for_warrant_gate(
-                tool_name,
-                args,
-                warrant,
-                request_hash,
-                holder_key=holder_key,
-            )
-
             result = handler(request)
             if _inspect.isawaitable(result):
                 result = await result
@@ -1255,6 +1255,7 @@ class TenuoActivityInboundInterceptor:
 
         raise ApprovalGateTriggered(
             tool=tool_name,
+            message=request.message,
             hint=(
                 "No approvals available — set approval_handler on "
                 "TenuoPluginConfig or supply x-tenuo-approvals header"

--- a/tenuo-python/tenuo/temporal/exceptions.py
+++ b/tenuo-python/tenuo/temporal/exceptions.py
@@ -65,8 +65,12 @@ def _build_non_retryable_application_error(exc: BaseException) -> "ApplicationEr
     """
     from temporalio.exceptions import ApplicationError  # type: ignore[import-not-found]
 
+    if isinstance(exc, ApprovalGateTriggered) and getattr(exc, "message", None):
+        wire_message = exc.message
+    else:
+        wire_message = str(exc)
     app_error = ApplicationError(
-        str(exc),
+        wire_message,
         type=_error_type_for_wire(exc),
         non_retryable=True,
     )

--- a/tenuo-python/tests/adapters/test_mcp_server.py
+++ b/tenuo-python/tests/adapters/test_mcp_server.py
@@ -524,7 +524,7 @@ class TestApprovalGateTriggered:
         assert not result.allowed
         assert result.is_approval_required
         assert result.jsonrpc_error_code == -32002
-        assert "approvals" in (result.denial_reason or "").lower()
+        assert result.denial_reason == "Approval required for tool 'transfer'"
         assert result.request_hash is not None, "request_hash must be populated from Rust"
         assert len(result.request_hash) > 0
 

--- a/tenuo-python/tests/unit/test_approval.py
+++ b/tenuo-python/tests/unit/test_approval.py
@@ -197,8 +197,8 @@ class TestExceptions:
             tool="transfer", arguments={}, warrant_id="wrt_123", request_hash=b"\x00" * 32
         )
         exc = ApprovalRequired(req)
+        assert str(exc) == "Approval required for tool 'transfer'"
         assert "transfer" in str(exc)
-        assert "wrt_123" in str(exc)
 
     def test_verification_error_not_approval_denied(self):
         assert not issubclass(ApprovalVerificationError, ApprovalDenied)

--- a/tenuo-python/tests/unit/test_approval_gate_message.py
+++ b/tenuo-python/tests/unit/test_approval_gate_message.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -137,6 +139,76 @@ def test_shared_enforcement_raises_resolved_message():
 
     assert str(exc_info.value) == CUSTOM
     assert exc_info.value.request.message == CUSTOM
+
+
+def test_fastapi_and_mcp_share_resolved_message():
+    pytest.importorskip("fastapi")
+
+    from fastapi import FastAPI, HTTPException
+    from tenuo.fastapi import TenuoGuard, configure_tenuo
+
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    approver = SigningKey.generate()
+    args = {"id": "42"}
+    w = _mint(
+        issuer,
+        holder,
+        approver,
+        {"email.delete": {"args": None, "message": CUSTOM}},
+    )
+    sig = w.sign(holder, "email.delete", args, int(time.time()))
+
+    app = FastAPI()
+    configure_tenuo(app, trusted_issuers=[issuer.public_key])
+    request = SimpleNamespace(
+        state=SimpleNamespace(tenuo_parents=[]),
+        path_params={},
+        query_params={},
+    )
+    guard = TenuoGuard("email.delete", extract_args=lambda _: args)
+
+    with pytest.raises(HTTPException) as fastapi_exc:
+        guard(
+            request,
+            warrant=w,
+            x_tenuo_pop=base64.b64encode(bytes(sig)).decode(),
+            x_tenuo_approvals=None,
+        )
+
+    authorizer = Authorizer(trusted_roots=[issuer.public_key])
+    meta = {
+        "tenuo": {
+            "warrant": w.to_base64(),
+            "signature": base64.b64encode(bytes(sig)).decode(),
+        }
+    }
+    mcp = MCPVerifier(authorizer=authorizer).verify("email.delete", args, meta=meta)
+
+    assert fastapi_exc.value.detail["message"] == CUSTOM
+    assert mcp.denial_reason == CUSTOM
+
+
+def test_a2a_and_control_plane_share_resolved_message():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    approver = SigningKey.generate()
+    args = {"id": "42"}
+    w = _mint(
+        issuer,
+        holder,
+        approver,
+        {"email.delete": {"args": None, "message": CUSTOM}},
+    )
+    rh = compute_request_hash(w.id, "email.delete", args, holder.public_key)
+    req = ApprovalRequest.for_warrant_gate("email.delete", args, w, rh)
+
+    a2a = ApprovalRequiredError("email.delete", message=req.message)
+    cp = build_control_plane_approval_request_v1(req, holder.public_key)
+
+    assert a2a.message == CUSTOM
+    assert a2a.data["message"] == CUSTOM
+    assert cp.to_json_dict()["message"] == CUSTOM
 
 
 def test_same_bytes_across_surfaces():

--- a/tenuo-python/tests/unit/test_approval_gate_message.py
+++ b/tenuo-python/tests/unit/test_approval_gate_message.py
@@ -170,7 +170,7 @@ def test_same_bytes_across_surfaces():
         app_err = _build_non_retryable_application_error(gate)
     except ImportError:
         pytest.skip("temporalio not installed")
-    assert str(app_err) == expected
+    assert app_err.message == expected
 
 
 def test_cli_prompt_prints_message(capsys):

--- a/tenuo-python/tests/unit/test_approval_gate_message.py
+++ b/tenuo-python/tests/unit/test_approval_gate_message.py
@@ -1,0 +1,246 @@
+"""Optional approval-gate display message: one resolved string, copied everywhere."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from tenuo import Authorizer, SigningKey, Warrant
+from tenuo.a2a.errors import ApprovalRequiredError
+from tenuo.approval import ApprovalRequest, ApprovalRequired, cli_prompt
+from tenuo.cp_approval import build_control_plane_approval_request_v1
+from tenuo.exceptions import ApprovalGateTriggered
+from tenuo.mcp.server import MCPVerifier
+from tenuo_core import py_compute_request_hash as compute_request_hash
+
+CUSTOM = "A human must confirm this deletion."
+
+
+def _mint(issuer, holder, approver, gates):
+    return Warrant.issue(
+        keypair=issuer,
+        capabilities={"email.delete": {}},
+        ttl_seconds=3600,
+        holder=holder.public_key,
+        required_approvers=[approver.public_key],
+        min_approvals=1,
+        approval_gates=gates,
+    )
+
+
+def _authorize(warrant, holder, issuer_pk, approvals=None):
+    auth = Authorizer(trusted_roots=[issuer_pk])
+    args = {"id": "42"}
+    sig = warrant.sign(holder, "email.delete", args, int(time.time()))
+    auth.authorize_one(warrant, "email.delete", args, bytes(sig), approvals or [])
+
+
+def test_custom_message_on_authorizer_exception():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    approver = SigningKey.generate()
+    w = _mint(
+        issuer,
+        holder,
+        approver,
+        {"email.delete": {"args": None, "message": CUSTOM}},
+    )
+    assert w.approval_gate_message("email.delete") == CUSTOM
+
+    with pytest.raises(ApprovalGateTriggered) as exc_info:
+        _authorize(w, holder, issuer.public_key)
+    assert exc_info.value.message == CUSTOM
+    assert str(exc_info.value) == CUSTOM
+    assert exc_info.value.details["message"] == CUSTOM
+
+
+def test_default_message_when_gate_has_none():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    approver = SigningKey.generate()
+    w = _mint(issuer, holder, approver, {"email.delete": None})
+    assert w.approval_gate_message("email.delete") is None
+
+    with pytest.raises(ApprovalGateTriggered) as exc_info:
+        _authorize(w, holder, issuer.public_key)
+    assert exc_info.value.message == "Approval required for tool 'email.delete'"
+
+
+def test_empty_message_omitted():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    approver = SigningKey.generate()
+    w = _mint(
+        issuer,
+        holder,
+        approver,
+        {"email.delete": {"args": None, "message": "   "}},
+    )
+    assert w.approval_gate_message("email.delete") is None
+
+
+def test_message_capped_at_200_chars():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    approver = SigningKey.generate()
+    long = "é" * 250
+    w = _mint(
+        issuer,
+        holder,
+        approver,
+        {"email.delete": {"args": None, "message": long}},
+    )
+    stored = w.approval_gate_message("email.delete")
+    assert stored is not None
+    assert len(stored) == 200
+
+
+def test_approval_required_and_for_warrant_gate_copy_message():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    approver = SigningKey.generate()
+    w = _mint(
+        issuer,
+        holder,
+        approver,
+        {"email.delete": {"args": None, "message": CUSTOM}},
+    )
+    args = {"id": "42"}
+    rh = compute_request_hash(w.id, "email.delete", args, holder.public_key)
+    req = ApprovalRequest.for_warrant_gate("email.delete", args, w, rh)
+    assert req.message == CUSTOM
+    assert str(ApprovalRequired(req)) == CUSTOM
+
+
+def test_same_bytes_across_surfaces():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    approver = SigningKey.generate()
+    w = _mint(
+        issuer,
+        holder,
+        approver,
+        {"email.delete": {"args": None, "message": CUSTOM}},
+    )
+    args = {"id": "42"}
+
+    with pytest.raises(ApprovalGateTriggered) as gate_info:
+        _authorize(w, holder, issuer.public_key)
+    gate = gate_info.value
+
+    rh = compute_request_hash(w.id, "email.delete", args, holder.public_key)
+    req = ApprovalRequest.for_warrant_gate("email.delete", args, w, rh)
+    approval_required = ApprovalRequired(req)
+
+    authorizer = Authorizer(trusted_roots=[issuer.public_key])
+    sig = w.sign(holder, "email.delete", args, int(time.time()))
+    meta = {
+        "tenuo": {
+            "warrant": w.to_base64(),
+            "signature": __import__("base64").b64encode(bytes(sig)).decode(),
+        }
+    }
+    mcp = MCPVerifier(authorizer=authorizer).verify("email.delete", args, meta=meta)
+
+    fastapi_from_gate = gate.message
+    fastapi_from_required = req.message or str(approval_required)
+    a2a = ApprovalRequiredError("email.delete", message=gate.message)
+
+    cp = build_control_plane_approval_request_v1(req, holder.public_key)
+    cp_dict = cp.to_json_dict()
+
+    expected = CUSTOM
+    assert str(gate) == expected
+    assert str(approval_required) == expected
+    assert fastapi_from_gate == expected
+    assert fastapi_from_required == expected
+    assert mcp.denial_reason == expected
+    assert a2a.message == expected
+    assert a2a.data["message"] == expected
+    assert cp.message == expected
+    assert cp_dict["message"] == expected
+
+    try:
+        from tenuo.temporal.exceptions import _build_non_retryable_application_error
+    except Exception:
+        pytest.skip("temporal adapter extras not installed")
+    try:
+        app_err = _build_non_retryable_application_error(gate)
+    except ImportError:
+        pytest.skip("temporalio not installed")
+    assert str(app_err) == expected
+
+
+def test_cli_prompt_prints_message(capsys):
+    approver = SigningKey.generate()
+    req = ApprovalRequest(
+        tool="email.delete",
+        arguments={"id": "42"},
+        warrant_id="w",
+        request_hash=b"\x00" * 32,
+        message=CUSTOM,
+    )
+    handler = cli_prompt(approver_key=approver)
+    with patch("builtins.input", return_value="y"):
+        handler(req)
+    err = capsys.readouterr().err
+    assert CUSTOM in err
+
+
+def test_positional_four_tuple_still_constructs():
+    exc = ApprovalGateTriggered("email.delete", "rid", "rhash", 2)
+    assert exc.tool == "email.delete"
+    assert exc.request_id == "rid"
+    assert exc.request_hash == "rhash"
+    assert exc.min_approvals == 2
+    assert exc.message == "Approval required for tool 'email.delete'"
+
+
+def test_merge_inherits_parent_message():
+    issuer = SigningKey.generate()
+    approver = SigningKey.generate()
+    child_key = SigningKey.generate()
+    parent = Warrant.issue(
+        keypair=issuer,
+        capabilities={"email.delete": {}, "email.read": {}},
+        ttl_seconds=3600,
+        holder=issuer.public_key,
+        required_approvers=[approver.public_key],
+        min_approvals=1,
+        approval_gates={"email.delete": {"args": None, "message": "parent text"}},
+    )
+    child = (
+        parent.grant_builder()
+        .capability("email.delete")
+        .holder(child_key.public_key)
+        .ttl(1800)
+        .approval_gates({"email.delete": None})
+        .grant(issuer)
+    )
+    assert child.approval_gate_message("email.delete") == "parent text"
+
+
+def test_merge_child_message_wins():
+    issuer = SigningKey.generate()
+    approver = SigningKey.generate()
+    child_key = SigningKey.generate()
+    parent = Warrant.issue(
+        keypair=issuer,
+        capabilities={"email.delete": {}},
+        ttl_seconds=3600,
+        holder=issuer.public_key,
+        required_approvers=[approver.public_key],
+        min_approvals=1,
+        approval_gates={"email.delete": {"args": None, "message": "parent text"}},
+    )
+    child = (
+        parent.grant_builder()
+        .capability("email.delete")
+        .holder(child_key.public_key)
+        .ttl(1800)
+        .approval_gates({"email.delete": {"args": None, "message": "child text"}})
+        .grant(issuer)
+    )
+    assert child.approval_gate_message("email.delete") == "child text"

--- a/tenuo-python/tests/unit/test_approval_gate_message.py
+++ b/tenuo-python/tests/unit/test_approval_gate_message.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
-from tenuo import Authorizer, SigningKey, Warrant
+from tenuo import Authorizer, BoundWarrant, SigningKey, Warrant
+from tenuo._enforcement import enforce_tool_call
 from tenuo.a2a.errors import ApprovalRequiredError
 from tenuo.approval import ApprovalRequest, ApprovalRequired, cli_prompt
 from tenuo.cp_approval import build_control_plane_approval_request_v1
@@ -112,6 +113,30 @@ def test_approval_required_and_for_warrant_gate_copy_message():
     req = ApprovalRequest.for_warrant_gate("email.delete", args, w, rh)
     assert req.message == CUSTOM
     assert str(ApprovalRequired(req)) == CUSTOM
+
+
+def test_shared_enforcement_raises_resolved_message():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    approver = SigningKey.generate()
+    w = _mint(
+        issuer,
+        holder,
+        approver,
+        {"email.delete": {"args": None, "message": CUSTOM}},
+    )
+    bound = BoundWarrant(w, holder)
+
+    with pytest.raises(ApprovalRequired) as exc_info:
+        enforce_tool_call(
+            "email.delete",
+            {"id": "42"},
+            bound,
+            trusted_roots=[issuer.public_key],
+        )
+
+    assert str(exc_info.value) == CUSTOM
+    assert exc_info.value.request.message == CUSTOM
 
 
 def test_same_bytes_across_surfaces():

--- a/tenuo-python/tests/unit/test_cp_approval_flow.py
+++ b/tenuo-python/tests/unit/test_cp_approval_flow.py
@@ -58,6 +58,21 @@ class TestControlPlaneApprovalFlow:
 
         # JSON round-trip of arguments must preserve types Tenuo accepts (int stays int).
         assert parsed.arguments["amount"] == 42
+        assert parsed.message == req.message
+
+    def test_from_json_dict_accepts_payload_without_message(self):
+        issuer = SigningKey.generate()
+        holder = SigningKey.generate()
+        approver = SigningKey.generate()
+        w = _mint_warrant_with_gate(issuer, holder, approver.public_key)
+        args = {"amount": 42}
+        rh = compute_request_hash(w.id, "risky", args, holder.public_key)
+        req = ApprovalRequest.for_warrant_gate("risky", args, w, rh)
+        data = build_control_plane_approval_request_v1(req, holder.public_key).to_json_dict()
+        data.pop("message", None)
+        parsed = ControlPlaneApprovalRequestV1.from_json_dict(data)
+        assert parsed.message is None
+        assert parsed.schema_version == 1
 
     def test_worker_and_cp_hash_match_explicit(self):
         issuer = SigningKey.generate()


### PR DESCRIPTION
## Summary
- Optional `message` on `ToolApprovalGate` (max 200 UTF-8 chars; empty omitted). When the gate fires, Rust resolves the string once onto `ApprovalRequest.message` and every adapter copies that field: exceptions, FastAPI 409, MCP `denial_reason`, Temporal `ApplicationError` body, authorizer JSON, A2A, control-plane request JSON, `cli_prompt`.
- Not part of `request_hash`, receipts, or error codes. Default remains `Approval required for tool '{tool}'`. Merge inherit: child text if set, else parent. Display text is not a security property.
- MCP no longer rewrites the reason with “Re-submit… `_meta.tenuo.approvals`” — that retry instruction stays in the docs.

## Test plan
- [x] Rust: old CBOR gate without `message` still parses; cap / empty omit; merge inherit; `authorize_one` + authorizer HTTP copy the resolved string
- [x] Python: `str(ApprovalGateTriggered)` / `str(ApprovalRequired)` / FastAPI `detail["message"]` / MCP `denial_reason` / A2A / CP JSON are the same bytes for one mint
- [x] `cli_prompt` prints the message
- [ ] Review: merge must not drop `message`; MCP must not reintroduce invented retry copy; Cloud/CP should read the `message` key (no schema_version bump)