### PR TITLE
fix(temporal): harden Nexus audit emission

### DIFF
--- a/tenuo-python/tenuo/temporal/_nexus.py
+++ b/tenuo-python/tenuo/temporal/_nexus.py
@@ -53,6 +53,10 @@ _TENUO_NEXUS_WORKFLOW_ENVELOPE_VERSION = "tenuo-nexus-workflow-envelope/v1"
 _UNSET = object()
 
 
+class _NexusEndpointMismatch(TenuoContextError):
+    """Raised when the handler context reports a different Nexus endpoint."""
+
+
 @_dataclasses.dataclass(frozen=True)
 class TenuoNexusWorkflowEnvelope:
     """Serializable Tenuo context for workflow-backed Nexus operations."""
@@ -972,9 +976,30 @@ def _verify_nexus_operation(
     operation: Optional[Any],
 ) -> Any:
     raw_headers = _decode_nexus_headers(getattr(ctx, "headers", {}) or {})
-    tool_name = _ctx_tool_name(ctx, endpoint, service, operation)
     args = nexus_input_args(input)
     start_ns = time.perf_counter_ns()
+    try:
+        tool_name = _ctx_tool_name(ctx, endpoint, service, operation)
+    except _NexusEndpointMismatch as exc:
+        warrant = _safe_extract_warrant_from_headers(raw_headers)
+        tool_name = _ctx_tool_name_unchecked(ctx, endpoint, service, operation)
+        endpoint_denial = TemporalConstraintViolation(
+            tool=tool_name,
+            arguments=args,
+            constraint=str(exc),
+            warrant_id=getattr(warrant, "id", None) or "none",
+        )
+        _emit_nexus_control_plane_event(
+            config,
+            ctx,
+            warrant,
+            None,
+            tool_name,
+            args,
+            start_ns=start_ns,
+            exc=endpoint_denial,
+        )
+        raise
     warrant = _extract_warrant_from_headers(raw_headers)
     if warrant is None:
         missing_warrant = TemporalConstraintViolation(
@@ -1129,42 +1154,35 @@ def _emit_nexus_control_plane_event(
     chain_result: Optional[Any] = None,
     exc: Optional[BaseException] = None,
 ) -> None:
-    control_plane = getattr(config, "control_plane", None)
-    if not control_plane:
-        return
+    try:
+        control_plane = getattr(config, "control_plane", None)
+        if not control_plane:
+            return
 
-    from tenuo._enforcement import EnforcementResult
+        from tenuo._enforcement import EnforcementResult
 
-    latency_us = int((time.perf_counter_ns() - start_ns) / 1000)
-    redacted_args = _redact_nexus_args(config, args)
-    request_id = getattr(ctx, "request_id", None)
+        latency_us = int((time.perf_counter_ns() - start_ns) / 1000)
+        redacted_args = _redact_nexus_args(config, args)
+        request_id = getattr(ctx, "request_id", None)
 
-    if exc is None:
-        result = EnforcementResult(
-            allowed=True,
-            tool=tool_name,
-            arguments=redacted_args,
-            warrant_id=getattr(warrant, "id", None),
-            chain_result=chain_result,
-        )
-        try:
+        if exc is None:
+            result = EnforcementResult(
+                allowed=True,
+                tool=tool_name,
+                arguments=redacted_args,
+                warrant_id=getattr(warrant, "id", None),
+                chain_result=chain_result,
+            )
             control_plane.emit_for_enforcement(
                 result,
                 chain_result=chain_result,
                 latency_us=latency_us,
                 request_id=str(request_id) if request_id else None,
             )
-        except Exception:
-            logger.warning(
-                "Control plane emission failed for Nexus allow '%s'; audit event lost",
-                tool_name,
-                exc_info=True,
-            )
-        return
+            return
 
-    result = _nexus_denial_result(exc, tool_name, args, redacted_args, warrant)
-    warrant_stack_b64 = _encode_nexus_warrant_stack_for_denial(warrant, chain)
-    try:
+        result = _nexus_denial_result(exc, tool_name, args, redacted_args, warrant)
+        warrant_stack_b64 = _encode_nexus_warrant_stack_for_denial(warrant, chain)
         control_plane.emit_for_enforcement(
             result,
             chain_result=None,
@@ -1173,11 +1191,35 @@ def _emit_nexus_control_plane_event(
             warrant_stack_override=warrant_stack_b64,
         )
     except Exception:
+        outcome = "allow" if exc is None else "denial"
         logger.warning(
-            "Control plane emission failed for Nexus denial '%s'; audit event lost",
+            "Control plane emission failed for Nexus %s '%s'; audit event lost",
+            outcome,
             tool_name,
             exc_info=True,
         )
+
+
+def _safe_extract_warrant_from_headers(raw_headers: Dict[str, bytes]) -> Optional[Any]:
+    try:
+        return _extract_warrant_from_headers(raw_headers)
+    except Exception:
+        return None
+
+
+def _ctx_tool_name_unchecked(
+    ctx: Any,
+    endpoint: Optional[str],
+    service: Optional[str],
+    operation: Optional[Any],
+) -> str:
+    service_name = service or getattr(ctx, "service", None)
+    operation_name = operation or getattr(ctx, "operation", None)
+    return nexus_tool_name(
+        endpoint or "unknown-endpoint",
+        operation_name or "unknown-operation",
+        service=service_name,
+    )
 
 
 def _redact_nexus_args(config: Any, args: Dict[str, Any]) -> Dict[str, Any]:
@@ -1283,7 +1325,7 @@ def _ctx_tool_name(
 def _validate_ctx_endpoint(ctx: Any, expected_endpoint: str) -> None:
     observed_endpoint = _ctx_endpoint(ctx)
     if observed_endpoint and observed_endpoint != expected_endpoint:
-        raise TenuoContextError(
+        raise _NexusEndpointMismatch(
             "Nexus endpoint mismatch: configured endpoint="
             f"{expected_endpoint!r}, but the handler context reports "
             f"{observed_endpoint!r}."

--- a/tenuo-python/tests/adapters/test_temporal_nexus.py
+++ b/tenuo-python/tests/adapters/test_temporal_nexus.py
@@ -106,6 +106,11 @@ class RecordingControlPlane:
             self.deny_events.append(event)
 
 
+class FailingControlPlane:
+    def emit_for_enforcement(self, *args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("control plane unavailable")
+
+
 class FakeNexusClient:
     endpoint = "billing-prod"
     service_name = "BillingService"
@@ -304,6 +309,37 @@ def test_verify_nexus_operation_emits_control_plane_allow(
     }
 
 
+def test_verify_nexus_operation_control_plane_failure_does_not_deny_allow(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    input = RefundInput("ord_123", 2500)
+    ctx = SimpleNamespace(
+        request_id="req-control-plane-fails-open-for-authz",
+        service="BillingService",
+        operation="refund",
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=input,
+        ),
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+        control_plane=FailingControlPlane(),
+    )
+
+    verified = verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+
+    assert verified.to_bytes() == nexus_warrant.to_bytes()
+
+
 def test_verify_nexus_operation_emits_control_plane_deny_before_reraising(
     nexus_keys: tuple[Any, Any],
     nexus_warrant: Any,
@@ -403,6 +439,45 @@ def test_verify_nexus_operation_rejects_context_endpoint_mismatch(
 
     with pytest.raises(TenuoContextError, match="endpoint mismatch"):
         verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+
+
+def test_verify_nexus_operation_emits_control_plane_deny_on_endpoint_mismatch(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    input = RefundInput("ord_123", 2500)
+    control_plane = RecordingControlPlane()
+    ctx = SimpleNamespace(
+        request_id="req-endpoint-mismatch",
+        endpoint="billing-staging",
+        service="BillingService",
+        operation="refund",
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=input,
+        ),
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+        control_plane=control_plane,
+    )
+
+    with pytest.raises(TenuoContextError, match="endpoint mismatch"):
+        verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+
+    assert len(control_plane.deny_events) == 1
+    entry = control_plane.deny_events[0]
+    assert entry["request_id"] == "req-endpoint-mismatch"
+    assert entry["result"].allowed is False
+    assert entry["result"].error_type == "constraint_violation"
+    assert "endpoint mismatch" in entry["result"].constraint_violated
 
 
 def test_verify_nexus_operation_rejects_nexus_info_endpoint_mismatch(


### PR DESCRIPTION
## Summary

This is a small follow-up to the Temporal Nexus authorization feature. It tightens the Nexus audit path without changing the authorization contract.

- Emit a control-plane deny event when a Nexus handler rejects a request because the observed endpoint does not match the configured endpoint.
- Make the Nexus control-plane emission helper fully fail-safe, so telemetry/redaction/event construction errors cannot turn an authorized operation into a runtime denial.
- Add focused regression tests for endpoint-mismatch denial emission and control-plane failure on an otherwise allowed Nexus request.

## Validation

- python3 -m pytest tenuo-python/tests/adapters/test_temporal_nexus.py -q
- python3 -m ruff check tenuo-python/tenuo/temporal/_nexus.py tenuo-python/tests/adapters/test_temporal_nexus.py
- git diff --check