### PR TITLE
feat(temporal): harden Nexus binding diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PoP replay checks with Nexus `request_id` scoping, and binds
   workflow-envelope `key_id` values to the warrant holder before backing
   workflows can sign downstream PoPs.
+- **Temporal Nexus DX hardening.** Tenuo-generated Nexus calls now include the
+  exact PoP tool name and input field list so handlers can report
+  caller/handler contract drift as a wiring error instead of an opaque policy
+  denial; manual callers that omit these binding headers now fail closed. Added
+  `TemporalNexusOperation.exact(...)` for minting canonical Nexus operation
+  capabilities.
 - **Temporal per-Activity warrant overrides.**
   `tenuo_execute_activity(..., warrant=..., key_id=...)` now applies a
   task-local warrant to one dispatch, including the active delegation chain.

--- a/docs/temporal-nexus.md
+++ b/docs/temporal-nexus.md
@@ -85,6 +85,13 @@ The proof input currently binds:
 - operation name;
 - normalized operation input.
 
+Tenuo-generated Nexus calls also carry diagnostic binding headers for the exact
+tool name and input fields used for PoP signing. The handler compares those
+headers to its own derived endpoint/service/operation and normalized input
+shape before cryptographic authorization, so contract drift shows up as a
+wiring error in handler logs instead of as an opaque policy denial. Manual
+callers must send these headers too; missing binding headers fail closed.
+
 `tenuo_nexus_headers(...)` is also available as a lower-level escape hatch for
 advanced wiring and tests.
 
@@ -122,6 +129,22 @@ The supported APIs are:
 - `verify_nexus_operation(ctx, input, config, ...)`
 - `tenuo_nexus_operation(config, ...)`
 - `nexus_tool_name(endpoint, operation, service=...)`
+- `TemporalNexusOperation.exact(endpoint, operation, service=..., ...)`
+
+Use the template helper when minting warrants so callers and handlers share the
+same canonical tool string:
+
+```python
+from tenuo.templates import TemporalNexusOperation
+
+refund_capability = TemporalNexusOperation.exact(
+    "billing-prod",
+    "refund",
+    service="BillingService",
+    order_id=Exact("ord_123"),
+    amount_cents=Range(max=5000),
+)
+```
 
 ### Workflow-backed Nexus operations
 

--- a/tenuo-python/tenuo/templates.py
+++ b/tenuo-python/tenuo/templates.py
@@ -314,6 +314,45 @@ class ApiClient:
 
 
 # =============================================================================
+# Temporal Nexus Templates
+# =============================================================================
+
+
+class TemporalNexusOperation:
+    """Temporal Nexus operation capability templates.
+
+    Nexus tool names include the endpoint, optional service, and operation so a
+    warrant minted for one Nexus boundary cannot silently authorize another.
+    """
+
+    @staticmethod
+    def exact(
+        endpoint: str,
+        operation: Any,
+        *,
+        service: Optional[str] = None,
+        **constraints: Any,
+    ) -> Capability:
+        """Authorize one Nexus operation with optional input constraints.
+
+        Example:
+            cap = TemporalNexusOperation.exact(
+                "billing-prod",
+                "refund",
+                service="BillingService",
+                order_id=Exact("ord_123"),
+                amount_cents=Range(max=5000),
+            )
+        """
+        from tenuo.temporal import nexus_tool_name
+
+        return Capability(
+            nexus_tool_name(endpoint, operation, service=service),
+            **constraints,
+        )
+
+
+# =============================================================================
 # Code Execution Templates
 # =============================================================================
 
@@ -627,6 +666,8 @@ __all__ = [
     # Web templates
     "WebSearcher",
     "ApiClient",
+    # Temporal templates
+    "TemporalNexusOperation",
     # Code/Shell templates
     "CodeRunner",
     "ShellExecutor",

--- a/tenuo-python/tenuo/temporal/_nexus.py
+++ b/tenuo-python/tenuo/temporal/_nexus.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
 
 from tenuo.temporal._constants import (
     TENUO_APPROVALS_HEADER,
+    TENUO_ARG_KEYS_HEADER,
     TENUO_CHAIN_HEADER,
     TENUO_POP_HEADER,
 )
@@ -48,6 +49,7 @@ from tenuo.temporal.exceptions import (
 logger = logging.getLogger("tenuo.temporal")
 
 TENUO_NEXUS_HEADER_ENCODING = "x-tenuo-nexus-header-encoding"
+TENUO_NEXUS_TOOL_HEADER = "x-tenuo-tool-name"
 _TENUO_NEXUS_HEADER_ENCODING_V1 = "base64-v1"
 _TENUO_NEXUS_WORKFLOW_ENVELOPE_VERSION = "tenuo-nexus-workflow-envelope/v1"
 _UNSET = object()
@@ -135,6 +137,8 @@ def tenuo_nexus_headers(
 
     tool_name = nexus_tool_name(endpoint, operation, service=service)
     args = nexus_input_args(input)
+    raw_headers[TENUO_NEXUS_TOOL_HEADER] = tool_name.encode("utf-8")
+    raw_headers[TENUO_ARG_KEYS_HEADER] = ",".join(args.keys()).encode("utf-8")
     ts = int(time.time()) if timestamp is None else int(timestamp)
     pop_signature = warrant.sign(signer, tool_name, args, ts)
     raw_headers[TENUO_POP_HEADER] = base64.b64encode(bytes(pop_signature))
@@ -1019,6 +1023,8 @@ def _verify_nexus_operation(
             exc=missing_warrant,
         )
         raise missing_warrant
+    _validate_nexus_tool_header(raw_headers, tool_name)
+    _validate_nexus_arg_keys_header(raw_headers, args, tool_name)
 
     chain: Optional[List[Any]] = None
     chain_header = raw_headers.get(TENUO_CHAIN_HEADER)
@@ -1222,6 +1228,68 @@ def _ctx_tool_name_unchecked(
     )
 
 
+def _validate_nexus_tool_header(
+    raw_headers: Mapping[str, bytes],
+    tool_name: str,
+) -> None:
+    raw_tool = raw_headers.get(TENUO_NEXUS_TOOL_HEADER)
+    if raw_tool is None:
+        raise TenuoContextError(
+            "Nexus request is missing x-tenuo-tool-name; upgrade the caller to "
+            "send the exact Tenuo tool name it used for PoP signing."
+        )
+    try:
+        advertised_tool = raw_tool.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise TenuoContextError(
+            "Nexus request has malformed x-tenuo-tool-name; expected UTF-8."
+        ) from exc
+    if advertised_tool != tool_name:
+        logger.warning(
+            "Nexus Tenuo tool binding mismatch: caller advertised %r but "
+            "handler derived %r",
+            advertised_tool,
+            tool_name,
+        )
+        raise TenuoContextError(
+            "Nexus Tenuo tool binding mismatch; caller and handler disagree on "
+            "endpoint/service/operation."
+        )
+
+
+def _validate_nexus_arg_keys_header(
+    raw_headers: Mapping[str, bytes],
+    args: Mapping[str, Any],
+    tool_name: str,
+) -> None:
+    raw_keys = raw_headers.get(TENUO_ARG_KEYS_HEADER)
+    if raw_keys is None:
+        raise TenuoContextError(
+            "Nexus request is missing x-tenuo-arg-keys; upgrade the caller to "
+            "send the input fields it used for PoP signing."
+        )
+    try:
+        decoded = raw_keys.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise TenuoContextError(
+            "Nexus request has malformed x-tenuo-arg-keys; expected UTF-8."
+        ) from exc
+    signed_keys = [] if decoded == "" else decoded.split(",")
+    handler_keys = list(args.keys())
+    if set(signed_keys) != set(handler_keys):
+        logger.warning(
+            "Nexus Tenuo argument binding mismatch for %s: caller advertised "
+            "keys %r but handler derived keys %r",
+            tool_name,
+            signed_keys,
+            handler_keys,
+        )
+        raise TenuoContextError(
+            "Nexus Tenuo argument binding mismatch; caller and handler disagree "
+            "on input fields."
+        )
+
+
 def _redact_nexus_args(config: Any, args: Dict[str, Any]) -> Dict[str, Any]:
     if not getattr(config, "redact_args_in_logs", True):
         return args
@@ -1315,9 +1383,14 @@ def _ctx_tool_name(
     _validate_ctx_endpoint(ctx, endpoint)
     service_name = service or getattr(ctx, "service", None)
     operation_name = operation or getattr(ctx, "operation", None)
+    if not operation_name:
+        raise TenuoContextError(
+            "verify_nexus_operation requires operation= when the Nexus handler "
+            "context does not expose an operation name."
+        )
     return nexus_tool_name(
         endpoint,
-        operation_name or "unknown-operation",
+        operation_name,
         service=service_name,
     )
 

--- a/tenuo-python/tests/adapters/test_temporal_nexus.py
+++ b/tenuo-python/tests/adapters/test_temporal_nexus.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Optional, Tuple
@@ -17,10 +18,12 @@ from tenuo.approval import ApprovalRequest, sign_approval  # noqa: E402
 from tenuo_core import Exact, Range, SigningKey, Warrant, py_compute_request_hash  # noqa: E402
 
 from tenuo.temporal._config import TenuoPluginConfig  # noqa: E402
+from tenuo.temporal._constants import TENUO_ARG_KEYS_HEADER  # noqa: E402
 from tenuo.temporal._dedup import _default_pop_dedup_store, _pop_dedup_cache  # noqa: E402
 from tenuo.temporal._workflow import current_key_id  # noqa: E402
 from tenuo.temporal._headers import tenuo_headers  # noqa: E402
 from tenuo.temporal._nexus import (  # noqa: E402
+    TENUO_NEXUS_TOOL_HEADER,
     TenuoNexusWorkflowEnvelope,
     nexus_input_args,
     nexus_tool_name,
@@ -51,7 +54,6 @@ from tenuo.exceptions import (  # noqa: E402
     ApprovalGateTriggered,
     ConstraintViolation,
     SignatureInvalid,
-    ToolNotAuthorized,
 )
 
 
@@ -698,8 +700,184 @@ def test_verify_nexus_operation_rejects_wrong_operation_binding(
         trusted_roots=[root_key.public_key],
     )
 
-    with pytest.raises((ConstraintViolation, ToolNotAuthorized)):
+    with pytest.raises(TenuoContextError, match="tool binding mismatch"):
         verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+
+
+def test_verify_nexus_operation_rejects_missing_tool_binding_header(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    input = RefundInput("ord_123", 2500)
+    headers = tenuo_nexus_headers(
+        nexus_warrant,
+        "agent-key",
+        agent_key,
+        endpoint="billing-prod",
+        service="BillingService",
+        operation="refund",
+        input=input,
+    )
+    del headers[TENUO_NEXUS_TOOL_HEADER]
+    ctx = SimpleNamespace(
+        request_id="req-default",
+        service="BillingService",
+        operation="refund",
+        headers=headers,
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+    )
+
+    with pytest.raises(TenuoContextError, match="missing x-tenuo-tool-name"):
+        verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+
+
+def test_verify_nexus_operation_rejects_missing_arg_key_binding_header(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    input = RefundInput("ord_123", 2500)
+    headers = tenuo_nexus_headers(
+        nexus_warrant,
+        "agent-key",
+        agent_key,
+        endpoint="billing-prod",
+        service="BillingService",
+        operation="refund",
+        input=input,
+    )
+    del headers[TENUO_ARG_KEYS_HEADER]
+    ctx = SimpleNamespace(
+        request_id="req-default",
+        service="BillingService",
+        operation="refund",
+        headers=headers,
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+    )
+
+    with pytest.raises(TenuoContextError, match="missing x-tenuo-arg-keys"):
+        verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+
+
+def test_verify_nexus_operation_requires_operation_name(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    input = RefundInput("ord_123", 2500)
+    headers = tenuo_nexus_headers(
+        nexus_warrant,
+        "agent-key",
+        agent_key,
+        endpoint="billing-prod",
+        service="BillingService",
+        operation="refund",
+        input=input,
+    )
+    ctx = SimpleNamespace(
+        request_id="req-default",
+        service="BillingService",
+        headers=headers,
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+    )
+
+    with pytest.raises(TenuoContextError, match="requires operation="):
+        verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+
+
+def test_verify_nexus_operation_accepts_arg_key_order_drift(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    signed_input = {"amount_cents": 2500, "order_id": "ord_123"}
+    headers = tenuo_nexus_headers(
+        nexus_warrant,
+        "agent-key",
+        agent_key,
+        endpoint="billing-prod",
+        service="BillingService",
+        operation="refund",
+        input=signed_input,
+    )
+    ctx = SimpleNamespace(
+        request_id="req-default",
+        service="BillingService",
+        operation="refund",
+        headers=headers,
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+    )
+
+    verify_nexus_operation(ctx, RefundInput("ord_123", 2500), config, endpoint="billing-prod")
+
+
+def test_verify_nexus_operation_rejects_arg_key_binding_mismatch(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    input = RefundInput("ord_123", 2500)
+    headers = tenuo_nexus_headers(
+        nexus_warrant,
+        "agent-key",
+        agent_key,
+        endpoint="billing-prod",
+        service="BillingService",
+        operation="refund",
+        input=input,
+    )
+    headers[TENUO_ARG_KEYS_HEADER] = base64.b64encode(
+        b"order_id,total_cents"
+    ).decode("ascii")
+    ctx = SimpleNamespace(
+        request_id="req-default",
+        service="BillingService",
+        operation="refund",
+        headers=headers,
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+    )
+
+    with pytest.raises(TenuoContextError, match="argument binding mismatch"):
+        verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+
+
+def test_tenuo_nexus_headers_send_binding_diagnostics(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    _root_key, agent_key = nexus_keys
+    headers = tenuo_nexus_headers(
+        nexus_warrant,
+        "agent-key",
+        agent_key,
+        endpoint="billing-prod",
+        service="BillingService",
+        operation="refund",
+        input=RefundInput("ord_123", 2500),
+    )
+
+    assert base64.b64decode(headers[TENUO_NEXUS_TOOL_HEADER]).decode() == (
+        "nexus:billing-prod:BillingService:refund"
+    )
+    assert base64.b64decode(headers[TENUO_ARG_KEYS_HEADER]).decode() == (
+        "order_id,amount_cents"
+    )
 
 
 def test_verify_nexus_operation_rejects_input_constraint_mismatch(

--- a/tenuo-python/tests/unit/test_templates.py
+++ b/tenuo-python/tests/unit/test_templates.py
@@ -24,6 +24,7 @@ from tenuo.templates import (
     FileReader,
     FileWriter,
     ShellExecutor,
+    TemporalNexusOperation,
     WebSearcher,
 )
 
@@ -228,6 +229,32 @@ class TestApiClient:
 
         assert isinstance(cap.constraints["url"], Pattern)
         assert "internal.company.com/api/*" in cap.constraints["url"].pattern
+
+
+class TestTemporalNexusOperation:
+    """Test Temporal Nexus operation templates."""
+
+    def test_exact_operation_with_service(self):
+        """TemporalNexusOperation.exact creates canonical Nexus tool names."""
+        cap = TemporalNexusOperation.exact(
+            "billing-prod",
+            "refund",
+            service="BillingService",
+            order_id=Exact("ord_123"),
+            amount_cents=Range(max=5000),
+        )
+
+        assert isinstance(cap, Capability)
+        assert cap.tool == "nexus:billing-prod:BillingService:refund"
+        assert isinstance(cap.constraints["order_id"], Exact)
+        assert isinstance(cap.constraints["amount_cents"], Range)
+
+    def test_exact_operation_without_service(self):
+        """Service is optional for service-less Nexus operation scopes."""
+        cap = TemporalNexusOperation.exact("shared-endpoint", "ping")
+
+        assert cap.tool == "nexus:shared-endpoint:ping"
+        assert cap.constraints == {}
 
 
 class TestCodeRunner:


### PR DESCRIPTION
## Summary
- Add Nexus binding headers for the caller-derived Tenuo tool name and normalized input field names.
- Verify those bindings on the handler before authorization so caller/handler contract drift is reported as a wiring error instead of an opaque policy denial.
- Compare advertised input fields order-insensitively, matching PoP canonicalization while still catching missing or extra fields.
- Stop falling back to `unknown-operation` on the Nexus verify path when the handler context does not expose an operation name.
- Add `TemporalNexusOperation.exact(...)` for minting canonical Nexus operation capabilities.
- Document that manual callers must send the new binding headers; missing binding headers fail closed.

## Validation
- `python3 -m pytest tests/adapters/test_temporal_nexus.py tests/unit/test_templates.py -q` — 85 passed
- `python3 -m ruff check tenuo/temporal/_nexus.py tenuo/templates.py tests/adapters/test_temporal_nexus.py tests/unit/test_templates.py`
- `python3 -m mypy tenuo/`
- `git diff --check`