### PR TITLE
feat(temporal): start Nexus workflows with ambient headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   denial; manual callers that omit these binding headers now fail closed. Added
   `TemporalNexusOperation.exact(...)` for minting canonical Nexus operation
   capabilities.
+- **Ambient Temporal Nexus backing workflow starts.**
+  `tenuo_start_nexus_workflow(...)` verifies a Nexus handler request, binds a
+  handler-minted workflow warrant to the backing `workflow_id` through
+  `TenuoClientInterceptor`, starts the workflow via `ctx.start_workflow(...)`,
+  and clears stale pending headers if startup fails before the interceptor
+  consumes them. The live Nexus test now exercises concurrent backing starts
+  over this interceptor path.
 - **Temporal per-Activity warrant overrides.**
   `tenuo_execute_activity(..., warrant=..., key_id=...)` now applies a
   task-local warrant to one dispatch, including the active delegation chain.

--- a/docs/temporal-nexus.md
+++ b/docs/temporal-nexus.md
@@ -149,37 +149,48 @@ refund_capability = TemporalNexusOperation.exact(
 ### Workflow-backed Nexus operations
 
 Python Nexus handlers commonly call `ctx.start_workflow(...)` from a
-`@nexus.workflow_run_operation`. Tenuo's high-level workflow-backed helpers use
-an explicit workflow-input envelope plus a bootstrap helper in the handler
-workflow so delegated authority remains visible in application code rather
-than hidden in transport plumbing.
+`@nexus.workflow_run_operation`. Tenuo supports that shape without putting
+authority into ordinary workflow input: `tenuo_start_nexus_workflow(...)`
+verifies the incoming Nexus request, binds a handler-created or attenuated
+workflow warrant to the exact backing `workflow_id`, then calls
+`ctx.start_workflow(...)` through the normal Temporal client interceptor path.
 
 Tenuo's client interceptor can inject headers into Nexus backing workflow
 starts without dropping Nexus-specific fields such as `request_id`, callbacks,
-or workflow event links; this path is covered by both a focused interceptor
-contract test and an isolated live Nexus backing-start probe. The envelope
-helpers remain the documented high-level path because they make forwarding,
-attenuation, target-workflow binding, and bootstrap validation explicit in
-application code.
+or workflow event links; this path is covered by both focused adapter coverage
+and an isolated live Nexus backing-start concurrency probe.
 
-Two modes are supported:
+Three modes are supported:
 
+- `tenuo_start_nexus_workflow(...)` carries handler-created, attenuated, or
+  freshly minted workflow authority via Temporal workflow headers. This is the
+  preferred production shape for backing workflows: the handler verifies the
+  public Nexus operation, decides what internal workflow work is allowed, and
+  starts that workflow with a narrower warrant held by a key the handler
+  namespace can resolve.
 - `tenuo_forward_nexus_authority(...)` forwards the exact verified caller
   warrant/key context into the backing workflow. This is the escape hatch for
   workflows that only need to inspect caller authority, or whose worker can
   resolve the caller holder key for downstream PoP signing.
 - `tenuo_create_nexus_workflow_envelope(...)` carries a handler-created,
-  attenuated, or freshly minted workflow warrant. This is the preferred
-  production shape: the handler verifies the Nexus operation, decides what
-  internal workflow work is allowed, and passes a narrower warrant held by a
-  key the handler namespace can resolve.
+  attenuated, or freshly minted workflow warrant through explicit workflow
+  input. Prefer `tenuo_start_nexus_workflow(...)` when the handler client has
+  `TenuoClientInterceptor`; keep the envelope path for manual transports,
+  migration, or cases where making bootstrap explicit in the workflow input is
+  desirable.
 
-The backing workflow calls `tenuo_bootstrap_nexus_workflow(input.tenuo)` before
-`current_warrant()`, `current_key_id()`, or `tenuo_execute_activity(...)`.
-Both envelope constructors require `workflow_id=` so the bootstrap step can
-reject replay into a different backing workflow. Bootstrap also resolves the
-envelope `key_id` and requires it to match the warrant holder key before the
-workflow can use that key for downstream PoP signing.
+The ambient helper requires a `TenuoClientInterceptor` installed on the handler
+namespace client. If `ctx.start_workflow(...)` fails before the interceptor
+consumes the pending header binding, Tenuo discards that binding so stale
+authority does not sit in memory until TTL eviction.
+
+Envelope-backed workflows call `tenuo_bootstrap_nexus_workflow(input.tenuo)`
+before `current_warrant()`, `current_key_id()`, or
+`tenuo_execute_activity(...)`. Both envelope constructors require
+`workflow_id=` so the bootstrap step can reject replay into a different backing
+workflow. Bootstrap also resolves the envelope `key_id` and requires it to
+match the warrant holder key before the workflow can use that key for
+downstream PoP signing.
 
 Treat the backing workflow as an internal implementation detail of the Nexus
 handler. Do not expose it for direct starts by untrusted clients; ordinary
@@ -193,8 +204,7 @@ Example preferred shape:
 ```python
 @nexus.workflow_run_operation
 async def minted_refund(self, ctx, input):
-    verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
-
+    workflow_id = f"refund-{ctx.request_id}"
     workflow_warrant = (
         Warrant.mint_builder()
         .holder(handler_key.public_key)
@@ -206,24 +216,24 @@ async def minted_refund(self, ctx, input):
         .ttl(3600)
         .mint(control_key)
     )
-    envelope = tenuo_create_nexus_workflow_envelope(
-        workflow_warrant,
-        "handler-workflow-key",
-        workflow_id=workflow_id,
-        source_ctx=ctx,
-        source_endpoint="billing-prod",
-    )
-    return await ctx.start_workflow(
+
+    return await tenuo_start_nexus_workflow(
+        ctx,
+        input,
+        config,
+        handler_client_interceptor,
         RefundWorkflow.run,
-        RefundWorkflowInput(input.order_id, input.amount_cents, tenuo=envelope),
-        id=workflow_id,
+        RefundWorkflowInput(input.order_id, input.amount_cents),
+        workflow_id=workflow_id,
+        workflow_warrant=workflow_warrant,
+        workflow_key_id="handler-workflow-key",
+        endpoint="billing-prod",
     )
 
 @workflow.defn
 class RefundWorkflow:
     @workflow.run
     async def run(self, input):
-        tenuo_bootstrap_nexus_workflow(input.tenuo)
         return await tenuo_execute_activity(...)
 ```
 

--- a/tenuo-python/tenuo/temporal/__init__.py
+++ b/tenuo-python/tenuo/temporal/__init__.py
@@ -91,6 +91,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "TenuoNexusWorkflowEnvelope": ("tenuo.temporal._nexus", "TenuoNexusWorkflowEnvelope"),
     "tenuo_forward_nexus_authority": ("tenuo.temporal._nexus", "tenuo_forward_nexus_authority"),
     "tenuo_create_nexus_workflow_envelope": ("tenuo.temporal._nexus", "tenuo_create_nexus_workflow_envelope"),
+    "tenuo_start_nexus_workflow": ("tenuo.temporal._nexus", "tenuo_start_nexus_workflow"),
     "tenuo_bootstrap_nexus_workflow": ("tenuo.temporal._nexus", "tenuo_bootstrap_nexus_workflow"),
     # _state — public escape hatch for manual worker setup
     "register_worker_config": ("tenuo.temporal._state", "register_worker_config"),

--- a/tenuo-python/tenuo/temporal/_client.py
+++ b/tenuo-python/tenuo/temporal/_client.py
@@ -163,6 +163,28 @@ class TenuoClientInterceptor(_TemporalClientInterceptor):
         with self._lock:
             return self._headers_by_workflow_id.pop(workflow_id, None) is not None
 
+    def discard_headers_for_workflow_if_match(
+        self,
+        workflow_id: str,
+        headers: Dict[str, bytes],
+    ) -> bool:
+        """Drop pending headers only when they still match *headers*.
+
+        Use this when a caller bound headers for a start attempt that failed
+        before the interceptor consumed them. If another concurrent attempt has
+        since rebound the same workflow id, this method leaves that newer
+        binding intact.
+        """
+        with self._lock:
+            existing = self._headers_by_workflow_id.get(workflow_id)
+            if existing is None:
+                return False
+            existing_headers, _inserted_at = existing
+            if existing_headers != headers:
+                return False
+            self._headers_by_workflow_id.pop(workflow_id, None)
+            return True
+
     def clear_headers(self) -> None:
         """Clear all pending headers."""
         with self._lock:

--- a/tenuo-python/tenuo/temporal/_nexus.py
+++ b/tenuo-python/tenuo/temporal/_nexus.py
@@ -539,27 +539,23 @@ def tenuo_create_nexus_workflow_envelope(
 ) -> TenuoNexusWorkflowEnvelope:
     """Create a workflow envelope for handler-minted or attenuated authority.
 
-    Use this as the preferred workflow-backed Nexus path: after verifying the
-    operation, the handler passes a narrower workflow warrant whose holder key
-    belongs to the handler/backing-workflow namespace.
+    Prefer ``tenuo_start_nexus_workflow`` when the handler namespace client has
+    ``TenuoClientInterceptor`` installed. Use this explicit envelope path for
+    manual transports, migration, or workflows that intentionally want
+    bootstrap data visible in ordinary workflow input.
     """
     if not workflow_id:
         raise TenuoContextError(
             "tenuo_create_nexus_workflow_envelope requires workflow_id= to bind "
             "the envelope to one backing workflow."
         )
-    raw_headers = tenuo_headers(warrant, key_id, compress=compress)
-    chain = list(warrant_chain) if warrant_chain is not None else [warrant]
-    _validate_chain_ends_with_warrant(
-        chain,
+    raw_headers = _workflow_headers_for_warrant(
         warrant,
+        key_id,
+        warrant_chain,
+        compress=compress,
         operation="tenuo_create_nexus_workflow_envelope",
     )
-    if len(chain) > 1:
-        from tenuo_core import encode_warrant_stack
-
-        raw_headers[TENUO_CHAIN_HEADER] = encode_warrant_stack(chain).encode("utf-8")
-
     return _workflow_envelope_from_raw_headers(
         raw_headers,
         ctx=source_ctx,
@@ -570,6 +566,94 @@ def tenuo_create_nexus_workflow_envelope(
         operation=source_operation,
         mode="minted",
     )
+
+
+async def tenuo_start_nexus_workflow(
+    ctx: Any,
+    input: Any,
+    config: Any,
+    client_interceptor: Any,
+    workflow_run_fn: Any,
+    workflow_input: Any = _UNSET,
+    *,
+    workflow_id: str,
+    workflow_warrant: Any,
+    workflow_key_id: str,
+    workflow_warrant_chain: Optional[List[Any]] = None,
+    endpoint: Optional[str] = None,
+    service: Optional[str] = None,
+    operation: Optional[Any] = None,
+    compress: bool = True,
+    **start_workflow_kwargs: Any,
+) -> Any:
+    """Verify a Nexus request, then start a backing workflow with Tenuo headers.
+
+    This is the ambient workflow-backed Nexus path for handler-minted or
+    attenuated authority. It avoids placing authority in ordinary workflow
+    input: the handler verifies the incoming Nexus operation, binds a workflow
+    warrant to the exact backing ``workflow_id`` through
+    ``TenuoClientInterceptor.set_headers_for_workflow()``, then starts the
+    workflow through the normal Temporal Nexus context.
+    """
+    if not workflow_id:
+        raise TenuoContextError(
+            "tenuo_start_nexus_workflow requires workflow_id= to bind Tenuo "
+            "headers to one backing workflow start."
+        )
+    if "id" in start_workflow_kwargs:
+        raise ValueError(
+            "Pass workflow_id via tenuo_start_nexus_workflow(..., workflow_id=...). "
+            "Do not also pass id= in start_workflow_kwargs."
+        )
+    if workflow_warrant is None:
+        raise TenuoContextError("tenuo_start_nexus_workflow requires workflow_warrant=.")
+    if not workflow_key_id:
+        raise TenuoContextError("tenuo_start_nexus_workflow requires workflow_key_id=.")
+    if not hasattr(client_interceptor, "set_headers_for_workflow"):
+        raise TenuoContextError(
+            "tenuo_start_nexus_workflow requires a TenuoClientInterceptor "
+            "installed on the handler namespace client."
+        )
+
+    verify_nexus_operation(
+        ctx,
+        input,
+        config,
+        endpoint=endpoint,
+        service=service,
+        operation=operation,
+        raise_nexus_error=True,
+    )
+    workflow_headers = _workflow_headers_for_warrant(
+        workflow_warrant,
+        workflow_key_id,
+        workflow_warrant_chain,
+        compress=compress,
+        operation="tenuo_start_nexus_workflow",
+    )
+    client_interceptor.set_headers_for_workflow(workflow_id, workflow_headers)
+    try:
+        if workflow_input is _UNSET:
+            return await ctx.start_workflow(
+                workflow_run_fn,
+                id=workflow_id,
+                **start_workflow_kwargs,
+            )
+        return await ctx.start_workflow(
+            workflow_run_fn,
+            workflow_input,
+            id=workflow_id,
+            **start_workflow_kwargs,
+        )
+    except Exception:
+        discard = getattr(
+            client_interceptor,
+            "discard_headers_for_workflow_if_match",
+            None,
+        )
+        if callable(discard):
+            discard(workflow_id, workflow_headers)
+        raise
 
 
 def tenuo_bootstrap_nexus_workflow(envelope: Any) -> None:
@@ -947,6 +1031,24 @@ def _workflow_envelope_from_raw_headers(
         target_workflow_type=workflow_type,
         mode=mode,
     )
+
+
+def _workflow_headers_for_warrant(
+    warrant: Any,
+    key_id: str,
+    warrant_chain: Optional[List[Any]],
+    *,
+    compress: bool,
+    operation: str,
+) -> Dict[str, bytes]:
+    raw_headers = tenuo_headers(warrant, key_id, compress=compress)
+    chain = list(warrant_chain) if warrant_chain is not None else [warrant]
+    _validate_chain_ends_with_warrant(chain, warrant, operation=operation)
+    if len(chain) > 1:
+        from tenuo_core import encode_warrant_stack
+
+        raw_headers[TENUO_CHAIN_HEADER] = encode_warrant_stack(chain).encode("utf-8")
+    return raw_headers
 
 
 def _coerce_workflow_envelope(envelope: Any) -> TenuoNexusWorkflowEnvelope:

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -4680,6 +4680,20 @@ class TestClientHeadersPendingMapBound:
         assert ci.discard_headers_for_workflow("wf-1") is True
         assert ci.discard_headers_for_workflow("wf-1") is False
 
+    def test_conditional_discard_preserves_rebound_entry(self):
+        from tenuo.temporal._client import TenuoClientInterceptor
+
+        ci = TenuoClientInterceptor()
+        original = {"x-tenuo-warrant": b"original"}
+        rebound = {"x-tenuo-warrant": b"rebound"}
+        ci.set_headers_for_workflow("wf-1", original)
+        ci.set_headers_for_workflow("wf-1", rebound)
+
+        assert ci.discard_headers_for_workflow_if_match("wf-1", original) is False
+        assert ci._headers_by_workflow_id["wf-1"][0] == rebound
+        assert ci.discard_headers_for_workflow_if_match("wf-1", rebound) is True
+        assert "wf-1" not in ci._headers_by_workflow_id
+
     def test_ttl_evicts_stale_entries_on_next_set(self):
         from tenuo.temporal._client import TenuoClientInterceptor
 

--- a/tenuo-python/tests/adapters/test_temporal_nexus.py
+++ b/tenuo-python/tests/adapters/test_temporal_nexus.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 import pytest
 
@@ -18,7 +18,11 @@ from tenuo.approval import ApprovalRequest, sign_approval  # noqa: E402
 from tenuo_core import Exact, Range, SigningKey, Warrant, py_compute_request_hash  # noqa: E402
 
 from tenuo.temporal._config import TenuoPluginConfig  # noqa: E402
-from tenuo.temporal._constants import TENUO_ARG_KEYS_HEADER  # noqa: E402
+from tenuo.temporal._client import TenuoClientInterceptor  # noqa: E402
+from tenuo.temporal._constants import (  # noqa: E402
+    TENUO_ARG_KEYS_HEADER,
+    TENUO_KEY_ID_HEADER,
+)
 from tenuo.temporal._dedup import _default_pop_dedup_store, _pop_dedup_cache  # noqa: E402
 from tenuo.temporal._workflow import current_key_id  # noqa: E402
 from tenuo.temporal._headers import tenuo_headers  # noqa: E402
@@ -37,6 +41,7 @@ from tenuo.temporal._nexus import (  # noqa: E402
     tenuo_nexus_query_workflow,
     tenuo_nexus_signal_workflow,
     tenuo_nexus_start_update,
+    tenuo_start_nexus_workflow,
     verify_nexus_operation,
 )
 from tenuo.temporal._state import (  # noqa: E402
@@ -123,6 +128,34 @@ class FakeNexusClient:
     async def execute_operation(self, operation: Any, input: Any, **kwargs: Any) -> str:
         self.execute_call = (operation, input, kwargs)
         return "accepted"
+
+
+class FakeNexusWorkflowRunContext:
+    def __init__(
+        self,
+        *,
+        headers: dict[str, str],
+        request_id: str = "req-default",
+        service: str = "BillingService",
+        operation: str = "refund",
+        fail_start: bool = False,
+        on_start: Optional[Callable[[], None]] = None,
+    ) -> None:
+        self.request_id = request_id
+        self.service = service
+        self.operation = operation
+        self.headers = headers
+        self.fail_start = fail_start
+        self.on_start = on_start
+        self.start_calls: list[tuple[Any, tuple[Any, ...], dict[str, Any]]] = []
+
+    async def start_workflow(self, workflow_run_fn: Any, *args: Any, **kwargs: Any) -> str:
+        self.start_calls.append((workflow_run_fn, args, kwargs))
+        if self.on_start is not None:
+            self.on_start()
+        if self.fail_start:
+            raise RuntimeError("start failed")
+        return "workflow-handle"
 
 
 class FakeWorkflowHandle:
@@ -1239,6 +1272,51 @@ async def test_nexus_query_and_update_helpers_preserve_sdk_kwargs(
     assert "wait_for_stage" in handle.calls[2][3]
 
 
+async def test_nexus_query_workflow_denial_raises_nexus_unauthorized(
+    nexus_keys: tuple[Any, Any],
+) -> None:
+    root_key, agent_key = nexus_keys
+    signed_input = RouterInput("refund-wf-001", "approve", "yes")
+    ctx, config = _router_ctx_and_config(root_key, agent_key, signed_input)
+    handle = FakeWorkflowHandle()
+
+    with pytest.raises(nexusrpc.HandlerError) as exc:
+        await tenuo_nexus_query_workflow(
+            ctx,
+            RouterInput("refund-wf-999", "approve", "yes"),
+            config,
+            handle,
+            "status",
+            endpoint="billing-prod",
+        )
+
+    assert exc.value.type == nexusrpc.HandlerErrorType.UNAUTHORIZED
+    assert handle.calls == []
+
+
+async def test_nexus_execute_update_denial_raises_nexus_unauthorized(
+    nexus_keys: tuple[Any, Any],
+) -> None:
+    root_key, agent_key = nexus_keys
+    signed_input = RouterInput("refund-wf-001", "approve", "yes")
+    ctx, config = _router_ctx_and_config(root_key, agent_key, signed_input)
+    handle = FakeWorkflowHandle()
+
+    with pytest.raises(nexusrpc.HandlerError) as exc:
+        await tenuo_nexus_execute_update(
+            ctx,
+            RouterInput("refund-wf-999", "approve", "yes"),
+            config,
+            handle,
+            "approve",
+            "yes",
+            endpoint="billing-prod",
+        )
+
+    assert exc.value.type == nexusrpc.HandlerErrorType.UNAUTHORIZED
+    assert handle.calls == []
+
+
 def test_forward_nexus_authority_creates_bootstrap_envelope(
     nexus_keys: tuple[Any, Any],
     nexus_warrant: Any,
@@ -1349,6 +1427,213 @@ def test_create_nexus_workflow_envelope_requires_workflow_id(
 
     with pytest.raises(TenuoContextError, match="requires workflow_id"):
         tenuo_create_nexus_workflow_envelope(workflow_warrant, "handler-key")
+
+
+async def test_start_nexus_workflow_binds_headers_and_starts_backing_workflow(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    handler_key = SigningKey.generate()
+    input = RefundInput("ord_123", 2500)
+    ctx = FakeNexusWorkflowRunContext(
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=input,
+        )
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+    )
+    workflow_warrant = (
+        Warrant.mint_builder()
+        .holder(handler_key.public_key)
+        .capability("RefundWorkflow", order_id=Exact("ord_123"))
+        .ttl(3600)
+        .mint(root_key)
+    )
+    client_interceptor = TenuoClientInterceptor()
+
+    result = await tenuo_start_nexus_workflow(
+        ctx,
+        input,
+        config,
+        client_interceptor,
+        "RefundWorkflow.run",
+        RouterInput("refund-wf-ambient", "refund", "ord_123"),
+        workflow_id="refund-wf-ambient",
+        workflow_warrant=workflow_warrant,
+        workflow_key_id="handler-key",
+        endpoint="billing-prod",
+    )
+
+    assert result == "workflow-handle"
+    assert ctx.start_calls == [
+        (
+            "RefundWorkflow.run",
+            (RouterInput("refund-wf-ambient", "refund", "ord_123"),),
+            {"id": "refund-wf-ambient"},
+        )
+    ]
+    bound_headers = client_interceptor._headers_by_workflow_id["refund-wf-ambient"][0]
+    assert bound_headers[TENUO_KEY_ID_HEADER] == b"handler-key"
+
+
+async def test_start_nexus_workflow_does_not_start_when_nexus_verification_fails(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    handler_key = SigningKey.generate()
+    signed_input = RefundInput("ord_123", 2500)
+    ctx = FakeNexusWorkflowRunContext(
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=signed_input,
+        )
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+    )
+    workflow_warrant = (
+        Warrant.mint_builder()
+        .holder(handler_key.public_key)
+        .capability("RefundWorkflow", order_id=Exact("ord_123"))
+        .ttl(3600)
+        .mint(root_key)
+    )
+    client_interceptor = TenuoClientInterceptor()
+
+    with pytest.raises(nexusrpc.HandlerError) as exc:
+        await tenuo_start_nexus_workflow(
+            ctx,
+            RefundInput("ord_999", 2500),
+            config,
+            client_interceptor,
+            "RefundWorkflow.run",
+            workflow_id="refund-wf-denied",
+            workflow_warrant=workflow_warrant,
+            workflow_key_id="handler-key",
+            endpoint="billing-prod",
+        )
+
+    assert exc.value.type == nexusrpc.HandlerErrorType.UNAUTHORIZED
+    assert ctx.start_calls == []
+    assert "refund-wf-denied" not in client_interceptor._headers_by_workflow_id
+
+
+async def test_start_nexus_workflow_discards_pending_headers_when_start_fails(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    handler_key = SigningKey.generate()
+    input = RefundInput("ord_123", 2500)
+    ctx = FakeNexusWorkflowRunContext(
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=input,
+        ),
+        fail_start=True,
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+    )
+    workflow_warrant = (
+        Warrant.mint_builder()
+        .holder(handler_key.public_key)
+        .capability("RefundWorkflow", order_id=Exact("ord_123"))
+        .ttl(3600)
+        .mint(root_key)
+    )
+    client_interceptor = TenuoClientInterceptor()
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        await tenuo_start_nexus_workflow(
+            ctx,
+            input,
+            config,
+            client_interceptor,
+            "RefundWorkflow.run",
+            workflow_id="refund-wf-failed-start",
+            workflow_warrant=workflow_warrant,
+            workflow_key_id="handler-key",
+            endpoint="billing-prod",
+        )
+
+    assert "refund-wf-failed-start" not in client_interceptor._headers_by_workflow_id
+
+
+async def test_start_nexus_workflow_does_not_discard_newer_rebound_headers(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    handler_key = SigningKey.generate()
+    input = RefundInput("ord_123", 2500)
+    client_interceptor = TenuoClientInterceptor()
+    newer_headers = {TENUO_KEY_ID_HEADER: b"newer-handler-key"}
+    ctx = FakeNexusWorkflowRunContext(
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=input,
+        ),
+        fail_start=True,
+        on_start=lambda: client_interceptor.set_headers_for_workflow(
+            "refund-wf-rebound",
+            newer_headers,
+        ),
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+    )
+    workflow_warrant = (
+        Warrant.mint_builder()
+        .holder(handler_key.public_key)
+        .capability("RefundWorkflow", order_id=Exact("ord_123"))
+        .ttl(3600)
+        .mint(root_key)
+    )
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        await tenuo_start_nexus_workflow(
+            ctx,
+            input,
+            config,
+            client_interceptor,
+            "RefundWorkflow.run",
+            workflow_id="refund-wf-rebound",
+            workflow_warrant=workflow_warrant,
+            workflow_key_id="handler-key",
+            endpoint="billing-prod",
+        )
+
+    rebound_headers = client_interceptor._headers_by_workflow_id["refund-wf-rebound"][0]
+    assert rebound_headers == newer_headers
 
 
 def test_bootstrap_nexus_workflow_installs_envelope_headers(

--- a/tenuo-python/tests/e2e/test_temporal_nexus_live.py
+++ b/tenuo-python/tests/e2e/test_temporal_nexus_live.py
@@ -7,6 +7,7 @@ version bundled by the Python SDK.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from dataclasses import dataclass
 from datetime import timedelta
@@ -39,7 +40,7 @@ from temporalio.worker.workflow_sandbox import (  # noqa: E402
 )
 
 import tenuo  # noqa: F401, E402 - installs Warrant.mint_builder()
-from tenuo_core import Exact, Range, SigningKey, Warrant  # noqa: E402
+from tenuo_core import Exact, Pattern, Range, SigningKey, Warrant  # noqa: E402
 
 from tenuo.temporal import (  # noqa: E402
     KeyResolver,
@@ -55,6 +56,7 @@ from tenuo.temporal import (  # noqa: E402
     tenuo_forward_nexus_authority,
     tenuo_headers,
     tenuo_nexus_operation,
+    tenuo_start_nexus_workflow,
     verify_nexus_operation,
 )
 
@@ -140,6 +142,22 @@ class NexusRawCallerWorkflow:
             endpoint=endpoint,
         )
         return await nexus_client.execute_operation(
+            HeaderProbeService.header_probe,
+            HeaderProbeInput(message=message),
+            schedule_to_close_timeout=timedelta(seconds=10),
+        )
+
+
+@workflow.defn
+class TenuoHeaderProbeCallerWorkflow:
+    @workflow.run
+    async def run(self, endpoint: str, message: str) -> str:
+        nexus_client = workflow.create_nexus_client(
+            service=HeaderProbeService,
+            endpoint=endpoint,
+        )
+        return await tenuo_execute_nexus_operation(
+            nexus_client,
             HeaderProbeService.header_probe,
             HeaderProbeInput(message=message),
             schedule_to_close_timeout=timedelta(seconds=10),
@@ -491,6 +509,7 @@ async def test_live_cross_namespace_nexus_operation_authorizes_headers() -> None
 @pytest.mark.asyncio
 async def test_live_nexus_backing_start_can_use_interceptor_bound_headers() -> None:
     control_key = SigningKey.generate()
+    agent_key = SigningKey.generate()
     handler_key = SigningKey.generate()
 
     suffix = uuid.uuid4().hex[:10]
@@ -499,7 +518,10 @@ async def test_live_nexus_backing_start_can_use_interceptor_bound_headers() -> N
     caller_task_queue = f"tenuo-caller-tq-{suffix}"
     handler_task_queue = f"tenuo-handler-tq-{suffix}"
     endpoint_name = f"tenuo-nexus-{suffix}"
-    caller_workflow_id = f"tenuo-nexus-header-probe-{suffix}"
+    caller_workflow_ids = [
+        f"tenuo-nexus-header-probe-a-{suffix}",
+        f"tenuo-nexus-header-probe-b-{suffix}",
+    ]
 
     async with await WorkflowEnvironment.start_local() as env:
         try:
@@ -516,7 +538,12 @@ async def test_live_nexus_backing_start_can_use_interceptor_bound_headers() -> N
 
         try:
             target = env.client.service_client.config.target_host
-            caller_client = await Client.connect(target, namespace=caller_namespace)
+            caller_headers = TenuoClientInterceptor()
+            caller_client = await Client.connect(
+                target,
+                namespace=caller_namespace,
+                interceptors=[caller_headers],  # type: ignore[list-item]
+            )
             handler_headers = TenuoClientInterceptor()
             handler_client = await Client.connect(
                 target,
@@ -524,9 +551,33 @@ async def test_live_nexus_backing_start_can_use_interceptor_bound_headers() -> N
                 interceptors=[handler_headers],  # type: ignore[list-item]
             )
             config = TenuoPluginConfig(
-                key_resolver=DictKeyResolver({"handler1": handler_key}),
+                key_resolver=DictKeyResolver(
+                    {
+                        "agent1": agent_key,
+                        "handler1": handler_key,
+                    }
+                ),
                 trusted_roots=[control_key.public_key],
             )
+            warrant = (
+                Warrant.mint_builder()
+                .holder(agent_key.public_key)
+                .capability(
+                    nexus_tool_name(
+                        endpoint_name,
+                        "header_probe",
+                        service="HeaderProbeService",
+                    ),
+                    message=Pattern("hello-*"),
+                )
+                .ttl(3600)
+                .mint(control_key)
+            )
+            for workflow_id in caller_workflow_ids:
+                caller_headers.set_headers_for_workflow(
+                    workflow_id,
+                    tenuo_headers(warrant, "agent1"),
+                )
 
             @nexus_handler.service_handler(service=HeaderProbeService)
             class HeaderProbeServiceHandler:
@@ -547,14 +598,17 @@ async def test_live_nexus_backing_start_can_use_interceptor_bound_headers() -> N
                         .ttl(3600)
                         .mint(control_key)
                     )
-                    handler_headers.set_headers_for_workflow(
-                        workflow_id,
-                        tenuo_headers(warrant, "handler1"),
-                    )
-                    return await ctx.start_workflow(
+                    return await tenuo_start_nexus_workflow(
+                        ctx,
+                        input,
+                        config,
+                        handler_headers,
                         HeaderProbeWorkflow.run,
                         input,
-                        id=workflow_id,
+                        workflow_id=workflow_id,
+                        workflow_warrant=warrant,
+                        workflow_key_id="handler1",
+                        endpoint=endpoint_name,
                     )
 
             sandbox_runner = SandboxedWorkflowRunner(
@@ -574,19 +628,28 @@ async def test_live_nexus_backing_start_can_use_interceptor_bound_headers() -> N
             ), Worker(
                 caller_client,
                 task_queue=caller_task_queue,
-                workflows=[NexusRawCallerWorkflow],
+                workflows=[TenuoHeaderProbeCallerWorkflow],
+                interceptors=[TenuoWorkerInterceptor(config, task_queue=caller_task_queue)],
                 workflow_runner=sandbox_runner,
             ):
-                result = await caller_client.execute_workflow(
-                    NexusRawCallerWorkflow.run,
-                    args=[endpoint_name, "hello"],
-                    id=caller_workflow_id,
-                    task_queue=caller_task_queue,
-                    execution_timeout=timedelta(seconds=20),
-                    retry_policy=RetryPolicy(maximum_attempts=1),
+                results = await asyncio.gather(
+                    *[
+                        caller_client.execute_workflow(
+                            TenuoHeaderProbeCallerWorkflow.run,
+                            args=[endpoint_name, message],
+                            id=workflow_id,
+                            task_queue=caller_task_queue,
+                            execution_timeout=timedelta(seconds=20),
+                            retry_policy=RetryPolicy(maximum_attempts=1),
+                        )
+                        for workflow_id, message in zip(
+                            caller_workflow_ids,
+                            ["hello-a", "hello-b"],
+                        )
+                    ]
                 )
 
-            assert result == "handler1:hello"
+            assert sorted(results) == ["handler1:hello-a", "handler1:hello-b"]
         finally:
             try:
                 await _delete_nexus_endpoint(env.client, endpoint_id, endpoint_version)


### PR DESCRIPTION
## Summary
- Add `tenuo_start_nexus_workflow(...)`, a workflow-run Nexus helper that verifies the incoming Nexus request, binds handler-minted workflow authority to the exact backing `workflow_id` through `TenuoClientInterceptor`, then calls `ctx.start_workflow(...)`.
- Share workflow warrant/header construction with the existing envelope path so chain handling does not drift.
- Fail safely on missing workflow id, missing workflow warrant/key id, duplicate `id=`, or missing handler-side client interceptor support.
- Clear stale pending header bindings only when the stored binding still matches the one this call inserted, preserving newer concurrent rebindings for the same workflow id.
- Preserve Nexus-native `UNAUTHORIZED` errors for signal/query/update/start-update helpers and the new ambient helper.
- Update the live Nexus proof to exercise two concurrent cross-namespace backing workflow starts over the interceptor path.
- Reframe the Nexus docs so ambient header propagation is the preferred handler-minted backing workflow path, while envelopes remain available for forwarding/manual transports.

## Validation
- `python3 -m pytest tests/adapters/test_temporal_nexus.py tests/adapters/test_temporal.py::TestClientHeadersPendingMapBound tests/unit/test_templates.py -q` — 97 passed
- `python3 -m ruff check tenuo/temporal/_nexus.py tenuo/temporal/_client.py tenuo/temporal/__init__.py tests/adapters/test_temporal_nexus.py tests/adapters/test_temporal.py tests/e2e/test_temporal_nexus_live.py`
- `python3 -m mypy tenuo/`
- `git diff --check`
- `python3 -m pytest tests/e2e/test_temporal_nexus_live.py::test_live_nexus_backing_start_can_use_interceptor_bound_headers -v -m temporal_live` — passed against local Temporal dev server