### PR TITLE
feat(temporal): make Nexus authorization production-ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and clears stale pending headers if startup fails before the interceptor
   consumes them. The live Nexus test now exercises concurrent backing starts
   over this interceptor path.
+- **Temporal Nexus production hardening.** `TenuoWorkerInterceptor` now
+  authorizes inbound Nexus starts by default when
+  `TenuoPluginConfig.nexus_endpoint` is set, wires `control_plane` onto the
+  shared config object used by verify/decorators, and emits `audit_callback`
+  plus metrics for Nexus allow/deny. Ambient backing starts fail closed if the
+  client interceptor does not consume the pending header binding.
 - **Temporal per-Activity warrant overrides.**
   `tenuo_execute_activity(..., warrant=..., key_id=...)` now applies a
   task-local warrant to one dispatch, including the active delegation chain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TenuoPluginConfig.nexus_endpoint` is set, wires `control_plane` onto the
   shared config object used by verify/decorators, and emits `audit_callback`
   plus metrics for Nexus allow/deny. Ambient backing starts fail closed if the
-  client interceptor does not consume the pending header binding.
+  client interceptor does not consume the pending header binding. Strict Nexus
+  PoP replay is bound to handler namespace, task queue, and `request_id`.
 - **Temporal per-Activity warrant overrides.**
   `tenuo_execute_activity(..., warrant=..., key_id=...)` now applies a
   task-local warrant to one dispatch, including the active delegation chain.

--- a/docs/temporal-nexus.md
+++ b/docs/temporal-nexus.md
@@ -53,6 +53,11 @@ The `billing-namespace` handler verifies the Tenuo warrant before performing
 the refund:
 
 ```python
+config = TenuoPluginConfig(
+    ...,
+    nexus_endpoint="billing-prod",
+)
+
 class BillingServiceHandler:
     @tenuo_nexus_operation(config, endpoint="billing-prod")
     async def refund(self, ctx, input: RefundInput) -> RefundOutput:
@@ -102,6 +107,12 @@ pass them as `approvals=[...]` on the caller helper. Nexus uses the same
 
 ### Handler verifier
 
+`TenuoWorkerInterceptor` authorizes inbound Nexus starts by default. Set
+`TenuoPluginConfig.nexus_endpoint` to the endpoint name this worker serves.
+A missing `@tenuo_nexus_operation` decorator can no longer skip authorization
+on a Tenuo worker. The decorator remains useful for tests and for making the
+endpoint explicit in handler source.
+
 The handler-side surface verifies `ctx.headers` before user code runs:
 
 - warrant chain roots, signatures, linkage, expiry, and revocation;
@@ -117,12 +128,13 @@ The handler-side surface verifies `ctx.headers` before user code runs:
 Authorization failures should raise Nexus-native non-retryable errors so
 Temporal does not retry permanent denials.
 
-Handlers must pass `endpoint=` explicitly so the signed tool string is stable
-and visible in application code. When the installed Temporal SDK exposes the
-live handler endpoint, Tenuo cross-checks it against the explicit value and
-rejects mismatches instead of accepting warrants scoped to the wrong endpoint.
-Tenuo intentionally refuses to fall back to a placeholder endpoint because
-endpoint names are part of the signed security boundary.
+Set `TenuoPluginConfig.nexus_endpoint` (and pass the same value as
+`endpoint=` on helpers) so the signed tool string is stable. When the
+installed Temporal SDK exposes the live handler endpoint, Tenuo cross-checks
+it against the configured value and rejects mismatches instead of accepting
+warrants scoped to the wrong endpoint. Tenuo intentionally refuses to fall
+back to a placeholder endpoint because endpoint names are part of the signed
+security boundary.
 
 The supported APIs are:
 
@@ -179,10 +191,11 @@ Three modes are supported:
   migration, or cases where making bootstrap explicit in the workflow input is
   desirable.
 
-The ambient helper requires a `TenuoClientInterceptor` installed on the handler
-namespace client. If `ctx.start_workflow(...)` fails before the interceptor
-consumes the pending header binding, Tenuo discards that binding so stale
-authority does not sit in memory until TTL eviction.
+The ambient helper requires the `TenuoClientInterceptor` instance installed on
+the handler namespace client. After a successful `ctx.start_workflow(...)`,
+Tenuo fails closed if that interceptor did not consume the pending header
+binding. If start fails before consume, Tenuo discards only the matching
+binding so a concurrent rebound of the same `workflow_id` stays intact.
 
 Envelope-backed workflows call `tenuo_bootstrap_nexus_workflow(input.tenuo)`
 before `current_warrant()`, `current_key_id()`, or
@@ -466,7 +479,30 @@ Tenuo normalizes the decoded Nexus operation input before checking warrant
 constraints. Python-to-Python callers can usually rely on dataclass or mapping
 field names. Polyglot services should define explicit JSON or protobuf field
 names and keep those names stable, because warrant constraints are written
-against the decoded argument shape.
+against the decoded argument shape. Non-Python callers must send the same
+`x-tenuo-*` headers that `tenuo_nexus_headers(...)` emits, including
+`x-tenuo-tool-name` and `x-tenuo-arg-keys`.
+
+## Production checklist
+
+Ship a Tenuo Nexus worker only when all of these are true:
+
+- `TenuoPluginConfig.nexus_endpoint` is set to the endpoint this worker serves.
+- The worker is constructed with `TenuoWorkerInterceptor` or
+  `TenuoTemporalPlugin`, so inbound Nexus starts are authorized by default.
+- Backing workflow starts use `tenuo_start_nexus_workflow(...)` with the
+  `TenuoClientInterceptor` instance installed on the handler client.
+- Backing workflows are not startable by untrusted clients.
+- `control_plane` is set, or you rely on the interceptor to attach
+  `get_or_create()` to the same config object used by verify/decorators.
+- `audit_callback` is set if you need in-process Temporal audit events for
+  Nexus allow/deny (control-plane emission is not a substitute).
+- Multi-worker fleets that enable `nexus_pop_replay_protection=True` also set
+  a shared owner-aware `pop_dedup_store`. Otherwise prefer stable backing
+  `workflow_id` values and Temporal conflict policy for at-least-once delivery.
+- Polyglot callers share the same canonical tool string
+  (`nexus:<endpoint>:<service>:<operation>`) and the same top-level input
+  field names the warrant constrains.
 
 ## Phased implementation
 
@@ -492,8 +528,9 @@ against the decoded argument shape.
      the envelope into normal Tenuo workflow context.
 
 4. **Production rollout guide**
-   - Cover endpoint naming, namespace boundaries, revocation providers, trusted
-     roots, operation naming, input normalization, retries, and observability.
+   - Covered above: interceptor-default Nexus authorization, shared
+     control-plane/audit wiring, ambient backing starts, endpoint naming,
+     replay vs workflow-id idempotency, and polyglot header contracts.
 
 5. **Enterprise router helpers**
    - Add first-class helpers for Nexus handlers that authorize the incoming
@@ -502,16 +539,11 @@ against the decoded argument shape.
 
 ## Open questions
 
-- Should Nexus PoP bind the endpoint name only, or endpoint + resolved handler
-  namespace/task queue when available?
-- Should operation constraints use the service contract operation name, the
-  Python handler method name, or an explicit Tenuo tool mapping?
-- Should the workflow envelope grow an additional handler signature over the
-  target workflow binding, or is mandatory `workflow_id` binding plus
-  Temporal's handler-created input boundary sufficient for the first
-  surface?
-- Should a denied Nexus operation be represented as `UNAUTHORIZED` or as a
-  Tenuo-specific non-retryable operation error with structured details?
+- Should Nexus PoP later also bind the resolved handler namespace or task
+  queue, or is the explicit endpoint name enough for this surface?
+- v1 decisions already locked: tool names use
+  `nexus:<endpoint>:<service>:<operation>`; ambient header starts are preferred
+  over envelopes; handler denials use Nexus `UNAUTHORIZED`.
 
 ## References
 

--- a/docs/temporal-nexus.md
+++ b/docs/temporal-nexus.md
@@ -441,15 +441,18 @@ Nexus delivery is at-least-once. Tenuo verifies authority, but replay
 suppression is not enabled by default because identical repeat calls can share
 the same PoP signature inside the core PoP time bucket. If you enable
 `TenuoPluginConfig.nexus_pop_replay_protection=True`, Tenuo rejects a captured
-PoP signature reused under a different Nexus `request_id`, while allowing the
-same signature with the same `request_id` as a Temporal redelivery. Use a
+PoP signature reused under a different handler namespace, task queue, or Nexus
+`request_id`, while allowing the same signature on the same namespace, task
+queue, and `request_id` as a Temporal redelivery. Namespace comes from the
+handler Temporal client; task queue comes from `temporalio.nexus.info()`. Use a
 shared owner-aware `pop_dedup_store` for multi-worker or multi-namespace
 deployments.
 
 Replay suppression still does not make arbitrary handler side effects
-idempotent, and a captured PoP replayed with the captured `request_id` is
-indistinguishable from Temporal redelivery. For workflow-backed operations,
-derive a stable workflow id from the business request and use Temporal's
+idempotent, and a captured PoP replayed with the same namespace, task queue,
+and `request_id` is indistinguishable from Temporal redelivery. For
+workflow-backed operations, derive a stable workflow id from the business
+request and use Temporal's
 workflow id conflict policy to dedupe retried or duplicated Nexus starts; sync
 operations need their own business idempotency if duplicate effects matter.
 `tenuo_create_nexus_workflow_envelope(...)` and
@@ -498,7 +501,8 @@ Ship a Tenuo Nexus worker only when all of these are true:
 - `audit_callback` is set if you need in-process Temporal audit events for
   Nexus allow/deny (control-plane emission is not a substitute).
 - Multi-worker fleets that enable `nexus_pop_replay_protection=True` also set
-  a shared owner-aware `pop_dedup_store`. Otherwise prefer stable backing
+  a shared owner-aware `pop_dedup_store`. Replay ownership includes handler
+  namespace, task queue, and `request_id`. Otherwise prefer stable backing
   `workflow_id` values and Temporal conflict policy for at-least-once delivery.
 - Polyglot callers share the same canonical tool string
   (`nexus:<endpoint>:<service>:<operation>`) and the same top-level input
@@ -539,11 +543,10 @@ Ship a Tenuo Nexus worker only when all of these are true:
 
 ## Open questions
 
-- Should Nexus PoP later also bind the resolved handler namespace or task
-  queue, or is the explicit endpoint name enough for this surface?
 - v1 decisions already locked: tool names use
   `nexus:<endpoint>:<service>:<operation>`; ambient header starts are preferred
-  over envelopes; handler denials use Nexus `UNAUTHORIZED`.
+  over envelopes; handler denials use Nexus `UNAUTHORIZED`; strict PoP replay
+  is owned by handler namespace + task queue + `request_id`.
 
 ## References
 

--- a/tenuo-python/tenuo/temporal/_client.py
+++ b/tenuo-python/tenuo/temporal/_client.py
@@ -163,6 +163,19 @@ class TenuoClientInterceptor(_TemporalClientInterceptor):
         with self._lock:
             return self._headers_by_workflow_id.pop(workflow_id, None) is not None
 
+    def pending_headers_match(
+        self,
+        workflow_id: str,
+        headers: Dict[str, bytes],
+    ) -> bool:
+        """Return True when *workflow_id* still has pending headers equal to *headers*."""
+        with self._lock:
+            existing = self._headers_by_workflow_id.get(workflow_id)
+            if existing is None:
+                return False
+            existing_headers, _inserted_at = existing
+            return existing_headers == headers
+
     def discard_headers_for_workflow_if_match(
         self,
         workflow_id: str,

--- a/tenuo-python/tenuo/temporal/_client.py
+++ b/tenuo-python/tenuo/temporal/_client.py
@@ -68,10 +68,12 @@ class TenuoClientInterceptor(_TemporalClientInterceptor):
         self._next_headers: Dict[str, bytes] = {}
         # ``OrderedDict`` so we can evict oldest-first when the bound grows
         # past ``_pending_headers_max_size``. Entry value is
-        # ``(headers, insert_monotonic_time)`` so TTL eviction is cheap.
-        self._headers_by_workflow_id: "OrderedDict[str, Tuple[Dict[str, bytes], float]]" = (
+        # ``(headers, insert_monotonic_time, generation)`` so TTL eviction is
+        # cheap and race-safe cleanup can distinguish identical rebindings.
+        self._headers_by_workflow_id: "OrderedDict[str, Tuple[Dict[str, bytes], float, int]]" = (
             OrderedDict()
         )
+        self._pending_headers_generation: int = 0
         self._lock = threading.Lock()
         self._pending_headers_max_size: int = (
             pending_headers_max_size
@@ -91,7 +93,7 @@ class TenuoClientInterceptor(_TemporalClientInterceptor):
             return
         now = time.monotonic()
         expired: List[str] = []
-        for wf_id, (_headers, inserted_at) in self._headers_by_workflow_id.items():
+        for wf_id, (_headers, inserted_at, _generation) in self._headers_by_workflow_id.items():
             if (now - inserted_at) < ttl:
                 # OrderedDict preserves insertion order; once we hit a fresh
                 # entry everything after is also fresh.
@@ -116,7 +118,7 @@ class TenuoClientInterceptor(_TemporalClientInterceptor):
         with self._lock:
             self._next_headers = dict(headers)
 
-    def set_headers_for_workflow(self, workflow_id: str, headers: Dict[str, bytes]) -> None:
+    def set_headers_for_workflow(self, workflow_id: str, headers: Dict[str, bytes]) -> int:
         """Set headers for a specific workflow ID.
 
         This is concurrency-safe and deterministic for multi-tenant clients.
@@ -129,16 +131,24 @@ class TenuoClientInterceptor(_TemporalClientInterceptor):
         comes first. This protects long-running clients from unbounded
         growth. Callers can also call :meth:`discard_headers_for_workflow`
         to drop an entry explicitly.
+
+        Returns a generation token that can be passed to
+        :meth:`discard_headers_for_workflow_if_match` or
+        :meth:`pending_headers_match` when cleanup must not race with a newer
+        binding for the same workflow id.
         """
         if not workflow_id:
             raise ValueError("workflow_id must be a non-empty string")
         with self._lock:
             self._evict_expired_locked()
+            self._pending_headers_generation += 1
+            generation = self._pending_headers_generation
             # Move-to-end semantics so explicit re-binding refreshes the TTL.
             self._headers_by_workflow_id.pop(workflow_id, None)
             self._headers_by_workflow_id[workflow_id] = (
                 dict(headers),
                 time.monotonic(),
+                generation,
             )
             max_size = self._pending_headers_max_size
             if max_size > 0:
@@ -152,6 +162,7 @@ class TenuoClientInterceptor(_TemporalClientInterceptor):
                         max_size,
                         evicted_id,
                     )
+            return generation
 
     def discard_headers_for_workflow(self, workflow_id: str) -> bool:
         """Drop any pending headers bound to *workflow_id*.
@@ -167,33 +178,40 @@ class TenuoClientInterceptor(_TemporalClientInterceptor):
         self,
         workflow_id: str,
         headers: Dict[str, bytes],
+        token: Optional[int] = None,
     ) -> bool:
         """Return True when *workflow_id* still has pending headers equal to *headers*."""
         with self._lock:
             existing = self._headers_by_workflow_id.get(workflow_id)
             if existing is None:
                 return False
-            existing_headers, _inserted_at = existing
-            return existing_headers == headers
+            existing_headers, _inserted_at, existing_token = existing
+            return existing_headers == headers and (
+                token is None or existing_token == token
+            )
 
     def discard_headers_for_workflow_if_match(
         self,
         workflow_id: str,
         headers: Dict[str, bytes],
+        token: Optional[int] = None,
     ) -> bool:
         """Drop pending headers only when they still match *headers*.
 
         Use this when a caller bound headers for a start attempt that failed
         before the interceptor consumed them. If another concurrent attempt has
-        since rebound the same workflow id, this method leaves that newer
-        binding intact.
+        since rebound the same workflow id, pass the generation token returned
+        by :meth:`set_headers_for_workflow` so this method leaves that newer
+        binding intact even when the header bytes are identical.
         """
         with self._lock:
             existing = self._headers_by_workflow_id.get(workflow_id)
             if existing is None:
                 return False
-            existing_headers, _inserted_at = existing
-            if existing_headers != headers:
+            existing_headers, _inserted_at, existing_token = existing
+            if existing_headers != headers or (
+                token is not None and existing_token != token
+            ):
                 return False
             self._headers_by_workflow_id.pop(workflow_id, None)
             return True

--- a/tenuo-python/tenuo/temporal/_config.py
+++ b/tenuo-python/tenuo/temporal/_config.py
@@ -228,7 +228,18 @@ class TenuoPluginConfig:
     can reject legitimate rapid repeats. High-value Nexus operations should
     prefer workflow-backed idempotency via stable workflow ids/conflict policy;
     enable this flag only when duplicate identical operation/input calls within
-    the PoP bucket are not expected or are acceptable to reject.
+    the PoP bucket are not expected or are acceptable to reject. Multi-worker
+    deployments that enable this flag must also set ``pop_dedup_store`` to a
+    shared owner-aware backend.
+    """
+
+    nexus_endpoint: Optional[str] = None
+    """
+    Endpoint name this worker serves for inbound Nexus authorization.
+
+    Required when the worker handles Nexus operations. ``TenuoWorkerInterceptor``
+    verifies every Nexus start against this endpoint by default so a missing
+    ``@tenuo_nexus_operation`` decorator cannot skip authorization.
     """
 
     authorized_signals: Optional[List[str]] = None

--- a/tenuo-python/tenuo/temporal/_config.py
+++ b/tenuo-python/tenuo/temporal/_config.py
@@ -219,9 +219,10 @@ class TenuoPluginConfig:
     Opt-in strict Nexus PoP replay suppression.
 
     When enabled, ``verify_nexus_operation()`` rejects reuse of the same PoP
-    signature under a different Nexus ``request_id``. This detects captured
-    header replay across the Nexus boundary while allowing Temporal redelivery
-    of the same request id.
+    signature under a different handler namespace, task queue, or Nexus
+    ``request_id``. This detects captured header replay across the Nexus
+    boundary while allowing Temporal redelivery of the same request on the
+    same handler worker identity.
 
     Default is ``False`` because the core PoP signature can be identical for
     repeated identical calls inside the PoP time bucket, so strict suppression

--- a/tenuo-python/tenuo/temporal/_dedup.py
+++ b/tenuo-python/tenuo/temporal/_dedup.py
@@ -49,10 +49,10 @@ class PopDedupStore(Protocol):
 class OwnerAwarePopDedupStore(PopDedupStore, Protocol):
     """Optional extension for Nexus PoP replay suppression.
 
-    Nexus uses the PoP signature as the replay key and the Nexus ``request_id``
-    as the owner: the same signature with the same request id is a permitted
-    redelivery, while the same signature with a different request id is a
-    replay.
+    Nexus uses the PoP signature as the replay key and
+    ``namespace + task_queue + request_id`` as the owner: the same signature
+    on the same handler namespace, task queue, and request id is a permitted
+    redelivery, while the same signature with a different owner is a replay.
     """
 
     def check_pop_replay_for_owner(
@@ -147,7 +147,7 @@ class InMemoryPopDedupStore:
                     raise PopVerificationError(
                         reason=(
                             "replay detected (PoP signature already used for "
-                            f"different request_id {existing_owner!r})"
+                            f"different request owner {existing_owner!r})"
                         ),
                         activity_name=activity_name,
                     )

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -676,8 +676,12 @@ class TenuoNexusOperationInboundInterceptor(_NexusOperationInboundInterceptor):
             raise_nexus_error=True,
         )
         from tenuo.temporal._nexus import (
+            _ctx_tool_name,
+            _nexus_verified_args,
             _nexus_verified_request_id,
+            _nexus_verified_tool_name,
             _nexus_verified_warrant,
+            nexus_input_args,
         )
 
         request_id = getattr(input.ctx, "request_id", None)
@@ -685,9 +689,15 @@ class TenuoNexusOperationInboundInterceptor(_NexusOperationInboundInterceptor):
             str(request_id) if request_id is not None else None
         )
         warrant_token = _nexus_verified_warrant.set(warrant)
+        tool_token = _nexus_verified_tool_name.set(
+            _ctx_tool_name(input.ctx, endpoint, None, None)
+        )
+        args_token = _nexus_verified_args.set(nexus_input_args(input.input))
         try:
             return await self.next.execute_nexus_operation_start(input)
         finally:
+            _nexus_verified_args.reset(args_token)
+            _nexus_verified_tool_name.reset(tool_token)
             _nexus_verified_request_id.reset(request_token)
             _nexus_verified_warrant.reset(warrant_token)
 

--- a/tenuo-python/tenuo/temporal/_interceptors.py
+++ b/tenuo-python/tenuo/temporal/_interceptors.py
@@ -121,12 +121,21 @@ except ImportError:
 
 # Temporal interceptor base classes — fallback to object when not installed
 _TemporalWorkerInterceptor: Any
+_NexusOperationInboundInterceptor: Any
 try:
     from temporalio.worker import Interceptor as _tw_interceptor
 
     _TemporalWorkerInterceptor = _tw_interceptor
 except ImportError:  # pragma: no cover
     _TemporalWorkerInterceptor = object
+try:
+    from temporalio.worker import (
+        NexusOperationInboundInterceptor as _nx_inbound,
+    )
+
+    _NexusOperationInboundInterceptor = _nx_inbound
+except ImportError:  # pragma: no cover
+    _NexusOperationInboundInterceptor = object
 
 
 # ── Utility helpers ──────────────────────────────────────────────────────
@@ -537,15 +546,10 @@ class TenuoWorkerInterceptor(_TemporalWorkerInterceptor):
 
         if config.control_plane is None:
             from tenuo.control_plane import get_or_create
-            # NB: we deliberately avoid ``dataclasses.replace(config, ...)``
-            # here: ``replace`` re-runs ``__post_init__``, which would fail
-            # for configs built with ``trusted_roots_provider=`` because
-            # the first post-init has already seeded ``trusted_roots`` from
-            # the provider and the second run would see both fields
-            # populated and raise ``ConfigurationError``. A shallow copy
-            # preserves the already-resolved state.
-            import copy as _copy
-            config = _copy.copy(config)
+            # Mutate the caller's config in place so Nexus verify/decorators
+            # that captured this object see the same control-plane client.
+            # Do not use ``dataclasses.replace``: it re-runs ``__post_init__``
+            # and fails configs built with ``trusted_roots_provider=``.
             config.control_plane = get_or_create()
         self._config = config
         self._version = self._get_version()
@@ -622,6 +626,10 @@ class TenuoWorkerInterceptor(_TemporalWorkerInterceptor):
             self._version,
         )
 
+    def intercept_nexus_operation(self, next: Any) -> Any:
+        """Authorize every inbound Nexus start before handler code runs."""
+        return TenuoNexusOperationInboundInterceptor(next, self._config)
+
     def workflow_interceptor_class(
         self,
         input: Any,
@@ -634,6 +642,54 @@ class TenuoWorkerInterceptor(_TemporalWorkerInterceptor):
             {"_config": bound_config},
         )
         return interceptor_cls
+
+
+# ── Nexus Inbound Interceptor ────────────────────────────────────────────
+
+
+class TenuoNexusOperationInboundInterceptor(_NexusOperationInboundInterceptor):
+    """Verify Tenuo headers on every inbound Nexus operation start."""
+
+    def __init__(self, next_interceptor: Any, config: Any) -> None:
+        if _NexusOperationInboundInterceptor is object:
+            self.next = next_interceptor
+        else:
+            super().__init__(next_interceptor)
+        self._config = config
+
+    async def execute_nexus_operation_start(self, input: Any) -> Any:
+        from tenuo.temporal.exceptions import TenuoContextError
+        from tenuo.temporal._nexus import verify_nexus_operation
+
+        endpoint = getattr(self._config, "nexus_endpoint", None)
+        if not endpoint:
+            raise TenuoContextError(
+                "TenuoPluginConfig.nexus_endpoint is required when this worker "
+                "handles Nexus operations. Set it to the endpoint name this "
+                "worker serves so inbound Nexus calls are authorized by default."
+            )
+        warrant = verify_nexus_operation(
+            input.ctx,
+            input.input,
+            self._config,
+            endpoint=endpoint,
+            raise_nexus_error=True,
+        )
+        from tenuo.temporal._nexus import (
+            _nexus_verified_request_id,
+            _nexus_verified_warrant,
+        )
+
+        request_id = getattr(input.ctx, "request_id", None)
+        request_token = _nexus_verified_request_id.set(
+            str(request_id) if request_id is not None else None
+        )
+        warrant_token = _nexus_verified_warrant.set(warrant)
+        try:
+            return await self.next.execute_nexus_operation_start(input)
+        finally:
+            _nexus_verified_request_id.reset(request_token)
+            _nexus_verified_warrant.reset(warrant_token)
 
 
 # ── Activity Inbound Interceptor ─────────────────────────────────────────

--- a/tenuo-python/tenuo/temporal/_nexus.py
+++ b/tenuo-python/tenuo/temporal/_nexus.py
@@ -62,6 +62,14 @@ _nexus_verified_warrant: ContextVar[Any] = ContextVar(
     "tenuo_nexus_verified_warrant",
     default=None,
 )
+_nexus_verified_tool_name: ContextVar[Optional[str]] = ContextVar(
+    "tenuo_nexus_verified_tool_name",
+    default=None,
+)
+_nexus_verified_args: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+    "tenuo_nexus_verified_args",
+    default=None,
+)
 
 
 class _NexusEndpointMismatch(TenuoContextError):
@@ -257,12 +265,24 @@ def verify_nexus_operation(
     """
     request_id = getattr(ctx, "request_id", None)
     cached_request_id = _nexus_verified_request_id.get()
+    cached_warrant = _nexus_verified_warrant.get()
     if (
         request_id is not None
         and cached_request_id == str(request_id)
-        and _nexus_verified_warrant.get() is not None
+        and cached_warrant is not None
     ):
-        return _nexus_verified_warrant.get()
+        try:
+            tool_name = _ctx_tool_name(ctx, endpoint, service, operation)
+            args = nexus_input_args(input)
+        except Exception as exc:
+            if raise_nexus_error:
+                raise _as_nexus_unauthorized(exc) from exc
+            raise
+        if (
+            _nexus_verified_tool_name.get() == tool_name
+            and _nexus_verified_args.get() == args
+        ):
+            return cached_warrant
     try:
         return _verify_nexus_operation(
             ctx,
@@ -648,7 +668,10 @@ async def tenuo_start_nexus_workflow(
         compress=compress,
         operation="tenuo_start_nexus_workflow",
     )
-    client_interceptor.set_headers_for_workflow(workflow_id, workflow_headers)
+    header_token = client_interceptor.set_headers_for_workflow(
+        workflow_id,
+        workflow_headers,
+    )
     try:
         if workflow_input is _UNSET:
             result = await ctx.start_workflow(
@@ -670,17 +693,21 @@ async def tenuo_start_nexus_workflow(
             None,
         )
         if callable(discard):
-            discard(workflow_id, workflow_headers)
+            discard(workflow_id, workflow_headers, header_token)
         raise
     still_pending = getattr(client_interceptor, "pending_headers_match", None)
-    if callable(still_pending) and still_pending(workflow_id, workflow_headers):
+    if callable(still_pending) and still_pending(
+        workflow_id,
+        workflow_headers,
+        header_token,
+    ):
         discard = getattr(
             client_interceptor,
             "discard_headers_for_workflow_if_match",
             None,
         )
         if callable(discard):
-            discard(workflow_id, workflow_headers)
+            discard(workflow_id, workflow_headers, header_token)
         raise TenuoContextError(
             "TenuoClientInterceptor did not consume pending headers for "
             f"workflow_id={workflow_id!r}. Pass the interceptor instance "
@@ -996,14 +1023,14 @@ def _check_nexus_pop_replay(
             "Nexus PoP replay protection requires pop_dedup_store to implement "
             "check_pop_replay_for_owner(dedup_key, owner_id, now, ttl_seconds, ...)."
         )
-    request_id = _ctx_request_id(ctx)
+    owner_id = _nexus_replay_owner_id(ctx)
     dedup_key = f"nexus-pop:{hashlib.sha256(pop_bytes).hexdigest()}"
     now = time.time()
     from tenuo_core import Warrant
 
     owner_method(
         dedup_key,
-        request_id,
+        owner_id,
         now,
         float(Warrant.dedup_ttl_secs()),
         activity_name=tool_name,
@@ -1018,6 +1045,59 @@ def _ctx_request_id(ctx: Any) -> str:
             "PoP replay protection."
         )
     return str(request_id)
+
+
+def _nexus_replay_owner_id(ctx: Any) -> str:
+    """Identify one permitted redelivery of a Nexus PoP signature.
+
+    Temporal redelivery keeps the same request id on the same handler
+    namespace and task queue. A captured PoP reused on a different
+    namespace or task queue is a different owner and is treated as replay.
+    """
+    return "\x1f".join(
+        (_ctx_namespace(ctx), _ctx_task_queue(ctx), _ctx_request_id(ctx))
+    )
+
+
+def _ctx_namespace(ctx: Any) -> str:
+    value = getattr(ctx, "namespace", None)
+    if value:
+        return str(value)
+    try:
+        from temporalio import nexus as temporal_nexus  # type: ignore[import-not-found]
+
+        info = temporal_nexus.info()
+        namespace = getattr(info, "namespace", None)
+        if namespace:
+            return str(namespace)
+    except Exception:
+        pass
+    try:
+        from temporalio import nexus as temporal_nexus  # type: ignore[import-not-found]
+
+        client = temporal_nexus.client()
+        namespace = getattr(client, "namespace", None)
+        if namespace:
+            return str(namespace)
+    except Exception:
+        pass
+    return ""
+
+
+def _ctx_task_queue(ctx: Any) -> str:
+    value = getattr(ctx, "task_queue", None)
+    if value:
+        return str(value)
+    try:
+        from temporalio import nexus as temporal_nexus  # type: ignore[import-not-found]
+
+        info = temporal_nexus.info()
+        task_queue = getattr(info, "task_queue", None)
+        if task_queue:
+            return str(task_queue)
+    except Exception:
+        pass
+    return ""
 
 
 def _nexus_auth_error_types() -> tuple[type[BaseException], ...]:

--- a/tenuo-python/tenuo/temporal/_nexus.py
+++ b/tenuo-python/tenuo/temporal/_nexus.py
@@ -16,6 +16,7 @@ import inspect
 import json
 import logging
 import time
+from contextvars import ContextVar
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
 
 from tenuo.temporal._constants import (
@@ -53,6 +54,14 @@ TENUO_NEXUS_TOOL_HEADER = "x-tenuo-tool-name"
 _TENUO_NEXUS_HEADER_ENCODING_V1 = "base64-v1"
 _TENUO_NEXUS_WORKFLOW_ENVELOPE_VERSION = "tenuo-nexus-workflow-envelope/v1"
 _UNSET = object()
+_nexus_verified_request_id: ContextVar[Optional[str]] = ContextVar(
+    "tenuo_nexus_verified_request_id",
+    default=None,
+)
+_nexus_verified_warrant: ContextVar[Any] = ContextVar(
+    "tenuo_nexus_verified_warrant",
+    default=None,
+)
 
 
 class _NexusEndpointMismatch(TenuoContextError):
@@ -246,6 +255,14 @@ def verify_nexus_operation(
     Returns the verified warrant. When ``raise_nexus_error=True``, failures are
     translated to a Nexus ``HandlerError`` with type ``UNAUTHORIZED``.
     """
+    request_id = getattr(ctx, "request_id", None)
+    cached_request_id = _nexus_verified_request_id.get()
+    if (
+        request_id is not None
+        and cached_request_id == str(request_id)
+        and _nexus_verified_warrant.get() is not None
+    ):
+        return _nexus_verified_warrant.get()
     try:
         return _verify_nexus_operation(
             ctx,
@@ -634,17 +651,18 @@ async def tenuo_start_nexus_workflow(
     client_interceptor.set_headers_for_workflow(workflow_id, workflow_headers)
     try:
         if workflow_input is _UNSET:
-            return await ctx.start_workflow(
+            result = await ctx.start_workflow(
                 workflow_run_fn,
                 id=workflow_id,
                 **start_workflow_kwargs,
             )
-        return await ctx.start_workflow(
-            workflow_run_fn,
-            workflow_input,
-            id=workflow_id,
-            **start_workflow_kwargs,
-        )
+        else:
+            result = await ctx.start_workflow(
+                workflow_run_fn,
+                workflow_input,
+                id=workflow_id,
+                **start_workflow_kwargs,
+            )
     except Exception:
         discard = getattr(
             client_interceptor,
@@ -654,6 +672,21 @@ async def tenuo_start_nexus_workflow(
         if callable(discard):
             discard(workflow_id, workflow_headers)
         raise
+    still_pending = getattr(client_interceptor, "pending_headers_match", None)
+    if callable(still_pending) and still_pending(workflow_id, workflow_headers):
+        discard = getattr(
+            client_interceptor,
+            "discard_headers_for_workflow_if_match",
+            None,
+        )
+        if callable(discard):
+            discard(workflow_id, workflow_headers)
+        raise TenuoContextError(
+            "TenuoClientInterceptor did not consume pending headers for "
+            f"workflow_id={workflow_id!r}. Pass the interceptor instance "
+            "installed on the handler namespace Client, not a new instance."
+        )
+    return result
 
 
 def tenuo_bootstrap_nexus_workflow(envelope: Any) -> None:
@@ -1262,17 +1295,19 @@ def _emit_nexus_control_plane_event(
     chain_result: Optional[Any] = None,
     exc: Optional[BaseException] = None,
 ) -> None:
-    try:
-        control_plane = getattr(config, "control_plane", None)
-        if not control_plane:
-            return
+    latency_s = (time.perf_counter_ns() - start_ns) / 1e9
+    redacted_args = _redact_nexus_args(config, args)
+    request_id = getattr(ctx, "request_id", None)
+    _record_nexus_metrics(config, tool_name, latency_s, exc)
+    _emit_nexus_audit_event(config, ctx, warrant, tool_name, redacted_args, exc)
 
+    control_plane = getattr(config, "control_plane", None)
+    if not control_plane:
+        return
+    try:
         from tenuo._enforcement import EnforcementResult
 
-        latency_us = int((time.perf_counter_ns() - start_ns) / 1000)
-        redacted_args = _redact_nexus_args(config, args)
-        request_id = getattr(ctx, "request_id", None)
-
+        latency_us = int(latency_s * 1e6)
         if exc is None:
             result = EnforcementResult(
                 allowed=True,
@@ -1304,6 +1339,112 @@ def _emit_nexus_control_plane_event(
             "Control plane emission failed for Nexus %s '%s'; audit event lost",
             outcome,
             tool_name,
+            exc_info=True,
+        )
+
+
+def _record_nexus_metrics(
+    config: Any,
+    tool_name: str,
+    latency_s: float,
+    exc: Optional[BaseException],
+) -> None:
+    metrics = getattr(config, "metrics", None)
+    if metrics is None:
+        return
+    try:
+        if exc is None:
+            metrics.record_authorized(
+                tool=tool_name,
+                workflow_type="nexus",
+                latency_seconds=latency_s,
+            )
+        else:
+            metrics.record_denied(
+                tool=tool_name,
+                reason=str(exc),
+                workflow_type="nexus",
+                latency_seconds=latency_s,
+            )
+    except Exception:
+        logger.warning(
+            "Nexus metrics emission failed for '%s'",
+            tool_name,
+            exc_info=True,
+        )
+
+
+def _emit_nexus_audit_event(
+    config: Any,
+    ctx: Any,
+    warrant: Optional[Any],
+    tool_name: str,
+    redacted_args: Dict[str, Any],
+    exc: Optional[BaseException],
+) -> None:
+    callback = getattr(config, "audit_callback", None)
+    if not callback:
+        return
+    allowed = exc is None
+    if allowed and not getattr(config, "audit_allow", True):
+        return
+    if not allowed and not getattr(config, "audit_deny", True):
+        return
+
+    from tenuo.temporal._observability import TemporalAuditEvent
+
+    request_id = str(getattr(ctx, "request_id", "") or "")
+    task_queue = ""
+    try:
+        from temporalio import nexus as temporal_nexus  # type: ignore[import-not-found]
+
+        task_queue = str(getattr(temporal_nexus.info(), "task_queue", "") or "")
+    except Exception:
+        pass
+
+    expires_at = None
+    capabilities: List[str] = []
+    if warrant is not None:
+        expires_fn = getattr(warrant, "expires_at", None)
+        if callable(expires_fn):
+            try:
+                expires_at = expires_fn()
+            except Exception:
+                expires_at = None
+        capabilities = list(getattr(warrant, "tools", None) or [])
+
+    try:
+        from tenuo import __version__ as tenuo_version
+    except ImportError:
+        tenuo_version = "unknown"
+
+    event = TemporalAuditEvent(
+        workflow_id=request_id,
+        workflow_type="nexus",
+        workflow_run_id=request_id,
+        activity_name=tool_name,
+        activity_id=request_id,
+        task_queue=task_queue,
+        decision="ALLOW" if allowed else "DENY",
+        tool=tool_name,
+        arguments=redacted_args,
+        warrant_id=getattr(warrant, "id", None) or "none",
+        warrant_expires_at=expires_at,
+        warrant_capabilities=capabilities,
+        denial_reason=None if allowed else str(exc),
+        constraint_violated=(
+            getattr(exc, "constraint", None) if exc is not None else None
+        ),
+        tenuo_version=tenuo_version,
+    )
+    try:
+        callback(event)
+    except Exception as callback_exc:
+        logger.error(
+            "Audit callback failed for Nexus %s event (tool=%s): %s",
+            "ALLOW" if allowed else "DENY",
+            tool_name,
+            callback_exc,
             exc_info=True,
         )
 

--- a/tenuo-python/tests/adapters/test_temporal.py
+++ b/tenuo-python/tests/adapters/test_temporal.py
@@ -4686,13 +4686,54 @@ class TestClientHeadersPendingMapBound:
         ci = TenuoClientInterceptor()
         original = {"x-tenuo-warrant": b"original"}
         rebound = {"x-tenuo-warrant": b"rebound"}
-        ci.set_headers_for_workflow("wf-1", original)
-        ci.set_headers_for_workflow("wf-1", rebound)
+        original_token = ci.set_headers_for_workflow("wf-1", original)
+        rebound_token = ci.set_headers_for_workflow("wf-1", rebound)
 
-        assert ci.discard_headers_for_workflow_if_match("wf-1", original) is False
+        assert (
+            ci.discard_headers_for_workflow_if_match(
+                "wf-1",
+                original,
+                original_token,
+            )
+            is False
+        )
         assert ci._headers_by_workflow_id["wf-1"][0] == rebound
-        assert ci.discard_headers_for_workflow_if_match("wf-1", rebound) is True
+        assert (
+            ci.discard_headers_for_workflow_if_match(
+                "wf-1",
+                rebound,
+                rebound_token,
+            )
+            is True
+        )
         assert "wf-1" not in ci._headers_by_workflow_id
+
+    def test_conditional_discard_preserves_identical_rebound_entry(self):
+        from tenuo.temporal._client import TenuoClientInterceptor
+
+        ci = TenuoClientInterceptor()
+        original = {"x-tenuo-warrant": b"same"}
+        rebound = {"x-tenuo-warrant": b"same"}
+        original_token = ci.set_headers_for_workflow("wf-1", original)
+        rebound_token = ci.set_headers_for_workflow("wf-1", rebound)
+
+        assert (
+            ci.discard_headers_for_workflow_if_match(
+                "wf-1",
+                original,
+                original_token,
+            )
+            is False
+        )
+        assert ci.pending_headers_match("wf-1", rebound, rebound_token) is True
+        assert (
+            ci.discard_headers_for_workflow_if_match(
+                "wf-1",
+                rebound,
+                rebound_token,
+            )
+            is True
+        )
 
     def test_ttl_evicts_stale_entries_on_next_set(self):
         from tenuo.temporal._client import TenuoClientInterceptor

--- a/tenuo-python/tests/adapters/test_temporal_nexus.py
+++ b/tenuo-python/tests/adapters/test_temporal_nexus.py
@@ -688,6 +688,103 @@ def test_verify_nexus_operation_strict_replay_scoped_by_request_id(
         verify_nexus_operation(replay_ctx, input, config, endpoint="billing-prod")
 
 
+def test_verify_nexus_operation_strict_replay_rejects_namespace_or_task_queue_drift(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    input = RefundInput("ord_123", 2500)
+    headers = tenuo_nexus_headers(
+        nexus_warrant,
+        "agent-key",
+        agent_key,
+        endpoint="billing-prod",
+        service="BillingService",
+        operation="refund",
+        input=input,
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+        nexus_pop_replay_protection=True,
+    )
+    original = SimpleNamespace(
+        request_id="req-bound",
+        namespace="billing-prod-ns",
+        task_queue="billing-tq",
+        service="BillingService",
+        operation="refund",
+        headers=headers,
+    )
+
+    verify_nexus_operation(original, input, config, endpoint="billing-prod")
+    verify_nexus_operation(original, input, config, endpoint="billing-prod")
+
+    other_namespace = SimpleNamespace(
+        request_id="req-bound",
+        namespace="billing-staging-ns",
+        task_queue="billing-tq",
+        service="BillingService",
+        operation="refund",
+        headers=headers,
+    )
+    with pytest.raises(PopVerificationError, match="replay detected"):
+        verify_nexus_operation(other_namespace, input, config, endpoint="billing-prod")
+
+    other_queue = SimpleNamespace(
+        request_id="req-bound",
+        namespace="billing-prod-ns",
+        task_queue="billing-tq-canary",
+        service="BillingService",
+        operation="refund",
+        headers=headers,
+    )
+    with pytest.raises(PopVerificationError, match="replay detected"):
+        verify_nexus_operation(other_queue, input, config, endpoint="billing-prod")
+
+
+def test_verify_nexus_operation_strict_replay_uses_nexus_info_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    input = RefundInput("ord_123", 2500)
+    headers = tenuo_nexus_headers(
+        nexus_warrant,
+        "agent-key",
+        agent_key,
+        endpoint="billing-prod",
+        service="BillingService",
+        operation="refund",
+        input=input,
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+        nexus_pop_replay_protection=True,
+    )
+    reported = SimpleNamespace(namespace="billing-prod-ns")
+    monkeypatch.setattr(
+        "temporalio.nexus.info",
+        lambda: SimpleNamespace(namespace=reported.namespace),
+    )
+    ctx = SimpleNamespace(
+        request_id="req-bound",
+        task_queue="billing-tq",
+        service="BillingService",
+        operation="refund",
+        headers=headers,
+    )
+
+    verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+    verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+    reported.namespace = "billing-staging-ns"
+
+    with pytest.raises(PopVerificationError, match="replay detected"):
+        verify_nexus_operation(ctx, input, config, endpoint="billing-prod")
+
+
 def test_execute_nexus_operation_rejects_reserved_header_case_insensitive(
     monkeypatch: pytest.MonkeyPatch,
     nexus_keys: tuple[Any, Any],
@@ -1812,6 +1909,48 @@ async def test_verify_nexus_operation_skips_duplicate_emit_inside_inbound_interc
     assert seen[0].to_bytes() == nexus_warrant.to_bytes()
     assert len(control_plane.allow_events) == 1
     assert len(events) == 1
+
+
+async def test_inbound_interceptor_cache_still_checks_explicit_binding(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    input = RefundInput("ord_123", 2500)
+    ctx = SimpleNamespace(
+        request_id="req-cache-binding",
+        service="BillingService",
+        operation="refund",
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=input,
+        ),
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+        nexus_endpoint="billing-prod",
+    )
+
+    class _Next:
+        async def execute_nexus_operation_start(self, inbound_input: Any) -> Any:
+            verify_nexus_operation(
+                inbound_input.ctx,
+                inbound_input.input,
+                config,
+                endpoint="billing-prod",
+                operation="capture",
+            )
+
+    inbound = TenuoNexusOperationInboundInterceptor(_Next(), config)
+
+    with pytest.raises(TenuoContextError, match="tool binding mismatch"):
+        await inbound.execute_nexus_operation_start(SimpleNamespace(ctx=ctx, input=input))
 
 
 async def test_nexus_inbound_interceptor_verifies_before_handler(

--- a/tenuo-python/tests/adapters/test_temporal_nexus.py
+++ b/tenuo-python/tests/adapters/test_temporal_nexus.py
@@ -19,6 +19,10 @@ from tenuo_core import Exact, Range, SigningKey, Warrant, py_compute_request_has
 
 from tenuo.temporal._config import TenuoPluginConfig  # noqa: E402
 from tenuo.temporal._client import TenuoClientInterceptor  # noqa: E402
+from tenuo.temporal._interceptors import (  # noqa: E402
+    TenuoNexusOperationInboundInterceptor,
+    TenuoWorkerInterceptor,
+)
 from tenuo.temporal._constants import (  # noqa: E402
     TENUO_ARG_KEYS_HEADER,
     TENUO_KEY_ID_HEADER,
@@ -140,6 +144,7 @@ class FakeNexusWorkflowRunContext:
         operation: str = "refund",
         fail_start: bool = False,
         on_start: Optional[Callable[[], None]] = None,
+        consume_interceptor: Any = None,
     ) -> None:
         self.request_id = request_id
         self.service = service
@@ -147,6 +152,7 @@ class FakeNexusWorkflowRunContext:
         self.headers = headers
         self.fail_start = fail_start
         self.on_start = on_start
+        self.consume_interceptor = consume_interceptor
         self.start_calls: list[tuple[Any, tuple[Any, ...], dict[str, Any]]] = []
 
     async def start_workflow(self, workflow_run_fn: Any, *args: Any, **kwargs: Any) -> str:
@@ -155,6 +161,9 @@ class FakeNexusWorkflowRunContext:
             self.on_start()
         if self.fail_start:
             raise RuntimeError("start failed")
+        workflow_id = kwargs.get("id")
+        if self.consume_interceptor is not None and workflow_id:
+            self.consume_interceptor.discard_headers_for_workflow(workflow_id)
         return "workflow-handle"
 
 
@@ -1459,6 +1468,7 @@ async def test_start_nexus_workflow_binds_headers_and_starts_backing_workflow(
         .mint(root_key)
     )
     client_interceptor = TenuoClientInterceptor()
+    ctx.consume_interceptor = client_interceptor
 
     result = await tenuo_start_nexus_workflow(
         ctx,
@@ -1481,8 +1491,7 @@ async def test_start_nexus_workflow_binds_headers_and_starts_backing_workflow(
             {"id": "refund-wf-ambient"},
         )
     ]
-    bound_headers = client_interceptor._headers_by_workflow_id["refund-wf-ambient"][0]
-    assert bound_headers[TENUO_KEY_ID_HEADER] == b"handler-key"
+    assert "refund-wf-ambient" not in client_interceptor._headers_by_workflow_id
 
 
 async def test_start_nexus_workflow_does_not_start_when_nexus_verification_fails(
@@ -1634,6 +1643,236 @@ async def test_start_nexus_workflow_does_not_discard_newer_rebound_headers(
 
     rebound_headers = client_interceptor._headers_by_workflow_id["refund-wf-rebound"][0]
     assert rebound_headers == newer_headers
+
+
+async def test_start_nexus_workflow_rejects_unconsumed_pending_headers(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    handler_key = SigningKey.generate()
+    input = RefundInput("ord_123", 2500)
+    ctx = FakeNexusWorkflowRunContext(
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=input,
+        )
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+    )
+    workflow_warrant = (
+        Warrant.mint_builder()
+        .holder(handler_key.public_key)
+        .capability("RefundWorkflow", order_id=Exact("ord_123"))
+        .ttl(3600)
+        .mint(root_key)
+    )
+    client_interceptor = TenuoClientInterceptor()
+
+    with pytest.raises(TenuoContextError, match="did not consume pending headers"):
+        await tenuo_start_nexus_workflow(
+            ctx,
+            input,
+            config,
+            client_interceptor,
+            "RefundWorkflow.run",
+            workflow_id="refund-wf-wrong-interceptor",
+            workflow_warrant=workflow_warrant,
+            workflow_key_id="handler-key",
+            endpoint="billing-prod",
+        )
+
+    assert "refund-wf-wrong-interceptor" not in client_interceptor._headers_by_workflow_id
+
+
+def test_worker_interceptor_wires_control_plane_on_shared_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = object()
+    monkeypatch.setattr("tenuo.control_plane.get_or_create", lambda: sentinel)
+    root_key = SigningKey.generate()
+    config = TenuoPluginConfig(
+        signing_key=root_key,
+        trusted_roots=[root_key.public_key],
+    )
+    assert config.control_plane is None
+
+    interceptor = TenuoWorkerInterceptor(config)
+
+    assert interceptor._config is config
+    assert config.control_plane is sentinel
+
+
+def test_verify_nexus_operation_emits_audit_callback_on_allow_and_deny(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    events: list[Any] = []
+    input = RefundInput("ord_123", 2500)
+    allow_ctx = SimpleNamespace(
+        request_id="req-audit-allow",
+        service="BillingService",
+        operation="refund",
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=input,
+        ),
+    )
+    allow_config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+        audit_callback=events.append,
+    )
+
+    verify_nexus_operation(allow_ctx, input, allow_config, endpoint="billing-prod")
+
+    deny_ctx = SimpleNamespace(
+        request_id="req-audit-deny",
+        service="BillingService",
+        operation="refund",
+        headers=allow_ctx.headers,
+    )
+    deny_config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+        audit_callback=events.append,
+    )
+    with pytest.raises(SignatureInvalid):
+        verify_nexus_operation(
+            deny_ctx,
+            RefundInput("ord_999", 2500),
+            deny_config,
+            endpoint="billing-prod",
+        )
+
+    assert [event.decision for event in events] == ["ALLOW", "DENY"]
+    assert events[0].workflow_type == "nexus"
+    assert events[0].tool == "nexus:billing-prod:BillingService:refund"
+
+
+async def test_verify_nexus_operation_skips_duplicate_emit_inside_inbound_interceptor(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    control_plane = RecordingControlPlane()
+    events: list[Any] = []
+    input = RefundInput("ord_123", 2500)
+    ctx = SimpleNamespace(
+        request_id="req-dedup-verify",
+        service="BillingService",
+        operation="refund",
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=input,
+        ),
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+        control_plane=control_plane,
+        audit_callback=events.append,
+        nexus_endpoint="billing-prod",
+    )
+    seen: list[Any] = []
+
+    class _Next:
+        async def execute_nexus_operation_start(self, inbound_input: Any) -> Any:
+            seen.append(
+                verify_nexus_operation(
+                    inbound_input.ctx,
+                    inbound_input.input,
+                    config,
+                    endpoint="billing-prod",
+                )
+            )
+            return "ok"
+
+    inbound = TenuoNexusOperationInboundInterceptor(_Next(), config)
+    await inbound.execute_nexus_operation_start(SimpleNamespace(ctx=ctx, input=input))
+
+    assert seen[0].to_bytes() == nexus_warrant.to_bytes()
+    assert len(control_plane.allow_events) == 1
+    assert len(events) == 1
+
+
+async def test_nexus_inbound_interceptor_verifies_before_handler(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    root_key, agent_key = nexus_keys
+    input = RefundInput("ord_123", 2500)
+    ctx = SimpleNamespace(
+        request_id="req-inbound-interceptor",
+        service="BillingService",
+        operation="refund",
+        headers=tenuo_nexus_headers(
+            nexus_warrant,
+            "agent-key",
+            agent_key,
+            endpoint="billing-prod",
+            service="BillingService",
+            operation="refund",
+            input=input,
+        ),
+    )
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[root_key.public_key],
+        nexus_endpoint="billing-prod",
+    )
+    started: list[Any] = []
+
+    class _Next:
+        async def execute_nexus_operation_start(self, inbound_input: Any) -> str:
+            started.append(inbound_input)
+            return "ok"
+
+    inbound = TenuoNexusOperationInboundInterceptor(_Next(), config)
+    result = await inbound.execute_nexus_operation_start(
+        SimpleNamespace(ctx=ctx, input=input)
+    )
+
+    assert result == "ok"
+    assert len(started) == 1
+
+
+async def test_nexus_inbound_interceptor_requires_endpoint(
+    nexus_keys: tuple[Any, Any],
+    nexus_warrant: Any,
+) -> None:
+    _root_key, agent_key = nexus_keys
+    config = TenuoPluginConfig(
+        key_resolver=StaticResolver(agent_key),
+        trusted_roots=[nexus_keys[0].public_key],
+    )
+    inbound = TenuoNexusOperationInboundInterceptor(SimpleNamespace(), config)
+
+    with pytest.raises(TenuoContextError, match="nexus_endpoint is required"):
+        await inbound.execute_nexus_operation_start(
+            SimpleNamespace(
+                ctx=SimpleNamespace(request_id="req-missing-endpoint"),
+                input=RefundInput("ord_123", 2500),
+            )
+        )
 
 
 def test_bootstrap_nexus_workflow_installs_envelope_headers(

--- a/tenuo-python/tests/e2e/test_temporal_nexus_live.py
+++ b/tenuo-python/tests/e2e/test_temporal_nexus_live.py
@@ -359,6 +359,7 @@ async def test_live_cross_namespace_nexus_operation_authorizes_headers() -> None
                 ),
                 trusted_roots=[control_key.public_key],
                 activity_fns=[record_refund],
+                nexus_endpoint=endpoint_name,
             )
 
             @nexus_handler.service_handler(service=BillingService)
@@ -558,6 +559,7 @@ async def test_live_nexus_backing_start_can_use_interceptor_bound_headers() -> N
                     }
                 ),
                 trusted_roots=[control_key.public_key],
+                nexus_endpoint=endpoint_name,
             )
             warrant = (
                 Warrant.mint_builder()


### PR DESCRIPTION
## Summary
- Authorize inbound Nexus starts by default when `TenuoPluginConfig.nexus_endpoint` is set.
- Share control-plane, audit callback, and metrics emission across Nexus verify/decorator paths.
- Preserve Nexus-native `UNAUTHORIZED` errors for handler helpers, including query/update.
- Fail closed when ambient backing workflow header bindings are not consumed by the installed handler client interceptor.
- Make backing-start cleanup generation-token based so failed starts cannot delete newer concurrent rebindings, even when headers are identical.
- Keep duplicate in-handler verification fast paths binding-aware, so explicit endpoint/service/operation/input checks are still enforced.
- Bind strict Nexus PoP replay ownership to handler namespace, task queue, and `request_id`, including namespace from `temporalio.nexus.info()`.

## Validation
- `python3 -m pytest tests/adapters/test_temporal_nexus.py tests/adapters/test_temporal.py::TestClientHeadersPendingMapBound -q` — 62 passed
- `python3 -m ruff check tenuo/temporal/_nexus.py tenuo/temporal/_interceptors.py tenuo/temporal/_client.py tests/adapters/test_temporal_nexus.py tests/adapters/test_temporal.py`
- `python3 -m mypy tenuo/`
- `git diff --check`
- `python3 -m pytest tests/e2e/test_temporal_nexus_live.py::test_live_nexus_backing_start_can_use_interceptor_bound_headers -v -m temporal_live` — passed against local Temporal dev server