### PR TITLE
chore(core): gate receipts behind unstable-receipts before 0.2.4

### DIFF
--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -31,6 +31,10 @@ control-plane = []
 # Data Plane - for edge agents and verifiers  
 data-plane = []
 
+# Signed authorization receipts. Unstable: the API may change in a patch
+# release. `tenuo-wasm` enables this; nothing else in the workspace does.
+unstable-receipts = []
+
 # Python bindings
 python = ["pyo3"]
 python-extension = ["pyo3/extension-module", "python"]

--- a/tenuo-core/src/lib.rs
+++ b/tenuo-core/src/lib.rs
@@ -50,6 +50,12 @@ pub mod gateway_config;
 pub mod mcp;
 pub mod payload;
 pub mod planes;
+/// Signed authorization receipts.
+///
+/// Unstable: gated behind the `unstable-receipts` feature so the 0.2.x
+/// public API does not commit to this surface. Consumed today only by
+/// `tenuo-wasm`. Enable explicitly if you depend on it.
+#[cfg(feature = "unstable-receipts")]
 pub mod receipt;
 pub mod revocation;
 pub mod revocation_manager;
@@ -95,6 +101,7 @@ pub use planes::{
     Authorizer, AuthorizerBuilder, ChainStep, ChainVerificationResult, ControlPlane, DataPlane,
     VerifiedApproval, DEFAULT_CLOCK_TOLERANCE_SECS,
 };
+#[cfg(feature = "unstable-receipts")]
 pub use receipt::{Receipt, ReceiptPayload};
 pub use revocation::{
     RevocationRequest, SignedRevocationList, SrlBuilder, MAX_REVOCATION_REQUEST_AGE_SECS,

--- a/tenuo-wasm/Cargo.toml
+++ b/tenuo-wasm/Cargo.toml
@@ -17,7 +17,7 @@ serde-wasm-bindgen = "0.6"
 console_error_panic_hook = "0.1"
 
 # Tenuo Core (with CEL for Explorer constraint evaluation)
-tenuo = { path = "../tenuo-core", default-features = false, features = ["control-plane", "data-plane", "cel"] }
+tenuo = { path = "../tenuo-core", default-features = false, features = ["control-plane", "data-plane", "cel", "unstable-receipts"] }
 hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1.0"


### PR DESCRIPTION
Follow-up to #520.

## Why

#520 added `tenuo-core/src/receipt.rs` (840 new lines) and exported `Receipt` / `ReceiptPayload` from `lib.rs`. Cutting **0.2.4 as a stable release** would commit crates.io consumers to that API before it has been reviewed on its own terms.

This is also an internal consistency fix: we are deliberately shipping the TypeScript SDK as `0.2.4-beta.0` because its API may still move, while in the same release publishing a brand-new, less-exercised Rust module as stable. Those postures should match.

## What

- New `unstable-receipts` feature on `tenuo-core` (off by default).
- `pub mod receipt;` and `pub use receipt::{Receipt, ReceiptPayload};` are gated behind it.
- `tenuo-wasm` enables it explicitly. It is the only consumer in the workspace — nothing inside `tenuo-core` references the module.

`Error::InvalidReceipt` stays ungated: it is a variant on a `#[non_exhaustive]` enum, so it is not a breaking addition, and gating it would complicate the matches in `error.rs` and `python.rs`.

## Test coverage is unchanged

CI already runs `cargo test`, `cargo clippy`, and `cargo llvm-cov` with `--all-features`, which turns the feature on. The 20 tests in `receipt.rs` keep running. No workflow changes needed.

## Verification

| Configuration | Result |
| --- | --- |
| `tenuo-core`, default features (what crates.io gets) | `cargo check` clean, **433** lib tests pass |
| `tenuo-core`, `--features unstable-receipts` | `cargo check` clean, **453** lib tests pass |
| `tenuo-wasm`, `--target wasm32-unknown-unknown` | `cargo check` clean |

The 433 → 453 delta is exactly the 20 receipt tests, confirming the gate takes effect and that `--all-features` restores them.

## What this does not do

This buys time; it is not a substitute for reviewing `receipt.rs`, the 136 changed lines in `planes.rs`, or the 75 in `warrant.rs` that came in with #520. Once that review lands and the API is settled, dropping the gate is a one-line change.