### PR TITLE
chore(temporal): Nexus release polish (changelog accuracy, production guide, export)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,12 +64,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consumes them. The live Nexus test now exercises concurrent backing starts
   over this interceptor path.
 - **Temporal Nexus production hardening.** `TenuoWorkerInterceptor` now
-  authorizes inbound Nexus starts by default when
-  `TenuoPluginConfig.nexus_endpoint` is set, wires `control_plane` onto the
-  shared config object used by verify/decorators, and emits `audit_callback`
-  plus metrics for Nexus allow/deny. Ambient backing starts fail closed if the
-  client interceptor does not consume the pending header binding. Strict Nexus
-  PoP replay is bound to handler namespace, task queue, and `request_id`.
+  authorizes every inbound Nexus start by default, so a missing
+  `@tenuo_nexus_operation` decorator cannot skip authorization.
+  **`TenuoPluginConfig.nexus_endpoint` is now required on workers that serve
+  Nexus operations**: set it to the endpoint name the worker serves, or every
+  inbound Nexus request is denied. The interceptor also wires `control_plane`
+  onto the shared config object used by verify/decorators, and emits
+  `audit_callback` plus metrics for Nexus allow/deny. Ambient backing starts
+  fail closed if the client interceptor does not consume the pending header
+  binding. Strict Nexus PoP replay is bound to handler namespace, task queue,
+  and `request_id`.
+- **Temporal Nexus callers must send `x-tenuo-tool-name`.** Nexus handlers now
+  reject requests without it so a caller/handler disagreement on
+  endpoint/service/operation surfaces as a clear binding error instead of an
+  opaque PoP failure. `tenuo_nexus_headers(...)` emits it; non-Python and
+  older callers must be upgraded before the handler side rolls out.
 - **Temporal per-Activity warrant overrides.**
   `tenuo_execute_activity(..., warrant=..., key_id=...)` now applies a
   task-local warrant to one dispatch, including the active delegation chain.

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -254,8 +254,29 @@ print(f"Authorized: {authorized}")  # True
 
 **Rule of thumb**: Same language + same process = runtime integration only. Cross-service = add [A2A](./a2a).
 
+### Cross-namespace Temporal (Nexus)
+
+If your Temporal workers call across Namespaces with Nexus, the handler worker needs three things before it is safe to ship. The first one is required: a worker that serves Nexus operations without it denies every request.
+
+1. **Set `TenuoPluginConfig.nexus_endpoint`** to the endpoint name this worker serves.
+2. **Build the worker with `TenuoWorkerInterceptor`** (or `TenuoTemporalPlugin`). Inbound Nexus starts are then authorized even if a handler is missing its `@tenuo_nexus_operation` decorator.
+3. **Keep backing workflows unreachable by untrusted clients.** They are an implementation detail of the handler, and starting one directly skips the Nexus verifier.
+
+```python
+config = TenuoPluginConfig(
+    key_resolver=resolver,
+    trusted_roots=[root_key.public_key],
+    nexus_endpoint="billing-prod",   # required for Nexus handler workers
+)
+```
+
+Turning on `nexus_pop_replay_protection` adds one more requirement: a fleet running more than one worker also needs a shared owner-aware `pop_dedup_store`, because the in-process default only suppresses replays on a single worker.
+
+Full setup, the workflow-backed operation path, and the complete pre-ship checklist are in [Temporal Nexus Authorization](./temporal-nexus).
+
 ## Next Steps
 
+- **[Temporal Nexus Authorization](./temporal-nexus)** — cross-namespace setup, workflow-backed operations, production checklist
 - **[Constraint Types](./constraints)** — `Subpath`, `Pattern`, `Range`, `UrlSafe`, `Exact`, and more
 - **[Security Model](./security)** — threat model, PoP mechanics, delegation chain verification
 - **[API Reference](./api-reference)** — full `Warrant`, `SigningKey`, `BoundWarrant` API

--- a/tenuo-python/tenuo/temporal/__init__.py
+++ b/tenuo-python/tenuo/temporal/__init__.py
@@ -88,6 +88,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "tenuo_nexus_execute_update": ("tenuo.temporal._nexus", "tenuo_nexus_execute_update"),
     "tenuo_nexus_start_update": ("tenuo.temporal._nexus", "tenuo_nexus_start_update"),
     "nexus_tool_name": ("tenuo.temporal._nexus", "nexus_tool_name"),
+    # Re-exported from tenuo.templates so the whole Nexus surface is reachable
+    # from one module; tenuo.templates stays the canonical definition site.
+    "TemporalNexusOperation": ("tenuo.templates", "TemporalNexusOperation"),
     "TenuoNexusWorkflowEnvelope": ("tenuo.temporal._nexus", "TenuoNexusWorkflowEnvelope"),
     "tenuo_forward_nexus_authority": ("tenuo.temporal._nexus", "tenuo_forward_nexus_authority"),
     "tenuo_create_nexus_workflow_envelope": ("tenuo.temporal._nexus", "tenuo_create_nexus_workflow_envelope"),

--- a/tenuo-python/tenuo/temporal/_config.py
+++ b/tenuo-python/tenuo/temporal/_config.py
@@ -65,6 +65,12 @@ class TenuoPluginConfig:
     """
     Optional ControlPlaneClient for emitting authorization check results
     back to the control plane.
+
+    When this is left unset, ``TenuoWorkerInterceptor`` populates it **on this
+    config object** at construction time rather than on a copy. That is
+    deliberate: Nexus verification and ``@tenuo_nexus_operation`` decorators
+    capture the config instance you pass them, so they must observe the same
+    client as the activity path or their decisions go unreported.
     """
 
     on_denial: Literal["raise", "log", "skip"] = "raise"


### PR DESCRIPTION
Release-readiness polish for the Temporal Nexus surface. Docs plus one lazy re-export; no behavior changes.

## Why

Reviewing `main` for release readiness turned up three things worth fixing before we ship Nexus as a production feature.

**The changelog described a required setting as optional.** It said the interceptor authorizes inbound Nexus starts "when `TenuoPluginConfig.nexus_endpoint` is set." A worker that serves Nexus operations without it denies *every* inbound request. The field docstring already says "Required"; the changelog is what people read on upgrade day.

**`x-tenuo-tool-name` became mandatory for callers and was not in the changelog at all.** Handlers now reject requests without it. Older and non-Python callers must be upgraded before the handler side rolls out.

**`docs/production-guide.md` had zero Nexus coverage.** Someone doing a pre-ship pass from the main production guide would miss the required config, the interceptor requirement, the backing-workflow trust boundary, and the shared `pop_dedup_store` condition.

## Changes

- `CHANGELOG.md`: state that `nexus_endpoint` is required on Nexus workers, and add an entry for the `x-tenuo-tool-name` caller requirement.
- `docs/production-guide.md`: new "Cross-namespace Temporal (Nexus)" subsection under Combining Integrations, plus a Next Steps link. It names only the three things that will bite someone shipping and links to the full checklist in `temporal-nexus.md` rather than duplicating it, so the two cannot drift.
- `tenuo/temporal/__init__.py`: lazily re-export `TemporalNexusOperation`. Every other Nexus symbol is reachable from `tenuo.temporal`, so that is where users look first. `tenuo.templates` stays the definition site and both paths return the same object. Worth doing before release rather than committing to two documented import paths permanently.
- `tenuo/temporal/_config.py`: document that `TenuoWorkerInterceptor` populates `control_plane` on the caller's config object rather than a copy, and why (Nexus verification and decorators capture the instance they are given, so a copy would leave their decisions unreported).

## Verification

Claims in the new docs were checked rather than assumed:

- The documented config example constructs and exposes `nexus_endpoint`.
- An inbound Nexus start on a config without `nexus_endpoint` is denied with `TenuoContextError` before the handler runs, which is what the guide now says.
- `from tenuo.temporal import TemporalNexusOperation` and `from tenuo.templates import TemporalNexusOperation` return the same object; the name is in `__all__` and `dir()`.
- All relative links in the production guide resolve.

Test runs were done against a locally rebuilt `tenuo_core` 0.2.3 rather than a stale wheel:

- `tests/adapters/test_temporal*.py` + `test_tenant_isolation.py`: 289 passed, 1 skipped
- `tests/e2e/test_temporal_nexus_live.py -m temporal_live`: 2 passed against a real Temporal dev server
- ruff clean; mypy 0 errors in `tenuo/temporal/`

## Not included

Three items from the same review are deliberately left out as judgment calls, none blocking:

- The namespace/task-queue components of the Nexus replay owner. Both are constant per endpoint (Temporal registers an endpoint to one namespace and task queue), so I could not identify a replay they discriminate against, and they can cause false denials when one endpoint is served from two task queues. Low benefit and low harm either way, so worth a follow-up question to the author rather than churn now.
- `tenuo_start_nexus_workflow` raises after `ctx.start_workflow` has returned, leaving a backing workflow started without Tenuo headers. The trigger is passing the wrong `TenuoClientInterceptor` instance, which is a misconfiguration caught on first call, and a correctly-built backing workflow fails closed downstream anyway. Auto-cancelling from an error path risks masking the original error.
- Keeping the in-place `control_plane` mutation. It is load-bearing for Nexus telemetry; this PR documents it instead.