### PR TITLE
docs(ts): revamp TypeScript READMEs for install-first clarity

### DIFF
--- a/tenuo-ts/README.md
+++ b/tenuo-ts/README.md
@@ -1,25 +1,41 @@
-# `@tenuo/core`
+# Tenuo TypeScript SDK
 
-TypeScript SDK for Tenuo. Authorization decisions run in the Rust core (WASM).
+Task-scoped authorization for AI agents. Decisions run in the Rust core
+(WASM). TypeScript wraps tools, sessions, and MCP wire; it does not decide
+allow or deny.
 
-> Beta: the TypeScript packages ship as `0.2.4-beta.0` under the npm `beta`
-> dist-tag while the Python/Rust/Docker release is `0.2.4`. Install with
-> `@beta`; the TypeScript API may still move before its first stable npm tag.
+| Package | Role |
+|---------|------|
+| [`@tenuo/core`](packages/core) | Tools, sessions, SRL, receipts, MCP attach/verify |
+| [`@tenuo/mcp`](packages/mcp) | Official MCP TypeScript **v2** server adapter |
+
+> **Beta.** Packages ship as `0.2.4-beta.0` on the npm `beta` tag. The API may
+> still move before a stable tag. Requires **Node 20+**. Not a browser or
+> Workers runtime.
+
+```bash
+npm i @tenuo/core@beta
+# MCP v2 server adapter (optional)
+npm i @tenuo/mcp@beta @modelcontextprotocol/server
+```
 
 What ships today:
 
 - `createTenuo`, `tenuo.tool()`, `session` / `sessionFromWire`, `narrow`, `toWire`
-- Allow / hard deny / approval-required — the original `execute` never runs unless Rust allowed
+- Allow / hard deny / approval-required. The original `execute` never runs unless Rust allowed
 - Signed revocation lists (`revocationList` / `tenuo.revoke`)
 - Signed receipts (`onReceipt`)
 - MCP attach / verify on `_meta.tenuo` (`tenuo.mcp`)
 
-Requires **Node 20+**. This is not a browser or Workers runtime. There is no
-Vercel AI SDK adapter and no Mastra adapter (`@tenuo/mastra` is deferred).
-`tenuo.tool()` wraps any `{ execute }` object, including a Vercel `tool()`, but
-that is not a supported integration.
+There is no Vercel AI SDK adapter and no Mastra adapter. `tenuo.tool()` wraps
+any `{ execute }` object, including a Vercel `tool()`, but that is not a
+supported integration.
 
 ## Five-minute path
+
+`devRoot()` is for local development. Set `NODE_ENV=development` (or `test`),
+pass `devRoot({ allowInProduction: true })`, or set `TENUO_ALLOW_DEV=1`.
+Unset `NODE_ENV` is not treated as development.
 
 ```ts
 import { createTenuo, under } from "@tenuo/core";
@@ -37,19 +53,22 @@ const session = tenuo.session({ tools: [readFile] });
 
 await tenuo.withSession(session, async () => {
   await readFile.execute({ path: "/data/q3.pdf" }); // allowed
-  await readFile.execute({ path: "/etc/passwd" }); // denied — execute does not run
+  await readFile.execute({ path: "/etc/passwd" }); // denied; execute does not run
 });
 ```
 
-Host schemas (Zod or otherwise) answer **valid**. Tool `allow` is the host ceiling. The session is what this agent may do. Rust AND's both; TypeScript does not decide. `session({ tools })` mints from the wrappers so you do not write the same map twice.
+Host schemas (Zod or otherwise) answer **valid**. Tool `allow` is the host
+ceiling. The session is what this agent may do. Rust ANDs both; TypeScript
+does not decide. `session({ tools })` mints from the wrappers so you do not
+write the same map twice.
 
-`allow` is **zero-trust**: every argument on the call must be named in the policy. `{ path: under("/data") }` rejects `{ path, encoding }` until `encoding` is in `allow` (for example `pattern("*")`). Empty `allow: {}` adds no extra ceiling. MCP `verify` / `handler` can take an optional `nonceStore` (`memoryNonceStore()`, or an async Redis `checkAndRecord`) to reject an exact replayed PoP; that is opt-in. `verify()` is async so a Promise from the store cannot fail open. PoP v1 is replayable in-window, including approval-gated calls — a captured `_meta.tenuo` with approvals verifies again until the window closes. Pass `nonceStore` on those tools if an approval must be one-use.
+Every argument on the call must be named in `allow`. `{ path: under("/data") }`
+rejects `{ path, encoding }` until `encoding` is listed (for example
+`pattern("*")`). Empty `allow: {}` adds no extra ceiling.
 
-`devRoot()` is for development. It requires `NODE_ENV=development` or `test`, `devRoot({ allowInProduction: true })`, or `TENUO_ALLOW_DEV=1`. Unset `NODE_ENV` is not treated as development.
+## Production session
 
-`onReceipt` is evidence. If the hook throws, authorize and execute still proceed.
-
-Production loads an issued warrant and a trusted root:
+Load an issued warrant and a trusted root:
 
 ```ts
 const tenuo = createTenuo({
@@ -67,14 +86,20 @@ const reports = tenuo.narrow(session, { path: under("/data/reports") });
 
 ## MCP
 
-The client attaches a warrant and a proof-of-possession to MCP `_meta.tenuo`. The server verifies that envelope in Rust before the tool handler runs. This is the same wire shape as the Python SDK (`warrant`, `signature`, optional `approvals`).
+The client attaches a warrant and a proof-of-possession to MCP `_meta.tenuo`.
+The server verifies that envelope in Rust before the tool handler runs. Same
+wire shape as the Python SDK (`warrant`, `signature`, optional `approvals`).
 
 ```ts
-// Client process
+// Client: session from the five-minute path, or sessionFromWire in production
 const call = tenuo.mcp.attach(session, "read_file", { path: "/data/q3.pdf" });
-await mcp.callTool({ name: call.name, arguments: call.arguments, _meta: call._meta });
+await mcp.callTool({
+  name: call.name,
+  arguments: call.arguments,
+  _meta: call._meta,
+});
 
-// Server process — trusted root only, no holder secret
+// Server: trusted root only, no holder secret
 const server = createTenuo({
   trustedRoots: [createTenuo.publicKeyFromEnv("TENUO_ROOT_PUBLIC_KEY")],
 });
@@ -89,7 +114,11 @@ const readFile = server.mcp.handler(
 await readFile(params.arguments, { _meta: params._meta });
 ```
 
-`attach` authorizes locally first, so a denied call never leaves the client. `verify` / `handler` is the enforcement point on the server. Handler `allow` is the server's immutable ceiling and is AND'd with the warrant in Rust. A JSON-RPC mapping is available as `tenuo.mcp.jsonRpcError(error)` (`-32001` deny, `-32002` approval required, `-32602` canonicalization).
+`attach` authorizes locally first, so a denied call never leaves the client.
+`verify` / `handler` is the enforcement point on the server. Handler `allow`
+is the server's immutable ceiling and is AND'd with the warrant in Rust.
+Map denials with `tenuo.mcp.jsonRpcError(error)` (`-32001` deny, `-32002`
+approval required, `-32602` canonicalization).
 
 `@tenuo/core` has no MCP framework dependency. For the official v2 server:
 
@@ -97,15 +126,40 @@ await readFile(params.arguments, { _meta: params._meta });
 import { guardTools } from "@tenuo/mcp";
 
 const tools = guardTools(serverTenuo, mcpServer);
-tools.register("read_file", {
-  inputSchema: z.object({ path: z.string() }),
-  allow: { path: under("/data") },
-}, async ({ path }) => ({ content: [{ type: "text", text: await read(path) }] }));
+tools.register(
+  "read_file",
+  {
+    inputSchema: z.object({ path: z.string() }),
+    allow: { path: under("/data") },
+  },
+  async ({ path }) => ({
+    content: [{ type: "text", text: await read(path) }],
+  }),
+);
 ```
 
-For `@modelcontextprotocol/sdk` v1, copy the recipe in `packages/core/examples/mcp/host.ts`. There is no FastMCP adapter.
+For `@modelcontextprotocol/sdk` v1, copy
+`packages/core/examples/mcp/host.ts`. There is no FastMCP adapter.
 
-A quarterly-close example lives in `packages/core/examples/mcp/`: per-agent warrants, an MCP `tools/call` dispatcher, approval-gated email, and fail-closed tampering. `pnpm example:mcp` runs the wire smoke. `pnpm test` also drives the official MCP TypeScript SDK host (`examples/mcp/host.ts`) so attach / verify / narrow / approvals / revocation go over a real `tools/call`.
+### PoP replay (opt-in)
+
+PoP v1 is replayable inside its time window, including approval-gated calls.
+A captured `_meta.tenuo` with approvals verifies again until the window closes.
+Pass `nonceStore` (`memoryNonceStore()`, or an async Redis `checkAndRecord`)
+on `verify` / `handler` if a proof or approval must be one-use. `verify()` is
+async so a Promise from the store cannot fail open.
+
+### Examples
+
+`packages/core/examples/mcp/` has a quarterly-close walkthrough: per-agent
+warrants, an MCP `tools/call` dispatcher, approval-gated email, and
+fail-closed tampering.
+
+```bash
+pnpm example:mcp           # wire smoke
+pnpm example:mcp:host      # v1 recipe over a real tools/call
+pnpm example:mcp:adapter   # @tenuo/mcp v2 adapter
+```
 
 ## Revocation and receipts
 
@@ -123,8 +177,8 @@ await readFile.execute(
 );
 ```
 
-`onReceipt` is evidence of the decision. A receipt that verifies is not an allow.
-Exceptions in the hook are isolated and never deny or fail the tool.
+`onReceipt` is evidence of the decision. A receipt that verifies is not an
+allow. If the hook throws, authorize and execute still proceed.
 
 ## Outcomes
 
@@ -132,7 +186,7 @@ Exceptions in the hook are isolated and never deny or fail the tool.
 |---|---|---|
 | Allow | Yes, with normalized args | Return the tool output |
 | Hard deny | No | Throw `AuthorizationDeniedError` |
-| Approval required | No | Throw `ApprovalRequiredError` — not a successful tool result |
+| Approval required | No | Throw `ApprovalRequiredError` (not a successful tool result) |
 
 ## Refuse list
 
@@ -145,18 +199,20 @@ These patterns will not ship:
 - a signing key on request context
 - hooks or tool filtering as the security boundary
 - a mock authorizer in tests
-- a boolean “user clicked Approve” as a Tenuo approval
+- a boolean "user clicked Approve" as a Tenuo approval
 
 ## Layout
 
 ```text
 tenuo-ts/
-  packages/core/             @tenuo/core
-  packages/mcp/              @tenuo/mcp — official v2 server adapter
-  packages/core/examples/mcp quarterly-close + v1 host recipe
+  packages/core/              @tenuo/core
+  packages/mcp/               @tenuo/mcp (official v2 server adapter)
+  packages/core/examples/mcp  quarterly-close + v1 host recipe
 ```
 
 ## Develop
+
+For contributors working in this monorepo:
 
 ```bash
 cd tenuo-ts
@@ -164,19 +220,17 @@ pnpm install
 pnpm build:wasm   # requires wasm-pack + rustc
 pnpm typecheck
 pnpm test
-pnpm example:mcp
-pnpm example:mcp:host      # v1 recipe smoke
-pnpm example:mcp:adapter   # @tenuo/mcp v2 adapter
 ```
 
-Requires Node 20+. `pnpm build:wasm` writes the Node WASM glue into `packages/core/src/generated/`, which `@tenuo/core` ships so `npm i` does not need wasm-pack. Rebuild it when you change `tenuo-wasm`. `pnpm --filter @tenuo/core pack:smoke` and `pnpm --filter @tenuo/mcp pack:smoke` install the published tarballs in a clean directory.
-
-Publish from GitHub Actions (`id-token: write`) so npm can attach provenance:
+`pnpm build:wasm` writes the Node WASM glue into
+`packages/core/src/generated/`, which `@tenuo/core` ships so `npm i` does not
+need wasm-pack. Rebuild when you change `tenuo-wasm`.
 
 ```bash
-pnpm --filter @tenuo/core build && pnpm --filter @tenuo/core publish:npm
-pnpm --filter @tenuo/mcp build && pnpm --filter @tenuo/mcp publish:npm
+pnpm --filter @tenuo/core pack:smoke
+pnpm --filter @tenuo/mcp pack:smoke
 ```
 
-The `publish:npm` scripts publish with `--tag beta`; do not move either package
-to npm `latest` until the TypeScript surface is declared stable.
+Publish from GitHub Actions (`id-token: write`) so npm can attach provenance.
+The `publish:npm` scripts use `--tag beta`. Do not move either package to npm
+`latest` until the TypeScript surface is declared stable.

--- a/tenuo-ts/packages/core/README.md
+++ b/tenuo-ts/packages/core/README.md
@@ -1,19 +1,17 @@
 # `@tenuo/core`
 
-TypeScript SDK for Tenuo. Authorization decisions run in the Rust core (WASM).
+Task-scoped authorization for AI agents. Decisions run in the Rust core
+(WASM). TypeScript wraps tools and sessions; it does not decide allow or deny.
 
-> Beta: install this package from the npm `beta` dist-tag. The authorization
-> semantics match Tenuo, but the TypeScript API may still change before the
-> first stable npm tag.
-
-Requires **Node 20+**. This package is not a browser or Workers runtime. There is
-no Vercel AI SDK adapter and no Mastra adapter. `tenuo.tool()` wraps any
-`{ execute }` object, including a Vercel `tool()`, but that is not a supported
-integration.
+> **Beta.** Install from the npm `beta` tag. The API may still move before a
+> stable tag. Requires **Node 20+**. Not a browser or Workers runtime.
 
 ```bash
 npm i @tenuo/core@beta
 ```
+
+`devRoot()` needs `NODE_ENV=development` (or `test`),
+`devRoot({ allowInProduction: true })`, or `TENUO_ALLOW_DEV=1`.
 
 ```ts
 import { createTenuo, under } from "@tenuo/core";
@@ -27,16 +25,13 @@ const session = tenuo.session({ tools: [readFile] });
 
 await tenuo.withSession(session, async () => {
   await readFile.execute({ path: "/data/q3.pdf" }); // allowed
-  await readFile.execute({ path: "/etc/passwd" }); // denied — execute does not run
+  await readFile.execute({ path: "/etc/passwd" }); // denied; execute does not run
 });
 ```
 
-Host schemas (Zod or otherwise) answer **valid**. Tool `allow` is the host ceiling.
-The session is what this agent may do. Rust AND's both. `allow` is zero-trust:
-every call argument must be named in the policy. `allow: {}` adds no extra
-ceiling. `devRoot()` requires `NODE_ENV=development` or `test`,
-`devRoot({ allowInProduction: true })`, or `TENUO_ALLOW_DEV=1`. Unset
-`NODE_ENV` is not treated as development.
+Host schemas (Zod or otherwise) answer **valid**. Tool `allow` is the host
+ceiling. The session is what this agent may do. Rust ANDs both. Every call
+argument must be named in `allow`. Empty `allow: {}` adds no extra ceiling.
 
 Production loads an issued warrant and a trusted root:
 
@@ -51,12 +46,13 @@ const session = tenuo.sessionFromWire({
 ```
 
 MCP wire helpers live on `tenuo.mcp` (`attach` / `verify` / `handler`). They do
-not depend on an MCP framework. For the official v2 server, use `@tenuo/mcp`.
-For `@modelcontextprotocol/sdk` v1, copy the recipe in `examples/mcp/host.ts`.
-`verify` / `handler` can take an optional `nonceStore` (`memoryNonceStore()`,
-or an async Redis `checkAndRecord`) to reject an exact replayed PoP; that is
-opt-in. PoP v1 is otherwise replayable in-window, including approval-gated
-calls. Pass `nonceStore` on those tools if an approval must be one-use.
+not depend on an MCP framework. For the official v2 server, use
+[`@tenuo/mcp`](https://www.npmjs.com/package/@tenuo/mcp). For
+`@modelcontextprotocol/sdk` v1, copy `examples/mcp/host.ts`.
 
-See the [workspace README](../../README.md) for the full API, refuse list, and
-how to rebuild WASM from this monorepo.
+There is no Vercel AI SDK adapter and no Mastra adapter. `tenuo.tool()` wraps
+any `{ execute }` object, including a Vercel `tool()`, but that is not a
+supported integration.
+
+See the [workspace README](../../README.md) for MCP PoP replay, receipts,
+revocation, the refuse list, and how to rebuild WASM from this monorepo.

--- a/tenuo-ts/packages/mcp/README.md
+++ b/tenuo-ts/packages/mcp/README.md
@@ -4,10 +4,8 @@ Optional adapter for the official MCP TypeScript **v2** server
 (`@modelcontextprotocol/server`). `@tenuo/core` stays free of MCP frameworks.
 Decisions still run in Rust via `tenuo.mcp.verify()`.
 
-> Beta: install this package from the npm `beta` dist-tag. The TypeScript MCP
-> adapter API may still change before the first stable npm tag.
-
-Requires **Node 20+**. Peers are required at install time:
+> **Beta.** Install from the npm `beta` tag. The adapter API may still move
+> before a stable tag. Requires **Node 20+**.
 
 ```bash
 npm i @tenuo/mcp@beta @tenuo/core@beta @modelcontextprotocol/server
@@ -33,7 +31,9 @@ tools.register(
     inputSchema: z.object({ path: z.string() }),
     allow: { path: under("/data") },
   },
-  async ({ path }) => ({ content: [{ type: "text", text: await readFile(path) }] }),
+  async ({ path }) => ({
+    content: [{ type: "text", text: await readFile(path) }],
+  }),
 );
 ```
 
@@ -41,28 +41,36 @@ The client still uses core:
 
 ```ts
 const call = tenuo.mcp.attach(session, "read_file", { path: "/data/q3.pdf" });
-await client.callTool({ name: call.name, arguments: call.arguments, _meta: call._meta });
+await client.callTool({
+  name: call.name,
+  arguments: call.arguments,
+  _meta: call._meta,
+});
 ```
 
-Zod (or any host schema) is **valid**. `allow` is **allowed**, AND'd with the
-warrant in Rust, and zero-trust: every argument must be named. `allow` is
-stripped before `registerTool` so it is not advertised. Pass `nonceStore:
-memoryNonceStore()` to reject an exact replayed PoP (opt-in, in-process only).
-PoP v1 is replayable in-window, including approval-gated calls; pass
-`nonceStore` on a gated tool if that approval must be one-use.
+Zod (or any host schema) is **valid**. `allow` is the server ceiling, AND'd with
+the warrant in Rust. Every argument must be named in `allow`. `allow` is
+stripped before `registerTool` so it is not advertised.
+
 Tenuo denials become `{ isError: true }` with a JSON-RPC body. Handler
 exceptions become `{ isError: true, content: [{ type: "text", text: "Tool execution failed" }] }`
-— the official transport must not see thrown messages. Pass `onHandlerError`
-to observe the original exception server-side. Tools without `inputSchema`
-are registered as `(ctx)` only, matching the official server. `guardHandler()`
-without a schema returns that same `(ctx)` callback so a raw `registerTool`
-wrap typechecks. `guardTools().register()` is the schema-typed path;
-`guardHandler()` with a typed callback infers args from it.
-A nonce-store
-failure returns the constant "Replay store unavailable"; pass
-`onNonceStoreError` for the original cause. Unknown option keys, including
-mixed typos like `{ allow, nonceStroe }`, throw at register time.
+so the transport never sees thrown messages. Pass `onHandlerError` to observe
+the original exception server-side.
+
+## Details
+
+- **PoP replay.** Pass `nonceStore: memoryNonceStore()` to reject an exact
+  replayed PoP (opt-in, in-process). PoP v1 is otherwise replayable in-window,
+  including approval-gated calls. A nonce-store failure returns
+  `"Replay store unavailable"`; use `onNonceStoreError` for the cause.
+- **Schema-less tools.** Tools without `inputSchema` register as `(ctx)` only,
+  matching the official server. `guardHandler()` without a schema returns that
+  same `(ctx)` callback. `guardTools().register()` is the schema-typed path;
+  `guardHandler()` with a typed callback infers args from it.
+- **Unknown options.** Unknown keys, including typos like `{ allow, nonceStroe }`,
+  throw at register time.
 
 There is no FastMCP adapter and no v1 adapter package. For
-`@modelcontextprotocol/sdk` v1, copy the recipe in
-`packages/core/examples/mcp/host.ts`.
+`@modelcontextprotocol/sdk` v1, copy
+`packages/core/examples/mcp/host.ts`. Full workspace notes:
+[tenuo-ts/README.md](../../README.md).


### PR DESCRIPTION
## Summary
- Retitle `tenuo-ts/README.md` as the TypeScript SDK workspace (core + mcp), with install first and a runnable five-minute path that calls out `NODE_ENV` / `devRoot` requirements.
- Move dense PoP/nonce/replay guidance under MCP; keep outcomes, refuse list, and production `sessionFromWire` / `narrow`.
- Trim `@tenuo/core` and `@tenuo/mcp` package READMEs so npm landings stay short and point at the workspace README for depth.

## Test plan
- [ ] Skim `tenuo-ts/README.md` as a first-time installer: install → five minutes → production → MCP
- [ ] Confirm package READMEs on npm would still make sense alone
- [ ] Spot-check links to `examples/mcp/host.ts` and workspace README relatives