### PR TITLE
SDK: local receipts, MCP denials, and terminal leaves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
         run: |
           pytest -v tests/adapters/test_mcp_ci_smoke.py
 
-      - name: Verify-only GitHub Actions gateway
+      - name: GitHub Actions gateway tests
         working-directory: github-actions
         run: |
           uv pip install --system pytest pyyaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,12 @@ jobs:
         run: |
           pytest -v tests/adapters/test_mcp_ci_smoke.py
 
+      - name: Verify-only GitHub Actions gateway
+        working-directory: github-actions
+        run: |
+          uv pip install --system pytest pyyaml
+          pytest -v
+
   # ============================================================================
   # TEMPORAL INTEGRATION (live Temporal server)
   # ============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Stable `TENUO_*` denial codes** on MCP results and in `error.data.code`
   (`TENUO_TOOL_NOT_AUTHORIZED`, `TENUO_CONSTRAINT_VIOLATION`,
   `TENUO_INVALID_POP`, `TENUO_REVOKED`, `TENUO_WARRANT_EXPIRED`).
+- **Verify-only GitHub Actions gateway** in `github-actions/`. FastMCP
+  ceiling, `github-triage` plus tripwires, file receipts, I10 refuse-to-start.
+  No GitHub API calls. `python -m tenuo_gha.check` replays the containment
+  fixtures.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP denial receipts.** `MCPVerificationResult` keeps `presented_chain`,
+  `error_type`, `error_code`, `verified_pop`, `pop_auth_args`, and
+  `authorizer` on denials after a warrant decodes, so `emit_for_enforcement`
+  can sign a refusal the same way `@guard` already does.
+- **`ReceiptSigner(signing_key, sink)`** in `tenuo.receipts`. Signs receipts
+  with no control-plane URL. Rust `ControlPlaneClient.local(signing_key)`
+  is the issuer underneath (no heartbeat).
+- **`SecureMCPClient.derive_terminal_leaf` / `tenuo.mcp.derive_terminal_leaf`.**
+  Attenuates a warrant to exact-argument constraints (`Exact` for strings,
+  `Range(n, n)` for integers, `Subset` for lists).
+- **Stable `TENUO_*` denial codes** on MCP results and in `error.data.code`
+  (`TENUO_TOOL_NOT_AUTHORIZED`, `TENUO_CONSTRAINT_VIOLATION`,
+  `TENUO_INVALID_POP`, `TENUO_REVOKED`, `TENUO_WARRANT_EXPIRED`).
+
+### Changed
+
+- Document `Range(n, n)` as the exact-match form for integers; `Exact` is
+  for strings and booleans.
+
 ## [0.2.4] - 2026-09-01
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Stable `TENUO_*` denial codes** on MCP results and in `error.data.code`
   (`TENUO_TOOL_NOT_AUTHORIZED`, `TENUO_CONSTRAINT_VIOLATION`,
   `TENUO_INVALID_POP`, `TENUO_REVOKED`, `TENUO_WARRANT_EXPIRED`).
-- **Verify-only GitHub Actions gateway** in `github-actions/`. FastMCP
-  ceiling, `github-triage` plus tripwires, file receipts, I10 refuse-to-start.
-  No GitHub API calls. `python -m tenuo_gha.check` replays the containment
-  fixtures.
+- **GitHub Actions gateway** in `github-actions/`. FastMCP ceiling,
+  `github-triage` catalog, file receipts, refuse-to-start on stored tokens
+  or PEMs. Tool handlers do not call GitHub. `python -m tenuo_gha.check`
+  replays the fixture table.
 
 ### Changed
 

--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -291,12 +291,17 @@ from tenuo import Range
 # 0 to 100 (inclusive)
 Range(min=0, max=100)
 
+# Exact integer match — `Exact` is string-typed
+Range(4127, 4127)
+
 # At most 1000
 Range.max_value(1000)
 
 # At least 10
 Range.min_value(10)
 ```
+
+`Range(n, n)` is the exact-match form for integers. Use it when a terminal leaf must bind one issue number, replica count, or other numeric argument. `Exact` is for strings (and booleans, which the terminal-leaf helper stringifies to `"true"` / `"false"`).
 
 > [!WARNING]
 > **Precision Limit**: Bounds are stored as 64-bit floats. Integers larger than 2^53 (9,007,199,254,740,992) will lose precision.

--- a/github-actions/Dockerfile
+++ b/github-actions/Dockerfile
@@ -1,0 +1,28 @@
+# Verify-only gateway (M2). Distroless / no-shell is M6.
+#
+# Build from the monorepo root after producing a tenuo wheel:
+#   (cd tenuo-python && maturin build --release)
+#   docker build -f github-actions/Dockerfile \
+#     --build-arg TENUO_WHEEL=tenuo-python/target/wheels/tenuo-<ver>-*.whl .
+
+FROM python:3.12-slim-bookworm
+ARG TENUO_WHEEL
+
+RUN useradd --create-home --uid 1000 --shell /usr/sbin/nologin tenuo \
+    && mkdir -p /state /etc/tenuo \
+    && chown -R tenuo:tenuo /state
+
+WORKDIR /app
+COPY ${TENUO_WHEEL} /tmp/tenuo.whl
+COPY github-actions /src/github-actions
+
+RUN pip install --no-cache-dir /tmp/tenuo.whl \
+    && pip install --no-cache-dir --no-deps /src/github-actions \
+    && pip install --no-cache-dir "pyyaml>=6.0" "fastmcp>=3.2.1" \
+    && rm -rf /tmp/tenuo.whl /src
+
+USER 1000
+WORKDIR /state
+ENV PYTHONUNBUFFERED=1
+EXPOSE 8000
+ENTRYPOINT ["python", "-m", "tenuo_gha"]

--- a/github-actions/Dockerfile
+++ b/github-actions/Dockerfile
@@ -1,5 +1,3 @@
-# Verify-only gateway (M2). Distroless / no-shell is M6.
-#
 # Build from the monorepo root after producing a tenuo wheel:
 #   (cd tenuo-python && maturin build --release)
 #   docker build -f github-actions/Dockerfile \

--- a/github-actions/README.md
+++ b/github-actions/README.md
@@ -1,17 +1,11 @@
 # Tenuo for GitHub Actions
 
-Verify-only gateway (M2). It checks warrants, emits file receipts, and never
-calls GitHub. Tripwires (`workflow_dispatch`, `install_package`, …) are
-registered so the containment check can call them and watch them fail.
+Checks warrants and writes file receipts. Tool handlers do not call GitHub.
 
 ```bash
-# Containment fixtures (must deny the attack shapes):
 PYTHONPATH=github-actions python -m tenuo_gha.check
 
-# HTTP entrypoint (verify-only; memory keys are test-only):
 TENUO_ALLOW_INSECURE_MEMORY_KEYS=1 \
 TENUO_ROOT_PUBLIC_KEY=<hex> \
 python -m tenuo_gha --config github-actions/examples/gateway.yaml
 ```
-
-Production custody (KMS, `/v1/exchange`, App tokens) is M3+.

--- a/github-actions/README.md
+++ b/github-actions/README.md
@@ -1,0 +1,17 @@
+# Tenuo for GitHub Actions
+
+Verify-only gateway (M2). It checks warrants, emits file receipts, and never
+calls GitHub. Tripwires (`workflow_dispatch`, `install_package`, …) are
+registered so the containment check can call them and watch them fail.
+
+```bash
+# Containment fixtures (must deny the attack shapes):
+PYTHONPATH=github-actions python -m tenuo_gha.check
+
+# HTTP entrypoint (verify-only; memory keys are test-only):
+TENUO_ALLOW_INSECURE_MEMORY_KEYS=1 \
+TENUO_ROOT_PUBLIC_KEY=<hex> \
+python -m tenuo_gha --config github-actions/examples/gateway.yaml
+```
+
+Production custody (KMS, `/v1/exchange`, App tokens) is M3+.

--- a/github-actions/examples/gateway.yaml
+++ b/github-actions/examples/gateway.yaml
@@ -1,0 +1,13 @@
+version: 1
+trust:
+  root_public_keys: ["${TENUO_ROOT_PUBLIC_KEY}"]
+  require_pop: true
+signing:
+  provider: memory
+ceiling:
+  repositories: ["acme/widgets"]
+tools:
+  packs: [github-triage]
+receipts:
+  sink: file
+  path: /tmp/tenuo-receipts.jsonl

--- a/github-actions/pyproject.toml
+++ b/github-actions/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tenuo-github-actions"
 version = "0.1.0"
-description = "Tenuo for GitHub Actions — verify-only gateway"
+description = "Tenuo for GitHub Actions"
 requires-python = ">=3.10"
 dependencies = [
     "tenuo",

--- a/github-actions/pyproject.toml
+++ b/github-actions/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "tenuo-github-actions"
+version = "0.1.0"
+description = "Tenuo for GitHub Actions — verify-only gateway"
+requires-python = ">=3.10"
+dependencies = [
+    "tenuo",
+    "pyyaml>=6.0",
+    "fastmcp>=3.2.1",
+]
+
+[project.scripts]
+tenuo-gha = "tenuo_gha.app:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["tenuo_gha*"]

--- a/github-actions/pytest.ini
+++ b/github-actions/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/github-actions/tenuo_gha/__init__.py
+++ b/github-actions/tenuo_gha/__init__.py
@@ -1,4 +1,4 @@
-"""Tenuo for GitHub Actions — verify-only gateway (M2)."""
+"""Tenuo for GitHub Actions gateway."""
 
 from .app import Gateway
 from .config import ConfigError, GatewayConfig

--- a/github-actions/tenuo_gha/__init__.py
+++ b/github-actions/tenuo_gha/__init__.py
@@ -1,0 +1,6 @@
+"""Tenuo for GitHub Actions — verify-only gateway (M2)."""
+
+from .app import Gateway
+from .config import ConfigError, GatewayConfig
+
+__all__ = ["Gateway", "GatewayConfig", "ConfigError"]

--- a/github-actions/tenuo_gha/__main__.py
+++ b/github-actions/tenuo_gha/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/github-actions/tenuo_gha/app.py
+++ b/github-actions/tenuo_gha/app.py
@@ -1,4 +1,4 @@
-"""Verify-only GitHub Actions gateway. I3 and I6; no GitHub API calls."""
+"""GitHub Actions gateway: warrant verify, file receipts, no GitHub calls."""
 
 from __future__ import annotations
 
@@ -43,7 +43,7 @@ class Gateway:
 
     def __init__(self, config: GatewayConfig) -> None:
         if config.signing_provider == "kms":
-            raise ConfigError("KMS signing is M3; this image is verify-only")
+            raise ConfigError("signing.provider=kms is not supported")
         self.config = config
         self.tools = tools_for_packs(config.packs)
         roots = [_public_key(item) for item in config.root_public_keys]
@@ -54,9 +54,7 @@ class Gateway:
             FileReceiptSink(self.config.receipt_path),
             authorizer=self.authorizer,
         )
-        # Tripwires are decided here, after a warrant decode and before any
-        # allow receipt, so a warrant that names a tripwire never produces
-        # an allow followed by a deny.
+        # Ceiling tools are checked after decode and before an allow receipt.
         self._raw = MCPVerifier(authorizer=self.authorizer, control_plane=False)
         self.verifier = MCPVerifier(
             authorizer=self.authorizer,
@@ -79,7 +77,7 @@ class Gateway:
                 clean_arguments=dict(arguments or {}),
                 constraints=dict(arguments or {}),
                 warrant_id=result.warrant_id,
-                denial_reason="gateway ceiling: tripwire tools cannot be enabled",
+                denial_reason="gateway ceiling: tool is not enabled",
                 jsonrpc_error_code=-32001,
                 error_type="tool_not_allowed",
                 error_code=TENUO_TOOL_NOT_AUTHORIZED,
@@ -97,7 +95,7 @@ class Gateway:
 
 
 def build_mcp(gateway: Gateway):
-    """FastMCP app: middleware verifies, handlers never call GitHub."""
+    """FastMCP app: middleware verifies; handlers do not perform the tool."""
     from fastmcp import FastMCP
     from fastmcp.server.middleware.middleware import CallNext, Middleware, MiddlewareContext
     import mcp.types as mt
@@ -137,7 +135,7 @@ def build_mcp(gateway: Gateway):
 def main() -> None:
     import argparse
 
-    parser = argparse.ArgumentParser(description="Tenuo for GitHub Actions (verify-only)")
+    parser = argparse.ArgumentParser(description="Tenuo for GitHub Actions")
     parser.add_argument("--config", default=os.environ.get("TENUO_GATEWAY_CONFIG", "/etc/tenuo/gateway.yaml"))
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)

--- a/github-actions/tenuo_gha/app.py
+++ b/github-actions/tenuo_gha/app.py
@@ -1,0 +1,152 @@
+"""Verify-only GitHub Actions gateway. I3 and I6; no GitHub API calls."""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Any, Dict, Optional
+
+from tenuo import Authorizer, PublicKey, SigningKey
+from tenuo.mcp import MCPVerificationResult, MCPVerifier, TENUO_TOOL_NOT_AUTHORIZED
+from tenuo.receipts import FileReceiptSink, ReceiptSigner
+
+from .catalog import TRIPWIRE_NAMES, ToolSpec, tools_for_packs
+from .config import ConfigError, GatewayConfig
+
+
+def _public_key(value: str) -> PublicKey:
+    raw = value.strip()
+    if raw.startswith("hex:"):
+        raw = raw[4:]
+    try:
+        return PublicKey.from_bytes(bytes.fromhex(raw))
+    except Exception:
+        return PublicKey.from_bytes(base64.b64decode(raw))
+
+
+def _signing_key(config: GatewayConfig) -> SigningKey:
+    raw = config.receipt_signing_key
+    if not raw:
+        if config.signing_provider == "memory":
+            return SigningKey.generate()
+        raise ConfigError("TENUO_RECEIPT_SIGNING_KEY is required")
+    try:
+        return SigningKey.from_base64(raw)
+    except AttributeError:
+        return SigningKey.from_bytes(base64.b64decode(raw))
+    except Exception:
+        return SigningKey.from_bytes(bytes.fromhex(raw))
+
+
+class Gateway:
+    """In-process gateway used by tests and by the HTTP entrypoint."""
+
+    def __init__(self, config: GatewayConfig) -> None:
+        if config.signing_provider == "kms":
+            raise ConfigError("KMS signing is M3; this image is verify-only")
+        self.config = config
+        self.tools = tools_for_packs(config.packs)
+        roots = [_public_key(item) for item in config.root_public_keys]
+        self.authorizer = Authorizer(trusted_roots=roots)
+        self.config.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        self.signer = ReceiptSigner(
+            _signing_key(config),
+            FileReceiptSink(self.config.receipt_path),
+            authorizer=self.authorizer,
+        )
+        # Tripwires are decided here, after a warrant decode and before any
+        # allow receipt, so a warrant that names a tripwire never produces
+        # an allow followed by a deny.
+        self._raw = MCPVerifier(authorizer=self.authorizer, control_plane=False)
+        self.verifier = MCPVerifier(
+            authorizer=self.authorizer,
+            control_plane=self.signer,
+        )
+
+    def verify(
+        self,
+        tool: str,
+        arguments: Optional[Dict[str, Any]],
+        meta: Any = None,
+    ) -> MCPVerificationResult:
+        if tool in TRIPWIRE_NAMES:
+            result = self._raw.verify(tool, arguments, meta=meta)
+            if not result.allowed and not result.presented_chain:
+                return result
+            denied = MCPVerificationResult(
+                allowed=False,
+                tool=tool,
+                clean_arguments=dict(arguments or {}),
+                constraints=dict(arguments or {}),
+                warrant_id=result.warrant_id,
+                denial_reason="gateway ceiling: tripwire tools cannot be enabled",
+                jsonrpc_error_code=-32001,
+                error_type="tool_not_allowed",
+                error_code=TENUO_TOOL_NOT_AUTHORIZED,
+                presented_chain=result.presented_chain,
+                verified_pop=result.verified_pop,
+                pop_auth_args=result.pop_auth_args,
+                authorizer=self.authorizer,
+            )
+            self.signer.emit_for_enforcement(denied)
+            return denied
+        return self.verifier.verify(tool, arguments, meta=meta)
+
+    def flush_receipts(self) -> bool:
+        return self.signer.flush()
+
+
+def build_mcp(gateway: Gateway):
+    """FastMCP app: middleware verifies, handlers never call GitHub."""
+    from fastmcp import FastMCP
+    from fastmcp.server.middleware.middleware import CallNext, Middleware, MiddlewareContext
+    import mcp.types as mt
+    from tenuo.mcp.fastmcp_middleware import _denial_tool_return, resolve_tool_call_meta_for_verify
+
+    class _Ceiling(Middleware):
+        async def on_call_tool(
+            self,
+            context: MiddlewareContext[mt.CallToolRequestParams],
+            call_next: CallNext[mt.CallToolRequestParams, Any],
+        ) -> Any:
+            params = context.message
+            result = gateway.verify(
+                params.name,
+                params.arguments or {},
+                meta=resolve_tool_call_meta_for_verify(params, context.fastmcp_context),
+            )
+            if not result.allowed:
+                return _denial_tool_return(result)
+            return await call_next(context)
+
+    mcp = FastMCP("tenuo-github-actions", middleware=[_Ceiling()])
+
+    def _register(spec: ToolSpec) -> None:
+        async def _handler(**kwargs: Any) -> Dict[str, Any]:
+            return {"executed": False, "mode": "verify_only", "tool": spec.name}
+
+        _handler.__name__ = spec.name.replace(".", "_")
+        _handler.__doc__ = spec.description
+        mcp.tool(name=spec.name)(_handler)
+
+    for spec in gateway.tools:
+        _register(spec)
+    return mcp
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Tenuo for GitHub Actions (verify-only)")
+    parser.add_argument("--config", default=os.environ.get("TENUO_GATEWAY_CONFIG", "/etc/tenuo/gateway.yaml"))
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args()
+    config = GatewayConfig.from_yaml(args.config)
+    gateway = Gateway(config)
+    mcp = build_mcp(gateway)
+    mcp.run(transport="streamable-http", host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/github-actions/tenuo_gha/catalog.py
+++ b/github-actions/tenuo_gha/catalog.py
@@ -1,0 +1,66 @@
+"""Tool catalog for the verify-only gateway.
+
+``github-triage`` tools are registered and execute nothing. Tripwires are
+registered so the containment check can call them; the gateway ceiling
+refuses them even if a warrant names them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    name: str
+    description: str
+    arguments: Tuple[str, ...]
+    tripwire: bool = False
+    mutating: bool = False
+
+
+TRIAGE: Tuple[ToolSpec, ...] = (
+    ToolSpec("github.get_issue", "Read one issue.", ("repository", "issue")),
+    ToolSpec("github.list_issue_comments", "List comments on an issue.", ("repository", "issue")),
+    ToolSpec("github.add_comment", "Add a comment.", ("repository", "issue", "body"), mutating=True),
+    ToolSpec("github.add_labels", "Add labels.", ("repository", "issue", "labels"), mutating=True),
+    ToolSpec("github.remove_label", "Remove a label.", ("repository", "issue", "name"), mutating=True),
+    ToolSpec(
+        "github.close_issue",
+        "Close an issue.",
+        ("repository", "issue", "state_reason"),
+        mutating=True,
+    ),
+)
+
+TRIPWIRES: Tuple[ToolSpec, ...] = (
+    ToolSpec("github.workflow_dispatch", "Tripwire: start a workflow.", ("repository", "workflow"), tripwire=True, mutating=True),
+    ToolSpec("github.get_file_contents", "Tripwire until github-review.", ("repository", "path", "ref"), tripwire=True),
+    ToolSpec("github.update_workflow", "Tripwire: write a workflow file.", ("repository", "path"), tripwire=True, mutating=True),
+    ToolSpec("github.get_secret", "Tripwire: read a secret.", ("repository", "name"), tripwire=True),
+    ToolSpec("github.create_deploy_key", "Tripwire: create a deploy key.", ("repository",), tripwire=True, mutating=True),
+    ToolSpec("github.create_release", "Tripwire: create a release.", ("repository", "tag"), tripwire=True, mutating=True),
+    ToolSpec("install_package", "Tripwire: install a package on the runner.", ("name",), tripwire=True, mutating=True),
+)
+
+PACKS: Dict[str, Tuple[ToolSpec, ...]] = {"github-triage": TRIAGE}
+
+TRIPWIRE_NAMES = frozenset(spec.name for spec in TRIPWIRES)
+
+
+def tools_for_packs(packs: List[str]) -> List[ToolSpec]:
+    chosen: List[ToolSpec] = []
+    seen = set()
+    for pack in packs:
+        if pack not in PACKS:
+            raise ValueError(f"unknown pack {pack!r}")
+        for spec in PACKS[pack]:
+            if spec.name not in seen:
+                chosen.append(spec)
+                seen.add(spec.name)
+    for spec in TRIPWIRES:
+        if spec.name not in seen:
+            chosen.append(spec)
+            seen.add(spec.name)
+    return chosen

--- a/github-actions/tenuo_gha/catalog.py
+++ b/github-actions/tenuo_gha/catalog.py
@@ -1,9 +1,4 @@
-"""Tool catalog for the verify-only gateway.
-
-``github-triage`` tools are registered and execute nothing. Tripwires are
-registered so the containment check can call them; the gateway ceiling
-refuses them even if a warrant names them.
-"""
+"""Tool catalog. Ceiling tools are registered and always refused."""
 
 from __future__ import annotations
 
@@ -35,13 +30,13 @@ TRIAGE: Tuple[ToolSpec, ...] = (
 )
 
 TRIPWIRES: Tuple[ToolSpec, ...] = (
-    ToolSpec("github.workflow_dispatch", "Tripwire: start a workflow.", ("repository", "workflow"), tripwire=True, mutating=True),
-    ToolSpec("github.get_file_contents", "Tripwire until github-review.", ("repository", "path", "ref"), tripwire=True),
-    ToolSpec("github.update_workflow", "Tripwire: write a workflow file.", ("repository", "path"), tripwire=True, mutating=True),
-    ToolSpec("github.get_secret", "Tripwire: read a secret.", ("repository", "name"), tripwire=True),
-    ToolSpec("github.create_deploy_key", "Tripwire: create a deploy key.", ("repository",), tripwire=True, mutating=True),
-    ToolSpec("github.create_release", "Tripwire: create a release.", ("repository", "tag"), tripwire=True, mutating=True),
-    ToolSpec("install_package", "Tripwire: install a package on the runner.", ("name",), tripwire=True, mutating=True),
+    ToolSpec("github.workflow_dispatch", "Start a workflow.", ("repository", "workflow"), tripwire=True, mutating=True),
+    ToolSpec("github.get_file_contents", "Read a file.", ("repository", "path", "ref"), tripwire=True),
+    ToolSpec("github.update_workflow", "Write a workflow file.", ("repository", "path"), tripwire=True, mutating=True),
+    ToolSpec("github.get_secret", "Read a secret.", ("repository", "name"), tripwire=True),
+    ToolSpec("github.create_deploy_key", "Create a deploy key.", ("repository",), tripwire=True, mutating=True),
+    ToolSpec("github.create_release", "Create a release.", ("repository", "tag"), tripwire=True, mutating=True),
+    ToolSpec("install_package", "Install a package on the runner.", ("name",), tripwire=True, mutating=True),
 )
 
 PACKS: Dict[str, Tuple[ToolSpec, ...]] = {"github-triage": TRIAGE}

--- a/github-actions/tenuo_gha/check.py
+++ b/github-actions/tenuo_gha/check.py
@@ -1,0 +1,184 @@
+"""Containment check: incident-shaped calls against a verify-only gateway."""
+
+from __future__ import annotations
+
+import base64
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from tenuo.mcp import (
+    TENUO_CONSTRAINT_VIOLATION,
+    TENUO_TOOL_NOT_AUTHORIZED,
+)
+
+from .app import Gateway
+
+
+@dataclass
+class CheckRow:
+    name: str
+    expected: str
+    actual: str
+    ok: bool
+
+
+def _meta(warrant: Any, key: Any, tool: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    sig = warrant.sign(key, tool, args, int(time.time()))
+    return {
+        "tenuo": {
+            "warrant": warrant.to_base64(),
+            "signature": base64.b64encode(bytes(sig)).decode(),
+        }
+    }
+
+
+def run_containment(
+    gateway: Gateway,
+    warrant: Any,
+    holder_key: Any,
+    *,
+    bound_repository: str,
+    bound_issue: int,
+    foreign_repository: str,
+) -> List[CheckRow]:
+    """Replay the incident shapes. Allowed stubs execute nothing."""
+    rows: List[CheckRow] = []
+
+    def row(name: str, expected: str, result: Any) -> None:
+        actual = "allow" if result.allowed else (result.error_code or "deny")
+        rows.append(CheckRow(name, expected, actual, actual == expected))
+
+    allowed_args = {"repository": bound_repository, "issue": bound_issue}
+    row(
+        "allowed get_issue",
+        "allow",
+        gateway.verify(
+            "github.get_issue",
+            allowed_args,
+            meta=_meta(warrant, holder_key, "github.get_issue", allowed_args),
+        ),
+    )
+
+    cross = {"repository": foreign_repository, "issue": 1}
+    row(
+        "GitLost cross-repo read",
+        TENUO_CONSTRAINT_VIOLATION,
+        gateway.verify(
+            "github.get_issue",
+            cross,
+            meta=_meta(warrant, holder_key, "github.get_issue", cross),
+        ),
+    )
+
+    dispatch = {"repository": bound_repository, "workflow": "release.yml"}
+    row(
+        "Gemini workflow_dispatch",
+        TENUO_TOOL_NOT_AUTHORIZED,
+        gateway.verify(
+            "github.workflow_dispatch",
+            dispatch,
+            meta=_meta(warrant, holder_key, "github.workflow_dispatch", dispatch),
+        ),
+    )
+
+    install = {"name": "evil-pkg"}
+    row(
+        "Clinejection install_package",
+        TENUO_TOOL_NOT_AUTHORIZED,
+        gateway.verify(
+            "install_package",
+            install,
+            meta=_meta(warrant, holder_key, "install_package", install),
+        ),
+    )
+
+    unsafe = {"repository": bound_repository, "path": ".env", "ref": "main"}
+    row(
+        "unsafe path read",
+        TENUO_TOOL_NOT_AUTHORIZED,
+        gateway.verify(
+            "github.get_file_contents",
+            unsafe,
+            meta=_meta(warrant, holder_key, "github.get_file_contents", unsafe),
+        ),
+    )
+
+    bare = gateway.verify("github.get_issue", allowed_args, meta={})
+    rows.append(
+        CheckRow(
+            "no envelope",
+            "deny-no-receipt",
+            "deny-no-receipt" if (not bare.allowed and not bare.presented_chain) else "unexpected",
+            not bare.allowed and not bare.presented_chain,
+        )
+    )
+
+    gateway.flush_receipts()
+    return rows
+
+
+def all_passed(rows: List[CheckRow]) -> bool:
+    return all(row.ok for row in rows)
+
+
+def format_table(rows: List[CheckRow]) -> str:
+    lines = [f"{'name':<36} {'expected':<28} {'actual':<28} result"]
+    for row in rows:
+        mark = "ok" if row.ok else "FAIL"
+        lines.append(f"{row.name:<36} {row.expected:<28} {row.actual:<28} {mark}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Local containment replay. Mints an in-process issuer; does not call GitHub."""
+    import tempfile
+    from pathlib import Path
+
+    from tenuo import Exact, Range
+    from tenuo_core import SigningKey, Warrant
+
+    from .app import Gateway
+    from .config import GatewayConfig
+
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    receipts = Path(tempfile.mkdtemp()) / "receipts.jsonl"
+    environ = {
+        "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+        "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+    }
+    config = GatewayConfig.from_mapping(
+        {
+            "version": 1,
+            "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+            "signing": {"provider": "memory"},
+            "ceiling": {"repositories": ["acme/widgets"]},
+            "tools": {"packs": ["github-triage"]},
+            "receipts": {"path": str(receipts)},
+        },
+        environ=environ,
+    )
+    warrant = (
+        Warrant.mint_builder()
+        .capability("github.get_issue", repository=Exact("acme/widgets"), issue=Range(4127, 4127))
+        .capability("github.add_comment", repository=Exact("acme/widgets"), issue=Range(4127, 4127))
+        .holder(holder.public_key)
+        .ttl(900)
+        .mint(issuer)
+    )
+    rows = run_containment(
+        Gateway(config),
+        warrant,
+        holder,
+        bound_repository="acme/widgets",
+        bound_issue=4127,
+        foreign_repository="acme/payments-internal",
+    )
+    print(format_table(rows))
+    if not all_passed(rows):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/github-actions/tenuo_gha/check.py
+++ b/github-actions/tenuo_gha/check.py
@@ -1,4 +1,4 @@
-"""Containment check: incident-shaped calls against a verify-only gateway."""
+"""Replay fixture calls against a local gateway and print expected vs actual."""
 
 from __future__ import annotations
 
@@ -42,7 +42,7 @@ def run_containment(
     bound_issue: int,
     foreign_repository: str,
 ) -> List[CheckRow]:
-    """Replay the incident shapes. Allowed stubs execute nothing."""
+    """Replay the fixture table. Allowed stubs execute nothing."""
     rows: List[CheckRow] = []
 
     def row(name: str, expected: str, result: Any) -> None:
@@ -131,7 +131,7 @@ def format_table(rows: List[CheckRow]) -> str:
 
 
 def main() -> None:
-    """Local containment replay. Mints an in-process issuer; does not call GitHub."""
+    """Mint an in-process issuer and replay the fixture table."""
     import tempfile
     from pathlib import Path
 

--- a/github-actions/tenuo_gha/config.py
+++ b/github-actions/tenuo_gha/config.py
@@ -1,0 +1,151 @@
+"""Gateway configuration. A PEM, PAT, or GITHUB_TOKEN is a startup error."""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+import yaml
+
+_TOKEN_PREFIXES = ("ghs_", "github_pat_", "gho_", "ghu_")
+_PEM_MARKERS = ("BEGIN ", "PRIVATE KEY", "-----")
+_FORBIDDEN_NAMES = frozenset(
+    {
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "TENUO_GITHUB_APP_PRIVATE_KEY",
+        "TENUO_ISSUER_KEY",
+        "TENUO_HOLDER_SECRET",
+    }
+)
+
+
+class ConfigError(ValueError):
+    """Invalid gateway configuration or I10 violation."""
+
+
+def _expand(value: Any, environ: Mapping[str, str]) -> Any:
+    if isinstance(value, str):
+        def repl(match: re.Match[str]) -> str:
+            key = match.group(1)
+            if key not in environ:
+                raise ConfigError(f"unresolved environment variable ${{{key}}}")
+            return environ[key]
+
+        return re.sub(r"\$\{([^}]+)\}", repl, value)
+    if isinstance(value, list):
+        return [_expand(item, environ) for item in value]
+    if isinstance(value, dict):
+        return {key: _expand(item, environ) for key, item in value.items()}
+    return value
+
+
+def _looks_like_token(raw: str) -> bool:
+    return any(raw.startswith(prefix) for prefix in _TOKEN_PREFIXES)
+
+
+def _looks_like_pem(raw: str) -> bool:
+    return any(marker in raw for marker in _PEM_MARKERS)
+
+
+def assert_no_runtime_secrets(environ: Mapping[str, str]) -> None:
+    """I10: refuse to start if a stored credential is visible in the environment."""
+    for name, raw in environ.items():
+        if not raw:
+            continue
+        if name in _FORBIDDEN_NAMES or name.endswith("_API_KEY"):
+            raise ConfigError(f"I10: {name} must not be present in the gateway environment")
+        if _looks_like_token(raw):
+            raise ConfigError(f"I10: {name} looks like a GitHub token")
+        if name.endswith("_KEY") or "PRIVATE_KEY" in name:
+            if _looks_like_pem(raw):
+                raise ConfigError(f"I10: {name} looks like a PEM")
+
+
+def _assert_no_embedded_secrets(data: Any, *, path: str = "config") -> None:
+    """I10: refuse token/PEM material written into the YAML itself."""
+    if isinstance(data, str):
+        if _looks_like_token(data) or _looks_like_pem(data):
+            raise ConfigError(f"I10: {path} looks like a stored credential")
+        return
+    if isinstance(data, list):
+        for index, item in enumerate(data):
+            _assert_no_embedded_secrets(item, path=f"{path}[{index}]")
+        return
+    if isinstance(data, dict):
+        for key, item in data.items():
+            _assert_no_embedded_secrets(item, path=f"{path}.{key}")
+
+
+@dataclass
+class GatewayConfig:
+    version: int
+    root_public_keys: List[str]
+    packs: List[str]
+    repositories: List[str]
+    receipt_path: Path
+    signing_provider: str
+    receipt_signing_key: Optional[str] = None
+    require_pop: bool = True
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any], *, environ: Mapping[str, str]) -> "GatewayConfig":
+        assert_no_runtime_secrets(environ)
+        data = _expand(dict(raw), environ)
+        if data.get("version") != 1:
+            raise ConfigError(f"unsupported config version {data.get('version')!r}")
+
+        signing = data.get("signing") or {}
+        provider = signing.get("provider") or "memory"
+        if provider == "memory":
+            if environ.get("TENUO_ALLOW_INSECURE_MEMORY_KEYS") != "1":
+                raise ConfigError(
+                    "signing.provider=memory requires TENUO_ALLOW_INSECURE_MEMORY_KEYS=1 "
+                    "(tests only). Production uses KMS."
+                )
+        elif provider != "kms":
+            raise ConfigError(f"unsupported signing.provider {provider!r}")
+
+        github_creds = (data.get("credentials") or {}).get("github") or {}
+        if github_creds:
+            raise ConfigError(
+                "credentials.github is M4; this image is verify-only and "
+                "refuses a token or App key at rest (I10)"
+            )
+        _assert_no_embedded_secrets(data)
+
+        trust = data.get("trust") or {}
+        keys = trust.get("root_public_keys") or []
+        if not keys:
+            raise ConfigError("trust.root_public_keys is required")
+
+        receipts = data.get("receipts") or {}
+        path = receipts.get("path") or "/state/receipts.jsonl"
+        tools = data.get("tools") or {}
+        packs = tools.get("packs") or ["github-triage"]
+        ceiling = data.get("ceiling") or {}
+        repositories = ceiling.get("repositories") or []
+
+        return cls(
+            version=1,
+            root_public_keys=list(keys),
+            packs=list(packs),
+            repositories=[str(item) for item in repositories],
+            receipt_path=Path(path),
+            signing_provider=provider,
+            receipt_signing_key=environ.get("TENUO_RECEIPT_SIGNING_KEY"),
+            require_pop=bool(trust.get("require_pop", True)),
+            extras=data,
+        )
+
+    @classmethod
+    def from_yaml(cls, path: "str | Path", *, environ: Optional[Mapping[str, str]] = None) -> "GatewayConfig":
+        text = Path(path).read_text(encoding="utf-8")
+        loaded = yaml.safe_load(text)
+        if not isinstance(loaded, dict):
+            raise ConfigError("config must be a mapping")
+        return cls.from_mapping(loaded, environ=environ or os.environ)

--- a/github-actions/tenuo_gha/config.py
+++ b/github-actions/tenuo_gha/config.py
@@ -1,4 +1,4 @@
-"""Gateway configuration. A PEM, PAT, or GITHUB_TOKEN is a startup error."""
+"""Gateway configuration. Stored tokens and PEMs are a startup error."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ _FORBIDDEN_NAMES = frozenset(
 
 
 class ConfigError(ValueError):
-    """Invalid gateway configuration or I10 violation."""
+    """Invalid gateway configuration."""
 
 
 def _expand(value: Any, environ: Mapping[str, str]) -> Any:
@@ -52,24 +52,24 @@ def _looks_like_pem(raw: str) -> bool:
 
 
 def assert_no_runtime_secrets(environ: Mapping[str, str]) -> None:
-    """I10: refuse to start if a stored credential is visible in the environment."""
+    """Refuse to start if a stored credential is visible in the environment."""
     for name, raw in environ.items():
         if not raw:
             continue
         if name in _FORBIDDEN_NAMES or name.endswith("_API_KEY"):
-            raise ConfigError(f"I10: {name} must not be present in the gateway environment")
+            raise ConfigError(f"{name} must not be present in the gateway environment")
         if _looks_like_token(raw):
-            raise ConfigError(f"I10: {name} looks like a GitHub token")
+            raise ConfigError(f"{name} looks like a GitHub token")
         if name.endswith("_KEY") or "PRIVATE_KEY" in name:
             if _looks_like_pem(raw):
-                raise ConfigError(f"I10: {name} looks like a PEM")
+                raise ConfigError(f"{name} looks like a PEM")
 
 
 def _assert_no_embedded_secrets(data: Any, *, path: str = "config") -> None:
-    """I10: refuse token/PEM material written into the YAML itself."""
+    """Refuse token or PEM material written into the YAML itself."""
     if isinstance(data, str):
         if _looks_like_token(data) or _looks_like_pem(data):
-            raise ConfigError(f"I10: {path} looks like a stored credential")
+            raise ConfigError(f"{path} looks like a stored credential")
         return
     if isinstance(data, list):
         for index, item in enumerate(data):
@@ -104,18 +104,14 @@ class GatewayConfig:
         if provider == "memory":
             if environ.get("TENUO_ALLOW_INSECURE_MEMORY_KEYS") != "1":
                 raise ConfigError(
-                    "signing.provider=memory requires TENUO_ALLOW_INSECURE_MEMORY_KEYS=1 "
-                    "(tests only). Production uses KMS."
+                    "signing.provider=memory requires TENUO_ALLOW_INSECURE_MEMORY_KEYS=1"
                 )
         elif provider != "kms":
             raise ConfigError(f"unsupported signing.provider {provider!r}")
 
         github_creds = (data.get("credentials") or {}).get("github") or {}
         if github_creds:
-            raise ConfigError(
-                "credentials.github is M4; this image is verify-only and "
-                "refuses a token or App key at rest (I10)"
-            )
+            raise ConfigError("credentials.github is not supported")
         _assert_no_embedded_secrets(data)
 
         trust = data.get("trust") or {}

--- a/github-actions/tests/test_verify_only.py
+++ b/github-actions/tests/test_verify_only.py
@@ -1,0 +1,201 @@
+"""I3 / I6 and I10 for the verify-only gateway."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tenuo_core")
+
+from tenuo import Exact, Range
+from tenuo.mcp import TENUO_CONSTRAINT_VIOLATION, TENUO_TOOL_NOT_AUTHORIZED
+from tenuo_core import SigningKey, Warrant, verify_receipt
+
+from tenuo_gha.app import Gateway
+from tenuo_gha.check import all_passed, run_containment
+from tenuo_gha.config import ConfigError, GatewayConfig
+
+
+def _config(tmp_path: Path, issuer: SigningKey, environ: dict) -> GatewayConfig:
+    root = issuer.public_key.to_bytes().hex()
+    env = {
+        "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+        "TENUO_ROOT_PUBLIC_KEY": root,
+        **environ,
+    }
+    return GatewayConfig.from_mapping(
+        {
+            "version": 1,
+            "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+            "signing": {"provider": "memory"},
+            "ceiling": {"repositories": ["acme/widgets"]},
+            "tools": {"packs": ["github-triage"]},
+            "receipts": {"path": str(tmp_path / "receipts.jsonl")},
+        },
+        environ=env,
+    )
+
+
+def _triage_warrant(issuer: SigningKey, holder: SigningKey) -> Warrant:
+    return (
+        Warrant.mint_builder()
+        .capability("github.get_issue", repository=Exact("acme/widgets"), issue=Range(4127, 4127))
+        .capability("github.add_comment", repository=Exact("acme/widgets"), issue=Range(4127, 4127))
+        .holder(holder.public_key)
+        .ttl(900)
+        .mint(issuer)
+    )
+
+
+def test_i10_refuses_github_token(tmp_path):
+    issuer = SigningKey.generate()
+    with pytest.raises(ConfigError, match="I10"):
+        _config(tmp_path, issuer, {"GITHUB_TOKEN": "ghs_not_a_real_token"})
+
+
+def test_memory_keys_require_the_escape(tmp_path):
+    issuer = SigningKey.generate()
+    env = {"TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex()}
+    with pytest.raises(ConfigError, match="TENUO_ALLOW_INSECURE_MEMORY_KEYS"):
+        GatewayConfig.from_mapping(
+            {
+                "version": 1,
+                "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+                "signing": {"provider": "memory"},
+                "receipts": {"path": str(tmp_path / "r.jsonl")},
+            },
+            environ=env,
+        )
+
+
+def test_github_credentials_are_a_startup_error(tmp_path):
+    issuer = SigningKey.generate()
+    with pytest.raises(ConfigError, match="credentials.github"):
+        GatewayConfig.from_mapping(
+            {
+                "version": 1,
+                "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+                "signing": {"provider": "memory"},
+                "credentials": {"github": {"provider": "token", "token_env": "GITHUB_TOKEN"}},
+                "receipts": {"path": str(tmp_path / "r.jsonl")},
+            },
+            environ={
+                "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+                "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+            },
+        )
+
+
+def test_i10_refuses_pem_in_env(tmp_path):
+    issuer = SigningKey.generate()
+    with pytest.raises(ConfigError, match="PEM"):
+        _config(
+            tmp_path,
+            issuer,
+            {"SIGNING_KEY": "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----"},
+        )
+
+
+def test_i10_refuses_embedded_token_in_yaml(tmp_path):
+    issuer = SigningKey.generate()
+    with pytest.raises(ConfigError, match="I10"):
+        GatewayConfig.from_mapping(
+            {
+                "version": 1,
+                "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+                "signing": {"provider": "memory"},
+                "notes": "ghs_not_a_real_token",
+                "receipts": {"path": str(tmp_path / "r.jsonl")},
+            },
+            environ={
+                "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+                "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+            },
+        )
+
+
+def test_containment_fixtures_deny_and_allowed_read_passes(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    os.environ["TENUO_ALLOW_INSECURE_MEMORY_KEYS"] = "1"
+    gateway = Gateway(_config(tmp_path, issuer, {}))
+    warrant = _triage_warrant(issuer, holder)
+    rows = run_containment(
+        gateway,
+        warrant,
+        holder,
+        bound_repository="acme/widgets",
+        bound_issue=4127,
+        foreign_repository="acme/payments-internal",
+    )
+    assert all_passed(rows), "\n".join(f"{r.name}: expected {r.expected} got {r.actual}" for r in rows)
+    text = Path(tmp_path / "receipts.jsonl").read_text(encoding="utf-8")
+    assert text.strip(), "I6: denials and the allow must produce receipts"
+
+
+def test_cross_repo_receipt_is_a_constraint_denial(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    gateway = Gateway(_config(tmp_path, issuer, {}))
+    warrant = _triage_warrant(issuer, holder)
+    rows = run_containment(
+        gateway,
+        warrant,
+        holder,
+        bound_repository="acme/widgets",
+        bound_issue=4127,
+        foreign_repository="acme/payments-internal",
+    )
+    lost = next(r for r in rows if r.name.startswith("GitLost"))
+    assert lost.actual == TENUO_CONSTRAINT_VIOLATION
+    dispatch = next(r for r in rows if "workflow_dispatch" in r.name)
+    assert dispatch.actual == TENUO_TOOL_NOT_AUTHORIZED
+    gateway.flush_receipts()
+    lines = Path(tmp_path / "receipts.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) >= 2
+    # File sink stores JSON {"receipt": "hex"}; verify the first hex we find.
+    import json
+
+    payload = verify_receipt(json.loads(lines[0])["receipt"])
+    assert payload.outcome in {"allow", "deny"}
+
+
+def test_tripwire_denies_even_when_the_warrant_names_it(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    os.environ["TENUO_ALLOW_INSECURE_MEMORY_KEYS"] = "1"
+    gateway = Gateway(_config(tmp_path, issuer, {}))
+    warrant = (
+        Warrant.mint_builder()
+        .capability("github.workflow_dispatch", repository=Exact("acme/widgets"))
+        .holder(holder.public_key)
+        .ttl(900)
+        .mint(issuer)
+    )
+    import base64
+    import time
+
+    args = {"repository": "acme/widgets", "workflow": "release.yml"}
+    sig = warrant.sign(holder, "github.workflow_dispatch", args, int(time.time()))
+    result = gateway.verify(
+        "github.workflow_dispatch",
+        args,
+        meta={
+            "tenuo": {
+                "warrant": warrant.to_base64(),
+                "signature": base64.b64encode(bytes(sig)).decode(),
+            }
+        },
+    )
+    assert not result.allowed
+    assert result.error_code == TENUO_TOOL_NOT_AUTHORIZED
+    assert result.presented_chain
+    assert gateway.flush_receipts()
+    import json
+
+    lines = Path(tmp_path / "receipts.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    payload = verify_receipt(json.loads(lines[0])["receipt"])
+    assert payload.outcome == "deny"

--- a/github-actions/tests/test_verify_only.py
+++ b/github-actions/tests/test_verify_only.py
@@ -1,4 +1,4 @@
-"""I3 / I6 and I10 for the verify-only gateway."""
+"""Gateway config refuse-to-start, fixture table, and signed receipts."""
 
 from __future__ import annotations
 
@@ -49,9 +49,9 @@ def _triage_warrant(issuer: SigningKey, holder: SigningKey) -> Warrant:
     )
 
 
-def test_i10_refuses_github_token(tmp_path):
+def test_refuses_github_token(tmp_path):
     issuer = SigningKey.generate()
-    with pytest.raises(ConfigError, match="I10"):
+    with pytest.raises(ConfigError, match="GITHUB_TOKEN"):
         _config(tmp_path, issuer, {"GITHUB_TOKEN": "ghs_not_a_real_token"})
 
 
@@ -88,7 +88,7 @@ def test_github_credentials_are_a_startup_error(tmp_path):
         )
 
 
-def test_i10_refuses_pem_in_env(tmp_path):
+def test_refuses_pem_in_env(tmp_path):
     issuer = SigningKey.generate()
     with pytest.raises(ConfigError, match="PEM"):
         _config(
@@ -98,9 +98,9 @@ def test_i10_refuses_pem_in_env(tmp_path):
         )
 
 
-def test_i10_refuses_embedded_token_in_yaml(tmp_path):
+def test_refuses_embedded_token_in_yaml(tmp_path):
     issuer = SigningKey.generate()
-    with pytest.raises(ConfigError, match="I10"):
+    with pytest.raises(ConfigError, match="stored credential"):
         GatewayConfig.from_mapping(
             {
                 "version": 1,
@@ -132,7 +132,7 @@ def test_containment_fixtures_deny_and_allowed_read_passes(tmp_path):
     )
     assert all_passed(rows), "\n".join(f"{r.name}: expected {r.expected} got {r.actual}" for r in rows)
     text = Path(tmp_path / "receipts.jsonl").read_text(encoding="utf-8")
-    assert text.strip(), "I6: denials and the allow must produce receipts"
+    assert text.strip(), "denials and the allow must produce receipts"
 
 
 def test_cross_repo_receipt_is_a_constraint_denial(tmp_path):

--- a/tenuo-core/src/python_control_plane.rs
+++ b/tenuo-core/src/python_control_plane.rs
@@ -327,6 +327,24 @@ impl PyControlPlaneClient {
         .map(Some)
     }
 
+    /// Receipt issuer with no control-plane URL and no heartbeat.
+    ///
+    /// Use this when the enforcement point signs receipts locally (file or
+    /// webhook sink) and must not open a network connection.
+    #[staticmethod]
+    fn local(signing_key: &PySigningKey) -> PyResult<Self> {
+        let (audit_tx, _audit_rx) = create_audit_channel(1);
+        let (shutdown_tx, _shutdown_rx) = tokio::sync::watch::channel(false);
+        Ok(Self {
+            receipt_signer: signing_key.inner.clone(),
+            trust: Arc::new(Mutex::new(None)),
+            last_receipt_hash: Arc::new(Mutex::new(None)),
+            sender: audit_tx,
+            authorizer_id_py: Arc::new(Mutex::new(None)),
+            shutdown_tx,
+        })
+    }
+
     /// Copy the enforcement point's trust context from its authorizer.
     ///
     /// Receipts commit to the trusted root set and the revocation list in force
@@ -702,9 +720,15 @@ impl PyControlPlaneClient {
     /// Flush pending events and stop the background heartbeat task.
     #[pyo3(signature = (timeout_secs = 5.0))]
     fn shutdown(&self, timeout_secs: f64) -> PyResult<()> {
-        let secs = timeout_secs.clamp(0.0, 30.0);
-        runtime().block_on(tokio::time::sleep(std::time::Duration::from_secs_f64(secs)));
         let _ = self.shutdown_tx.send(true);
+        let secs = timeout_secs.clamp(0.0, 30.0);
+        if secs > 0.0 {
+            // sleep() must be constructed inside the runtime, not as a
+            // block_on argument — Tokio 1.x timers require a context.
+            runtime().block_on(async {
+                tokio::time::sleep(std::time::Duration::from_secs_f64(secs)).await
+            });
+        }
         Ok(())
     }
 

--- a/tenuo-python/tenuo/mcp/__init__.py
+++ b/tenuo-python/tenuo/mcp/__init__.py
@@ -33,7 +33,20 @@ Server-side (verifying warrants inside an MCP server):
 """
 
 from ..exceptions import MCPToolCallError
-from .client import MCP_AVAILABLE, SecureMCPClient, discover_and_protect
+from .client import (
+    MCP_AVAILABLE,
+    SecureMCPClient,
+    derive_terminal_leaf,
+    discover_and_protect,
+    exact_argument_constraints,
+)
+from .codes import (
+    TENUO_CONSTRAINT_VIOLATION,
+    TENUO_INVALID_POP,
+    TENUO_REVOKED,
+    TENUO_TOOL_NOT_AUTHORIZED,
+    TENUO_WARRANT_EXPIRED,
+)
 from .server import (
     MCPApprovalRequired,
     MCPAuthorizationError,
@@ -54,6 +67,13 @@ __all__ = [
     "MCPAuthorizationError",
     "MCPApprovalRequired",
     "verify_mcp_call",
+    "derive_terminal_leaf",
+    "exact_argument_constraints",
+    "TENUO_TOOL_NOT_AUTHORIZED",
+    "TENUO_CONSTRAINT_VIOLATION",
+    "TENUO_INVALID_POP",
+    "TENUO_REVOKED",
+    "TENUO_WARRANT_EXPIRED",
 ]
 
 try:

--- a/tenuo-python/tenuo/mcp/client.py
+++ b/tenuo-python/tenuo/mcp/client.py
@@ -104,6 +104,78 @@ def _safe_mcp_tool_error_message(content: Any, tool_name: str) -> str:
     return f"Tool '{tool_name}' returned an error"
 
 
+def exact_argument_constraints(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Map call arguments to exact-match constraints for a terminal leaf.
+
+    Strings and bools become ``Exact``. Integers become ``Range(n, n)``.
+    Lists become ``Subset``. ``None`` is omitted (not part of the PoP view).
+    Values that already look like constraint objects are passed through,
+    including CEL expressions on free text.
+    """
+    from tenuo import Exact, Range, Subset
+
+    constraints: Dict[str, Any] = {}
+    for key, value in args.items():
+        if value is None:
+            continue
+        if hasattr(value, "constraint_type") or type(value).__name__ in {
+            "Exact",
+            "Range",
+            "Subset",
+            "CEL",
+            "Pattern",
+            "OneOf",
+        }:
+            constraints[key] = value
+            continue
+        if isinstance(value, bool):
+            # Exact is string-typed; core compares after str() of the argument.
+            constraints[key] = Exact("true" if value else "false")
+        elif isinstance(value, str):
+            constraints[key] = Exact(value)
+        elif isinstance(value, int):
+            constraints[key] = Range(value, value)
+        elif isinstance(value, float):
+            constraints[key] = Range(value, value)
+        elif isinstance(value, (list, tuple, set)):
+            constraints[key] = Subset(list(value))
+        else:
+            constraints[key] = Exact(value)
+    return constraints
+
+
+def derive_terminal_leaf(
+    warrant: Any,
+    holder_key: Any,
+    tool: str,
+    args: Dict[str, Any],
+    *,
+    ttl: int = 30,
+):
+    """Attenuate ``warrant`` to one tool call with exact-argument constraints.
+
+    Returns ``(leaf_warrant, leaf_key)``. A widening attempt raises
+    ``MonotonicityError`` before anything is signed.
+
+    Shared by the broker and the containment check so the mapping lives in
+    one place.
+    """
+    from tenuo_core import SigningKey
+
+    leaf_key = SigningKey.generate()
+    constraints = exact_argument_constraints(args)
+    parent = getattr(warrant, "warrant", warrant)
+    parent_key = getattr(warrant, "key", None) or holder_key
+    leaf = parent.grant(
+        to=leaf_key.public_key,
+        allow=tool,
+        ttl=ttl,
+        key=parent_key,
+        **constraints,
+    )
+    return leaf, leaf_key
+
+
 class SecureMCPClient:
     """
     MCP client with Tenuo authorization.
@@ -565,6 +637,28 @@ class SecureMCPClient:
                 reason=enforcement.denial_reason or "Authorization denied",
                 suggestions=[],
             )
+
+    def derive_terminal_leaf(
+        self,
+        tool: str,
+        args: Dict[str, Any],
+        *,
+        warrant: Any = None,
+        holder_key: Any = None,
+        ttl: int = 30,
+    ):
+        """Attenuate the current (or given) warrant to this call's arguments.
+
+        See :func:`derive_terminal_leaf`.
+        """
+        parent = warrant if warrant is not None else warrant_scope()
+        key = holder_key if holder_key is not None else key_scope()
+        if parent is None or key is None:
+            raise ConfigurationError(
+                "derive_terminal_leaf requires a warrant and holder key "
+                "(pass them, or call inside warrant_scope / key_scope)"
+            )
+        return derive_terminal_leaf(parent, key, tool, args, ttl=ttl)
 
     async def call_tool(
         self,

--- a/tenuo-python/tenuo/mcp/codes.py
+++ b/tenuo-python/tenuo/mcp/codes.py
@@ -1,0 +1,81 @@
+"""Stable denial codes for MCP brokers and job summaries.
+
+JSON-RPC still uses ``-32001`` / ``-32002``. These codes travel beside it
+(``MCPVerificationResult.error_code`` and ``error.data.code``) so a broker
+can map a refusal without parsing prose.
+
+Receipt payload key 10 stays kebab-case (``constraint-violation``). These
+``TENUO_*`` codes are the wire-facing names for the same categories.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+TENUO_TOOL_NOT_AUTHORIZED = "TENUO_TOOL_NOT_AUTHORIZED"
+TENUO_CONSTRAINT_VIOLATION = "TENUO_CONSTRAINT_VIOLATION"
+TENUO_INVALID_POP = "TENUO_INVALID_POP"
+TENUO_REVOKED = "TENUO_REVOKED"
+TENUO_WARRANT_EXPIRED = "TENUO_WARRANT_EXPIRED"
+TENUO_UNTRUSTED_ROOT = "TENUO_UNTRUSTED_ROOT"
+TENUO_APPROVAL_REQUIRED = "TENUO_APPROVAL_REQUIRED"
+
+# error_type (EnforcementResult / receipts) → TENUO_*
+_CODE_BY_ERROR_TYPE = {
+    "tool_not_allowed": TENUO_TOOL_NOT_AUTHORIZED,
+    "constraint_violation": TENUO_CONSTRAINT_VIOLATION,
+    "policy_violation": TENUO_CONSTRAINT_VIOLATION,
+    "invalid_pop": TENUO_INVALID_POP,
+    "revoked": TENUO_REVOKED,
+    "expired": TENUO_WARRANT_EXPIRED,
+    "untrusted_issuer": TENUO_UNTRUSTED_ROOT,
+    "insufficient_approvals": TENUO_APPROVAL_REQUIRED,
+    "approval_required": TENUO_APPROVAL_REQUIRED,
+    "approval_gate_misconfigured": TENUO_APPROVAL_REQUIRED,
+}
+
+
+def code_for_error_type(error_type: Optional[str]) -> Optional[str]:
+    """Map an ``EnforcementResult.error_type`` to a ``TENUO_*`` code."""
+    if not error_type:
+        return None
+    return _CODE_BY_ERROR_TYPE.get(error_type)
+
+
+def error_type_and_code(exc: BaseException) -> Tuple[str, str]:
+    """Classify a verification exception for receipts and the broker."""
+    from ..exceptions import (
+        ApprovalExpired,
+        ApprovalGateTriggered,
+        ConstraintViolation,
+        ExpiredError,
+        InsufficientApprovals,
+        InvalidApproval,
+        MissingSignature,
+        RevokedError,
+        SignatureInvalid,
+        SignatureMismatch,
+        ToolMismatch,
+        ToolNotAuthorized,
+        UntrustedRoot,
+    )
+
+    if isinstance(exc, (ToolNotAuthorized, ToolMismatch)):
+        return "tool_not_allowed", TENUO_TOOL_NOT_AUTHORIZED
+    if isinstance(exc, ConstraintViolation):
+        return "constraint_violation", TENUO_CONSTRAINT_VIOLATION
+    if isinstance(exc, (MissingSignature, SignatureInvalid, SignatureMismatch)):
+        return "invalid_pop", TENUO_INVALID_POP
+    if isinstance(exc, RevokedError):
+        return "revoked", TENUO_REVOKED
+    if isinstance(exc, ExpiredError):
+        return "expired", TENUO_WARRANT_EXPIRED
+    if isinstance(exc, UntrustedRoot):
+        return "untrusted_issuer", TENUO_UNTRUSTED_ROOT
+    if isinstance(exc, InsufficientApprovals):
+        return "insufficient_approvals", TENUO_APPROVAL_REQUIRED
+    if isinstance(exc, ApprovalGateTriggered):
+        return "approval_required", TENUO_APPROVAL_REQUIRED
+    if isinstance(exc, (InvalidApproval, ApprovalExpired)):
+        return "invalid_pop", TENUO_INVALID_POP
+    return "authorization_failed", TENUO_TOOL_NOT_AUTHORIZED

--- a/tenuo-python/tenuo/mcp/fastmcp_middleware.py
+++ b/tenuo-python/tenuo/mcp/fastmcp_middleware.py
@@ -135,6 +135,8 @@ def _denial_tool_return(verification: MCPVerificationResult) -> _VerifierDenialT
         "code": code,
         "message": message,
     }
+    if verification.error_code:
+        tenuo_block["error_code"] = verification.error_code
     if verification.request_hash:
         tenuo_block["request_hash"] = verification.request_hash
     if verification.approval_metadata:

--- a/tenuo-python/tenuo/mcp/server.py
+++ b/tenuo-python/tenuo/mcp/server.py
@@ -113,6 +113,15 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from .._pop_canonicalize import strip_none_values
+from ..control_plane import _POP_ESTABLISHED_ERROR_TYPES
+from .codes import (
+    TENUO_CONSTRAINT_VIOLATION,
+    TENUO_INVALID_POP,
+    TENUO_REVOKED,
+    TENUO_TOOL_NOT_AUTHORIZED,
+    TENUO_WARRANT_EXPIRED,
+    error_type_and_code,
+)
 from ..exceptions import (
     ApprovalExpired,
     ApprovalGateTriggered,
@@ -234,6 +243,24 @@ class MCPVerificationResult:
     approval_metadata: Optional[Dict[str, Any]] = field(default=None)
     """Structured approval counts for ``-32002`` responses (``got`` / ``need``)."""
 
+    error_type: Optional[str] = field(default=None)
+    """Coarse category for receipts (``constraint_violation``, ``expired``, …)."""
+
+    error_code: Optional[str] = field(default=None)
+    """Stable ``TENUO_*`` code for brokers and job summaries."""
+
+    presented_chain: Optional[Any] = field(default=None)
+    """Warrants presented with the call. Set on denials after a successful decode."""
+
+    verified_pop: Optional[Any] = field(default=None)
+    """Holder PoP, only when possession was established before the failure."""
+
+    pop_auth_args: Optional[Dict[str, Any]] = field(default=None)
+    """PoP-view arguments the holder signed over. Key 7 on a denial receipt."""
+
+    authorizer: Optional[Any] = field(default=None)
+    """Authorizer that decided. Required for local receipt trust binding."""
+
     @property
     def is_approval_required(self) -> bool:
         """``True`` when an approval gate fired and approvals must be supplied."""
@@ -272,6 +299,8 @@ class MCPVerificationResult:
                 data["got"] = self.approval_metadata["got"]
             if "need" in self.approval_metadata:
                 data["need"] = self.approval_metadata["need"]
+        if self.error_code:
+            data["code"] = self.error_code
         if data:
             error["data"] = data
         return error
@@ -352,6 +381,42 @@ class MCPApprovalRequired(MCPAuthorizationError):
                 request_hash=request_hash,
             )
             super().__init__(_result)
+
+
+def _denial_from_exc(
+    exc: BaseException,
+    *,
+    tool_name: str,
+    clean_arguments: Dict[str, Any],
+    constraints: Dict[str, Any],
+    warrant_id: Optional[str],
+    presented_chain: Any,
+    pop_args: Dict[str, Any],
+    authorizer: Any,
+    pop_sig: Optional[bytes],
+    jsonrpc_error_code: int = -32001,
+    denial_reason: Optional[str] = None,
+    request_hash: Optional[str] = None,
+    approval_metadata: Optional[Dict[str, Any]] = None,
+) -> MCPVerificationResult:
+    error_type, error_code = error_type_and_code(exc)
+    return MCPVerificationResult(
+        allowed=False,
+        tool=tool_name,
+        clean_arguments=clean_arguments,
+        constraints=constraints,
+        warrant_id=warrant_id,
+        denial_reason=denial_reason or _access_denial_reason(exc),
+        jsonrpc_error_code=jsonrpc_error_code,
+        request_hash=request_hash,
+        approval_metadata=approval_metadata,
+        error_type=error_type,
+        error_code=error_code,
+        presented_chain=presented_chain,
+        verified_pop=pop_sig if error_type in _POP_ESTABLISHED_ERROR_TYPES else None,
+        pop_auth_args=pop_args,
+        authorizer=authorizer,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -668,6 +733,7 @@ class MCPVerifier:
             ))
 
         warrant_id: Optional[str] = getattr(warrant, "id", None)
+        presented_chain = list(_chain_parents or []) + [warrant]
 
         # ------------------------------------------------------------------
         # Step 4: decode PoP signature
@@ -763,6 +829,11 @@ class MCPVerifier:
                             "timestamp for each tool call."
                         ),
                         jsonrpc_error_code=-32001,
+                        error_type="invalid_pop",
+                        error_code=TENUO_INVALID_POP,
+                        presented_chain=presented_chain,
+                        pop_auth_args=pop_args,
+                        authorizer=self._authorizer,
                     ),
                     latency_us=(time.perf_counter_ns() - start_ns) // 1000,
                 )
@@ -774,6 +845,10 @@ class MCPVerifier:
                 clean_arguments=clean_arguments,
                 constraints=constraints,
                 warrant_id=warrant_id,
+                presented_chain=presented_chain,
+                verified_pop=pop_sig,
+                pop_auth_args=pop_args,
+                authorizer=self._authorizer,
             )
         except ApprovalGateTriggered as gate_exc:
             logger.info(
@@ -781,15 +856,19 @@ class MCPVerifier:
                 tool_name,
                 warrant_id,
             )
-            result = MCPVerificationResult(
-                allowed=False,
-                tool=tool_name,
+            result = _denial_from_exc(
+                gate_exc,
+                tool_name=tool_name,
                 clean_arguments=clean_arguments,
                 constraints=constraints,
                 warrant_id=warrant_id,
-                request_hash=gate_exc.request_hash or None,
-                denial_reason=gate_exc.message,
+                presented_chain=presented_chain,
+                pop_args=pop_args,
+                authorizer=self._authorizer,
+                pop_sig=pop_sig,
                 jsonrpc_error_code=-32002,
+                denial_reason=gate_exc.message,
+                request_hash=gate_exc.request_hash or None,
             )
         except InsufficientApprovals as insuf_exc:
             # Multi-sig threshold not met — the warrant does authorise this tool
@@ -806,18 +885,22 @@ class MCPVerifier:
                 _got,
                 _need,
             )
-            result = MCPVerificationResult(
-                allowed=False,
-                tool=tool_name,
+            result = _denial_from_exc(
+                insuf_exc,
+                tool_name=tool_name,
                 clean_arguments=clean_arguments,
                 constraints=constraints,
                 warrant_id=warrant_id,
+                presented_chain=presented_chain,
+                pop_args=pop_args,
+                authorizer=self._authorizer,
+                pop_sig=pop_sig,
+                jsonrpc_error_code=-32002,
                 denial_reason=(
                     f"Insufficient approvals for '{tool_name}': "
                     f"got {_got}, need {_need}. "
                     "Re-submit with additional approvals in _meta.tenuo.approvals."
                 ),
-                jsonrpc_error_code=-32002,
                 approval_metadata={"got": _got, "need": _need},
             )
         except (InvalidApproval, ApprovalExpired) as approval_exc:
@@ -827,14 +910,16 @@ class MCPVerifier:
                 warrant_id,
                 approval_exc,
             )
-            result = MCPVerificationResult(
-                allowed=False,
-                tool=tool_name,
+            result = _denial_from_exc(
+                approval_exc,
+                tool_name=tool_name,
                 clean_arguments=clean_arguments,
                 constraints=constraints,
                 warrant_id=warrant_id,
-                denial_reason=_access_denial_reason(approval_exc),
-                jsonrpc_error_code=-32001,
+                presented_chain=presented_chain,
+                pop_args=pop_args,
+                authorizer=self._authorizer,
+                pop_sig=pop_sig,
             )
         except (
             ConstraintViolation,
@@ -850,14 +935,16 @@ class MCPVerifier:
                 warrant_id,
                 exc,
             )
-            result = MCPVerificationResult(
-                allowed=False,
-                tool=tool_name,
+            result = _denial_from_exc(
+                exc,
+                tool_name=tool_name,
                 clean_arguments=clean_arguments,
                 constraints=constraints,
                 warrant_id=warrant_id,
-                denial_reason=_access_denial_reason(exc),
-                jsonrpc_error_code=-32001,
+                presented_chain=presented_chain,
+                pop_args=pop_args,
+                authorizer=self._authorizer,
+                pop_sig=pop_sig,
             )
         except TenuoError as exc:
             logger.info(
@@ -866,14 +953,16 @@ class MCPVerifier:
                 warrant_id,
                 exc,
             )
-            result = MCPVerificationResult(
-                allowed=False,
-                tool=tool_name,
+            result = _denial_from_exc(
+                exc,
+                tool_name=tool_name,
                 clean_arguments=clean_arguments,
                 constraints=constraints,
                 warrant_id=warrant_id,
-                denial_reason=_access_denial_reason(exc),
-                jsonrpc_error_code=-32001,
+                presented_chain=presented_chain,
+                pop_args=pop_args,
+                authorizer=self._authorizer,
+                pop_sig=pop_sig,
             )
         except Exception as exc:
             logger.error(
@@ -890,6 +979,10 @@ class MCPVerifier:
                 warrant_id=warrant_id,
                 denial_reason=f"Internal verification error: {exc}",
                 jsonrpc_error_code=-32001,
+                error_type="internal_error",
+                presented_chain=presented_chain,
+                pop_auth_args=pop_args,
+                authorizer=self._authorizer,
             )
 
         latency_us = (time.perf_counter_ns() - start_ns) // 1000
@@ -983,6 +1076,11 @@ def verify_mcp_call(
 
 __all__ = [
     "MCPVerificationResult",
+    "TENUO_TOOL_NOT_AUTHORIZED",
+    "TENUO_CONSTRAINT_VIOLATION",
+    "TENUO_INVALID_POP",
+    "TENUO_REVOKED",
+    "TENUO_WARRANT_EXPIRED",
     "MCPAuthorizationError",
     "MCPVerifier",
     "verify_mcp_call",

--- a/tenuo-python/tenuo/receipts.py
+++ b/tenuo-python/tenuo/receipts.py
@@ -56,6 +56,7 @@ __all__ = [
     "FileReceiptSink",
     "DeferredEmitter",
     "JournalEmitter",
+    "ReceiptSigner",
     "deliver",
 ]
 
@@ -147,6 +148,82 @@ class FileReceiptSink:
     @property
     def path(self) -> Path:
         return self._path
+
+
+class ReceiptSigner:
+    """Sign receipts locally. No control-plane URL, no heartbeat.
+
+    The enforcement point still has to ``bind_authorizer`` before anything
+    is signed — a receipt that cannot name its trust context is not worth
+    emitting. After that, ``emit_for_enforcement`` is the same path
+    ``ControlPlaneClient`` uses.
+
+    KMS ``Sign`` callbacks (AWS / GCP / Azure / Vault) land with the
+    gateway custody work. Until then pass an in-process ``SigningKey``.
+
+        from tenuo.receipts import FileReceiptSink, ReceiptSigner
+
+        signer = ReceiptSigner(signing_key, FileReceiptSink(path))
+        signer.bind_authorizer(authorizer)
+        signer.emit_for_enforcement(result, chain_result=chain_result)
+    """
+
+    def __init__(
+        self,
+        signing_key: object,
+        sink: "ReceiptSink",
+        *,
+        authorizer: object = None,
+        emitter: object = None,
+        sign: object = None,
+    ) -> None:
+        if sign is not None:
+            raise NotImplementedError(
+                "custom Sign callbacks ship with the KMS signer. "
+                "Use ReceiptSigner(signing_key, sink) for an in-process key."
+            )
+        if signing_key is None:
+            raise ValueError("ReceiptSigner requires a signing_key")
+        if sink is None:
+            raise ValueError("ReceiptSigner requires a sink")
+
+        from tenuo_core import ControlPlaneClient as _Rust
+
+        from .control_plane import ControlPlaneClient
+
+        self._inner = _Rust.local(signing_key)
+        if emitter is None:
+            emitter = DeferredEmitter(sink)
+        self._emitter = emitter
+        self._emitter._attach(self._inner, None)
+        self._client = ControlPlaneClient.__new__(ControlPlaneClient)
+        self._client._inner = self._inner
+        self._client._receipt_emitter = self._emitter
+        self._client._receipt_sink = sink
+        self._client._on_receipt_error = None
+        self._client._receipt_unbound_warned = False
+        if authorizer is not None:
+            self.bind_authorizer(authorizer)
+
+    def bind_authorizer(self, authorizer: object) -> None:
+        self._client.bind_authorizer(authorizer)
+
+    @property
+    def receipt_signer_key(self) -> str:
+        return self._inner.receipt_signer_key
+
+    def emit_for_enforcement(self, result: object, chain_result: object = None, **kwargs: object) -> None:
+        self._client.emit_for_enforcement(result, chain_result=chain_result, **kwargs)
+
+    def flush(self, timeout: float = 10.0) -> bool:
+        return self._emitter.flush(timeout)
+
+    def close(self, timeout: float = 10.0) -> None:
+        self._emitter.close(timeout)
+        try:
+            self._inner.shutdown(0.0)
+        except Exception:  # noqa: BLE001
+            logger.warning("local receipt issuer did not shut down cleanly")
 
 
 def deliver(

--- a/tenuo-python/tests/unit/test_derive_terminal_leaf.py
+++ b/tenuo-python/tests/unit/test_derive_terminal_leaf.py
@@ -1,0 +1,78 @@
+"""Exact-argument terminal leaves for the broker and containment check."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("tenuo_core")
+
+from tenuo import Pattern
+from tenuo.exceptions import MonotonicityError
+from tenuo.mcp import derive_terminal_leaf, exact_argument_constraints
+from tenuo_core import SigningKey, Warrant
+
+
+def test_exact_argument_constraints_mapping():
+    mapped = exact_argument_constraints(
+        {
+            "repository": "acme/widgets",
+            "issue": 4127,
+            "draft": True,
+            "labels": ["bug"],
+            "note": None,
+        }
+    )
+    assert type(mapped["repository"]).__name__ == "Exact"
+    assert type(mapped["issue"]).__name__ == "Range"
+    assert type(mapped["draft"]).__name__ == "Exact"
+    assert type(mapped["labels"]).__name__ == "Subset"
+    assert "note" not in mapped
+
+
+def test_terminal_leaf_binds_exact_args():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    parent = (
+        Warrant.mint_builder()
+        .capability("read_file", path=Pattern("/data/*"))
+        .holder(holder.public_key)
+        .ttl(3600)
+        .mint(issuer)
+    )
+    leaf, leaf_key = derive_terminal_leaf(
+        parent, holder, "read_file", {"path": "/data/report.txt"}, ttl=30
+    )
+    assert leaf_key is not None
+    holder_pk = leaf.authorized_holder
+    holder_pk = holder_pk() if callable(holder_pk) else holder_pk
+    assert holder_pk.to_bytes() == leaf_key.public_key.to_bytes()
+
+
+def test_widening_the_path_fails_before_sign():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    parent = (
+        Warrant.mint_builder()
+        .capability("read_file", path=Pattern("/data/*"))
+        .holder(holder.public_key)
+        .ttl(3600)
+        .mint(issuer)
+    )
+    with pytest.raises(MonotonicityError):
+        derive_terminal_leaf(
+            parent, holder, "read_file", {"path": "/etc/passwd"}, ttl=30
+        )
+
+
+def test_unknown_tool_fails():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    parent = (
+        Warrant.mint_builder()
+        .capability("read_file", path=Pattern("/data/*"))
+        .holder(holder.public_key)
+        .ttl(3600)
+        .mint(issuer)
+    )
+    with pytest.raises(Exception):
+        derive_terminal_leaf(parent, holder, "delete_file", {"path": "/data/x"})

--- a/tenuo-python/tests/unit/test_mcp_denial_receipts.py
+++ b/tenuo-python/tests/unit/test_mcp_denial_receipts.py
@@ -1,0 +1,105 @@
+"""MCPVerifier denials carry a presented chain and emit a signed receipt."""
+
+from __future__ import annotations
+
+import pytest
+
+tenuo_core = pytest.importorskip("tenuo_core")
+
+from tenuo import Pattern
+from tenuo.mcp import (
+    MCPVerifier,
+    TENUO_CONSTRAINT_VIOLATION,
+    TENUO_TOOL_NOT_AUTHORIZED,
+)
+from tenuo.receipts import InMemoryReceiptSink, ReceiptSigner
+from tenuo_core import Authorizer, SigningKey, Warrant
+
+
+@pytest.fixture
+def issuer_key():
+    return SigningKey.generate()
+
+
+@pytest.fixture
+def agent_key():
+    return SigningKey.generate()
+
+
+@pytest.fixture
+def authorizer(issuer_key):
+    return Authorizer(trusted_roots=[issuer_key.public_key])
+
+
+@pytest.fixture
+def warrant(issuer_key, agent_key):
+    return Warrant.issue(
+        issuer_key,
+        capabilities={"read_file": {"path": Pattern("/data/*")}},
+        holder=agent_key.public_key,
+    )
+
+
+def _meta(warrant, key, tool, args):
+    import base64
+    import time
+
+    sig = warrant.sign(key, tool, args, int(time.time()))
+    return {
+        "tenuo": {
+            "warrant": warrant.to_base64(),
+            "signature": base64.b64encode(bytes(sig)).decode(),
+        }
+    }
+
+
+def test_constraint_denial_carries_chain_and_tenuo_code(authorizer, warrant, agent_key):
+    verifier = MCPVerifier(authorizer=authorizer, control_plane=False)
+    args = {"path": "/etc/passwd"}
+    result = verifier.verify("read_file", args, meta=_meta(warrant, agent_key, "read_file", args))
+
+    assert not result.allowed
+    assert result.error_type == "constraint_violation"
+    assert result.error_code == TENUO_CONSTRAINT_VIOLATION
+    assert result.presented_chain
+    assert result.authorizer is not None
+    assert result.verified_pop is not None
+    assert result.to_jsonrpc_error()["data"]["code"] == TENUO_CONSTRAINT_VIOLATION
+
+
+def test_wrong_tool_denial_carries_chain(authorizer, warrant, agent_key):
+    verifier = MCPVerifier(authorizer=authorizer, control_plane=False)
+    args = {"path": "/data/x"}
+    result = verifier.verify("delete_file", args, meta=_meta(warrant, agent_key, "delete_file", args))
+
+    assert not result.allowed
+    assert result.error_code == TENUO_TOOL_NOT_AUTHORIZED
+    assert result.presented_chain
+
+
+def test_no_warrant_is_not_receipted(authorizer, issuer_key):
+    sink = InMemoryReceiptSink()
+    signer = ReceiptSigner(issuer_key, sink, authorizer=authorizer)
+    verifier = MCPVerifier(authorizer=authorizer, control_plane=signer)
+    result = verifier.verify("read_file", {"path": "/data/x"}, meta={})
+
+    assert not result.allowed
+    assert result.presented_chain is None
+    signer.flush()
+    assert len(sink.receipts) == 0
+
+
+def test_constraint_denial_emits_a_signed_receipt(authorizer, warrant, agent_key, issuer_key):
+    sink = InMemoryReceiptSink()
+    signer = ReceiptSigner(issuer_key, sink, authorizer=authorizer)
+    verifier = MCPVerifier(authorizer=authorizer, control_plane=signer)
+    args = {"path": "/etc/passwd"}
+    result = verifier.verify("read_file", args, meta=_meta(warrant, agent_key, "read_file", args))
+
+    assert not result.allowed
+    assert signer.flush()
+    assert len(sink.receipts) == 1
+    payload = tenuo_core.verify_receipt(sink.receipts[0])
+    assert payload.outcome == "deny"
+    assert payload.decision_code == "constraint-violation"
+    assert payload.pop_signature is not None

--- a/tenuo-python/tests/unit/test_receipt_signer.py
+++ b/tenuo-python/tests/unit/test_receipt_signer.py
@@ -1,0 +1,55 @@
+"""Local ReceiptSigner: no control-plane URL, file/memory sink."""
+
+from __future__ import annotations
+
+import pytest
+
+tenuo_core = pytest.importorskip("tenuo_core")
+
+from tenuo import Pattern
+from tenuo._enforcement import enforce_tool_call
+from tenuo.receipts import InMemoryReceiptSink, ReceiptSigner
+from tenuo_core import SigningKey, Warrant
+
+
+def test_receipt_signer_rejects_a_sign_callback():
+    key = SigningKey.generate()
+    with pytest.raises(NotImplementedError, match="KMS"):
+        ReceiptSigner(key, InMemoryReceiptSink(), sign=lambda m: m)
+
+
+def test_local_client_has_no_url_requirement():
+    key = SigningKey.generate()
+    inner = tenuo_core.ControlPlaneClient.local(key)
+    assert isinstance(inner.receipt_signer_key, str)
+    assert len(inner.receipt_signer_key) == 64
+    inner.shutdown(0.0)
+
+
+def test_receipt_signer_signs_a_denial_without_a_control_plane():
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    warrant = (
+        Warrant.mint_builder()
+        .capability("read_file", path=Pattern("/data/*"))
+        .holder(holder.public_key)
+        .ttl(3600)
+        .mint(issuer)
+    )
+    bound = warrant.bind(holder)
+    result = enforce_tool_call(
+        "read_file",
+        {"path": "/etc/passwd"},
+        bound,
+        trusted_roots=[issuer.public_key],
+    )
+    assert not result.allowed
+
+    sink = InMemoryReceiptSink()
+    signer = ReceiptSigner(issuer, sink, authorizer=result.authorizer)
+    signer.emit_for_enforcement(result)
+    assert signer.flush()
+    assert len(sink.receipts) == 1
+    payload = tenuo_core.verify_receipt(sink.receipts[0])
+    assert payload.outcome == "deny"
+    assert payload.decision_code == "constraint-violation"


### PR DESCRIPTION
## Summary
- `MCPVerifier` now keeps the presented chain, `TENUO_*` error codes, and PoP on denials so a gateway can emit signed refusal receipts without a shim.
- `ReceiptSigner(signing_key, sink)` signs receipts locally via `ControlPlaneClient.local` — no control-plane URL or heartbeat.
- `derive_terminal_leaf` / `exact_argument_constraints` give the broker and containment check one exact-argument mapping (`Exact`, `Range(n, n)`, `Subset`).

This is M1 of Tenuo for GitHub Actions (`docs/spec/ci-gateway-v1.md` §8 / §10). KMS `Sign` callbacks stay for M3.

## Test plan
- [x] `pytest tests/unit/test_mcp_denial_receipts.py tests/unit/test_receipt_signer.py tests/unit/test_derive_terminal_leaf.py tests/unit/test_denial_receipt_wiring.py tests/adapters/test_mcp_server.py`
- [ ] CI green on this branch