### PR TITLE
Add GitHub Actions OIDC exchange and process roles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
       - name: GitHub Actions gateway tests
         working-directory: github-actions
         run: |
-          uv pip install --system pytest pyyaml
+          uv pip install --system pytest pyyaml PyJWT cryptography starlette httpx
           pytest -v
 
   # ============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `github-triage` catalog, file receipts, refuse-to-start on stored tokens
   or PEMs. Tool handlers do not call GitHub. `python -m tenuo_gha.check`
   replays the fixture table.
+- **`POST /v1/exchange`** (and `/v1/exchange/github`) mints a run warrant
+  from a GitHub Actions OIDC JWT. Capabilities outside the ceiling are
+  refused. A reused JWT id is `403`. `TENUO_ROLE=exchange|gateway`;
+  `role=both` needs `TENUO_ALLOW_COMBINED_ROLES=1`. The exchange role
+  refuses receipt and App key ids; the gateway role refuses an issuer
+  key id.
 
 ### Changed
 

--- a/github-actions/pyproject.toml
+++ b/github-actions/pyproject.toml
@@ -7,6 +7,10 @@ dependencies = [
     "tenuo",
     "pyyaml>=6.0",
     "fastmcp>=3.2.1",
+    "PyJWT>=2.8",
+    "cryptography>=42",
+    "starlette>=0.37",
+    "uvicorn>=0.30",
 ]
 
 [project.scripts]

--- a/github-actions/tenuo_gha/__init__.py
+++ b/github-actions/tenuo_gha/__init__.py
@@ -2,5 +2,6 @@
 
 from .app import Gateway
 from .config import ConfigError, GatewayConfig
+from .exchange import Exchange, ExchangeError
 
-__all__ = ["Gateway", "GatewayConfig", "ConfigError"]
+__all__ = ["Gateway", "GatewayConfig", "ConfigError", "Exchange", "ExchangeError"]

--- a/github-actions/tenuo_gha/app.py
+++ b/github-actions/tenuo_gha/app.py
@@ -12,6 +12,8 @@ from tenuo.receipts import FileReceiptSink, ReceiptSigner
 
 from .catalog import TRIPWIRE_NAMES, ToolSpec, tools_for_packs
 from .config import ConfigError, GatewayConfig
+from .exchange import Exchange
+from .http import build_http
 
 
 def _public_key(value: str) -> PublicKey:
@@ -135,15 +137,23 @@ def build_mcp(gateway: Gateway):
 def main() -> None:
     import argparse
 
+    import uvicorn
+
     parser = argparse.ArgumentParser(description="Tenuo for GitHub Actions")
     parser.add_argument("--config", default=os.environ.get("TENUO_GATEWAY_CONFIG", "/etc/tenuo/gateway.yaml"))
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
     args = parser.parse_args()
     config = GatewayConfig.from_yaml(args.config)
-    gateway = Gateway(config)
-    mcp = build_mcp(gateway)
-    mcp.run(transport="streamable-http", host=args.host, port=args.port)
+
+    exchange = None
+    mcp_app = None
+    if config.role in {"exchange", "both"}:
+        exchange = Exchange(config)
+    if config.role in {"gateway", "both"}:
+        mcp_app = build_mcp(Gateway(config)).http_app()
+
+    uvicorn.run(build_http(config, exchange=exchange, mcp_app=mcp_app), host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/github-actions/tenuo_gha/config.py
+++ b/github-actions/tenuo_gha/config.py
@@ -80,6 +80,30 @@ def _assert_no_embedded_secrets(data: Any, *, path: str = "config") -> None:
             _assert_no_embedded_secrets(item, path=f"{path}.{key}")
 
 
+_ROLES = frozenset({"exchange", "gateway", "both"})
+
+
+def parse_duration(value: Any) -> int:
+    """Parse seconds, or a string like ``15m`` / ``900s`` / ``1h``."""
+    if isinstance(value, bool):
+        raise ConfigError("duration must be an integer or a string")
+    if isinstance(value, int):
+        if value <= 0:
+            raise ConfigError("duration must be positive")
+        return value
+    raw = str(value).strip()
+    if raw.endswith("h"):
+        return int(raw[:-1]) * 3600
+    if raw.endswith("m"):
+        return int(raw[:-1]) * 60
+    if raw.endswith("s"):
+        return int(raw[:-1])
+    parsed = int(raw)
+    if parsed <= 0:
+        raise ConfigError("duration must be positive")
+    return parsed
+
+
 @dataclass
 class GatewayConfig:
     version: int
@@ -88,8 +112,22 @@ class GatewayConfig:
     repositories: List[str]
     receipt_path: Path
     signing_provider: str
+    role: str = "gateway"
     receipt_signing_key: Optional[str] = None
+    exchange_signing_key: Optional[str] = None
     require_pop: bool = True
+    audience: str = ""
+    ttl_max: int = 900
+    oidc_issuer: str = "https://token.actions.githubusercontent.com"
+    jwks_url: Optional[str] = None
+    clock_tolerance_seconds: int = 30
+    repository_owner_id: Optional[str] = None
+    repository_ids: List[str] = field(default_factory=list)
+    job_workflow_ref: Optional[str] = None
+    event_names: List[str] = field(default_factory=list)
+    issuer_key_id: Optional[str] = None
+    receipt_key_id: Optional[str] = None
+    github_app_key_id: Optional[str] = None
     extras: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -114,6 +152,23 @@ class GatewayConfig:
             raise ConfigError("credentials.github is not supported")
         _assert_no_embedded_secrets(data)
 
+        role = (environ.get("TENUO_ROLE") or data.get("role") or "gateway").strip()
+        if role not in _ROLES:
+            raise ConfigError(f"unsupported role {role!r}")
+        if role == "both" and environ.get("TENUO_ALLOW_COMBINED_ROLES") != "1":
+            raise ConfigError("role=both requires TENUO_ALLOW_COMBINED_ROLES=1")
+
+        kms = signing.get("kms") or {}
+        issuer_key_id = kms.get("issuer_key_id") or None
+        receipt_key_id = kms.get("receipt_key_id") or None
+        github_app_key_id = kms.get("github_app_key_id") or None
+        if role == "exchange":
+            if receipt_key_id or github_app_key_id:
+                raise ConfigError("exchange role cannot be configured with receipt or App key ids")
+        if role == "gateway":
+            if issuer_key_id:
+                raise ConfigError("gateway role cannot be configured with an issuer key id")
+
         trust = data.get("trust") or {}
         keys = trust.get("root_public_keys") or []
         if not keys:
@@ -126,6 +181,15 @@ class GatewayConfig:
         ceiling = data.get("ceiling") or {}
         repositories = ceiling.get("repositories") or []
 
+        exchange = data.get("exchange") or {}
+        conditions = exchange.get("conditions") or trust.get("conditions") or {}
+        repo_ids = conditions.get("repository_id") or []
+        if isinstance(repo_ids, (str, int)):
+            repo_ids = [repo_ids]
+        events = conditions.get("event_name") or []
+        if isinstance(events, str):
+            events = [events]
+
         return cls(
             version=1,
             root_public_keys=list(keys),
@@ -133,8 +197,26 @@ class GatewayConfig:
             repositories=[str(item) for item in repositories],
             receipt_path=Path(path),
             signing_provider=provider,
+            role=role,
             receipt_signing_key=environ.get("TENUO_RECEIPT_SIGNING_KEY"),
+            exchange_signing_key=environ.get("TENUO_EXCHANGE_SIGNING_KEY"),
             require_pop=bool(trust.get("require_pop", True)),
+            audience=str(exchange.get("audience") or ""),
+            ttl_max=parse_duration(exchange.get("ttl_max") or 900),
+            oidc_issuer=str(
+                exchange.get("issuer") or trust.get("issuer") or "https://token.actions.githubusercontent.com"
+            ),
+            jwks_url=exchange.get("jwks_url") or None,
+            clock_tolerance_seconds=int(trust.get("clock_tolerance_seconds") or 30),
+            repository_owner_id=(
+                str(conditions["repository_owner_id"]) if conditions.get("repository_owner_id") is not None else None
+            ),
+            repository_ids=[str(item) for item in repo_ids],
+            job_workflow_ref=conditions.get("job_workflow_ref") or None,
+            event_names=[str(item) for item in events],
+            issuer_key_id=str(issuer_key_id) if issuer_key_id else None,
+            receipt_key_id=str(receipt_key_id) if receipt_key_id else None,
+            github_app_key_id=str(github_app_key_id) if github_app_key_id else None,
             extras=data,
         )
 

--- a/github-actions/tenuo_gha/exchange.py
+++ b/github-actions/tenuo_gha/exchange.py
@@ -1,0 +1,207 @@
+"""OIDC bearer in, run warrant out. Refuse rather than trim."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping, Optional
+
+from tenuo import PublicKey, SigningKey, Warrant
+from tenuo.mcp import exact_argument_constraints
+
+from .catalog import PACKS, TRIPWIRE_NAMES
+from .config import ConfigError, GatewayConfig
+from .oidc import OidcError, assert_conditions, load_jwks, verify_oidc
+
+
+class ExchangeError(ValueError):
+    """Issuance refused. ``code`` is the wire error name."""
+
+    def __init__(self, code: str, detail: str, status: int = 403) -> None:
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
+        self.status = status
+
+
+@dataclass
+class ExchangeResult:
+    warrant: str
+    warrant_id: str
+    expires_at: str
+    root_public_keys: list[str]
+
+
+class ReplayCache:
+    """Remember JWT ids until they expire."""
+
+    def __init__(self) -> None:
+        self._seen: Dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def check_and_record(self, token_id: str, expires_at: int, *, now: Optional[int] = None) -> bool:
+        """Return True if this id is new and was recorded."""
+        if now is None:
+            now = int(time.time())
+        with self._lock:
+            expired = [key for key, exp in self._seen.items() if exp <= now]
+            for key in expired:
+                del self._seen[key]
+            if token_id in self._seen:
+                return False
+            self._seen[token_id] = expires_at
+            return True
+
+
+def _signing_key(config: GatewayConfig, override: Optional[SigningKey]) -> SigningKey:
+    if override is not None:
+        return override
+    raw = config.exchange_signing_key
+    if not raw:
+        if config.signing_provider == "memory":
+            return SigningKey.generate()
+        raise ConfigError("TENUO_EXCHANGE_SIGNING_KEY is required")
+    try:
+        return SigningKey.from_base64(raw)
+    except AttributeError:
+        return SigningKey.from_bytes(base64.b64decode(raw))
+    except Exception:
+        return SigningKey.from_bytes(bytes.fromhex(raw))
+
+
+def _public_key(value: str) -> PublicKey:
+    raw = value.strip()
+    if raw.startswith("hex:"):
+        raw = raw[4:]
+    try:
+        return PublicKey.from_bytes(bytes.fromhex(raw))
+    except Exception:
+        return PublicKey.from_bytes(base64.b64decode(raw))
+
+
+def _allowed_tools(packs: list[str]) -> set[str]:
+    names: set[str] = set()
+    for pack in packs:
+        for spec in PACKS.get(pack, ()):
+            names.add(spec.name)
+    return names
+
+
+def _token_id(claims: Mapping[str, Any], token: str) -> str:
+    jti = claims.get("jti")
+    if jti:
+        return str(jti)
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class Exchange:
+    """Mint a run warrant from a verified GitHub Actions OIDC token."""
+
+    def __init__(
+        self,
+        config: GatewayConfig,
+        *,
+        issuer_key: Optional[SigningKey] = None,
+        jwks: Optional[Mapping[str, Any]] = None,
+        jwks_fetcher: Optional[Callable[[str], Mapping[str, Any]]] = None,
+        replay: Optional[ReplayCache] = None,
+    ) -> None:
+        if config.signing_provider == "kms":
+            raise ConfigError("signing.provider=kms is not supported")
+        if config.role == "gateway":
+            raise ConfigError("exchange is not served by role=gateway")
+        if not config.audience:
+            raise ConfigError("exchange.audience is required")
+        self.config = config
+        self._issuer = _signing_key(config, issuer_key)
+        self._jwks = load_jwks(jwks=jwks, jwks_url=config.jwks_url, fetcher=jwks_fetcher)
+        self._replay = replay or ReplayCache()
+        self._allowed = _allowed_tools(config.packs)
+
+    def mint(
+        self,
+        token: str,
+        body: Mapping[str, Any],
+        *,
+        now: Optional[int] = None,
+    ) -> ExchangeResult:
+        if now is None:
+            now = int(time.time())
+        try:
+            claims = verify_oidc(
+                token,
+                issuer=self.config.oidc_issuer,
+                audience=self.config.audience,
+                jwks=self._jwks,
+                clock_tolerance_seconds=self.config.clock_tolerance_seconds,
+                now=now,
+            )
+            assert_conditions(
+                claims,
+                repository_owner_id=self.config.repository_owner_id,
+                repository_ids=self.config.repository_ids,
+                job_workflow_ref=self.config.job_workflow_ref,
+                event_names=self.config.event_names,
+                repositories=self.config.repositories,
+            )
+        except OidcError as exc:
+            raise ExchangeError(exc.code, exc.detail) from exc
+
+        token_id = _token_id(claims, token)
+        expires = int(claims.get("exp") or now)
+        if not self._replay.check_and_record(token_id, expires, now=now):
+            raise ExchangeError("token_reused", "OIDC token was already exchanged")
+
+        holder_raw = body.get("holder_public_key")
+        if not holder_raw or not isinstance(holder_raw, str):
+            raise ExchangeError("outside_ceiling", "holder_public_key is required", status=400)
+        try:
+            holder = _public_key(holder_raw)
+        except Exception as exc:
+            raise ExchangeError("outside_ceiling", "holder_public_key is invalid", status=400) from exc
+
+        ttl = body.get("ttl_seconds")
+        if ttl is None:
+            ttl = self.config.ttl_max
+        try:
+            ttl_i = int(ttl)
+        except (TypeError, ValueError) as exc:
+            raise ExchangeError("outside_ceiling", "ttl_seconds is invalid", status=400) from exc
+        if ttl_i <= 0:
+            raise ExchangeError("outside_ceiling", "ttl_seconds must be positive", status=400)
+        if ttl_i > self.config.ttl_max:
+            raise ExchangeError("outside_ceiling", "ttl_seconds exceeds ttl_max")
+
+        capabilities = body.get("capabilities")
+        if not isinstance(capabilities, dict) or not capabilities:
+            raise ExchangeError("outside_ceiling", "capabilities are required", status=400)
+
+        repository = str(claims["repository"])
+        builder = Warrant.mint_builder().holder(holder).ttl(ttl_i)
+        run_id = claims.get("run_id")
+        if run_id is not None:
+            builder = builder.session_id(str(run_id))
+
+        for tool, raw_args in capabilities.items():
+            if tool in TRIPWIRE_NAMES or tool not in self._allowed:
+                raise ExchangeError("outside_ceiling", f"{tool} is not in the configured packs")
+            args = dict(raw_args or {})
+            requested_repo = args.get("repository")
+            if requested_repo is not None and str(requested_repo) != repository:
+                raise ExchangeError("outside_ceiling", "repository does not match the OIDC subject")
+            args["repository"] = repository
+            builder = builder.capability(tool, exact_argument_constraints(args))
+
+        warrant = builder.mint(self._issuer)
+        expires_at = warrant.expires_at()
+        if callable(expires_at):
+            expires_at = expires_at()
+        return ExchangeResult(
+            warrant=warrant.to_base64(),
+            warrant_id=str(warrant.id),
+            expires_at=str(expires_at),
+            root_public_keys=list(self.config.root_public_keys),
+        )

--- a/github-actions/tenuo_gha/http.py
+++ b/github-actions/tenuo_gha/http.py
@@ -1,0 +1,70 @@
+"""ASGI app: exchange routes, health, and optional MCP."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Mount, Route
+
+from .config import GatewayConfig
+from .exchange import Exchange, ExchangeError
+
+
+def _bearer(request: Request) -> str:
+    header = request.headers.get("authorization") or request.headers.get("Authorization") or ""
+    if header.lower().startswith("bearer "):
+        return header[7:].strip()
+    return ""
+
+
+def build_http(
+    config: GatewayConfig,
+    *,
+    exchange: Optional[Exchange] = None,
+    mcp_app: Any = None,
+) -> Starlette:
+    ready = {"exchange": exchange is not None, "gateway": mcp_app is not None}
+
+    async def health(_request: Request) -> Response:
+        return JSONResponse({"status": "ok"})
+
+    async def ready_probe(_request: Request) -> Response:
+        return JSONResponse({"status": "ready", "role": config.role})
+
+    async def exchange_handler(request: Request) -> Response:
+        if exchange is None:
+            return JSONResponse({"error": "not_found", "detail": "exchange is not served"}, status_code=404)
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return JSONResponse({"error": "outside_ceiling", "detail": "body must be JSON"}, status_code=400)
+        if not isinstance(body, dict):
+            return JSONResponse({"error": "outside_ceiling", "detail": "body must be a mapping"}, status_code=400)
+        try:
+            result = exchange.mint(_bearer(request), body)
+        except ExchangeError as exc:
+            return JSONResponse({"error": exc.code, "detail": exc.detail}, status_code=exc.status)
+        return JSONResponse(
+            {
+                "warrant": result.warrant,
+                "warrant_id": result.warrant_id,
+                "expires_at": result.expires_at,
+                "root_public_keys": result.root_public_keys,
+            }
+        )
+
+    routes = [
+        Route("/health", health, methods=["GET"]),
+        Route("/ready", ready_probe, methods=["GET"]),
+        Route("/v1/exchange", exchange_handler, methods=["POST"]),
+        Route("/v1/exchange/github", exchange_handler, methods=["POST"]),
+    ]
+    if mcp_app is not None:
+        routes.append(Mount("/", app=mcp_app))
+    app = Starlette(routes=routes)
+    app.state.ready = ready
+    return app

--- a/github-actions/tenuo_gha/oidc.py
+++ b/github-actions/tenuo_gha/oidc.py
@@ -1,0 +1,130 @@
+"""Verify a GitHub Actions OIDC JWT against a JWKS."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import time
+import urllib.request
+from typing import Any, Callable, Dict, Mapping, Optional
+
+import jwt
+from jwt import PyJWK
+
+from .config import ConfigError
+
+
+class OidcError(ValueError):
+    """JWT failed verification or did not match the configured conditions."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
+
+
+def fetch_jwks(url: str, *, timeout: float = 5.0) -> Dict[str, Any]:
+    with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _audience_values(aud: Any) -> list[str]:
+    if aud is None:
+        return []
+    if isinstance(aud, str):
+        return [aud]
+    return [str(item) for item in aud]
+
+
+def verify_oidc(
+    token: str,
+    *,
+    issuer: str,
+    audience: str,
+    jwks: Mapping[str, Any],
+    clock_tolerance_seconds: int = 30,
+    now: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Verify signature, issuer, audience, and expiry. Returns claims."""
+    if not token:
+        raise OidcError("untrusted_workflow", "missing bearer token")
+    try:
+        header = jwt.get_unverified_header(token)
+    except jwt.InvalidTokenError as exc:
+        raise OidcError("untrusted_workflow", f"malformed token: {exc}") from exc
+    kid = header.get("kid")
+    keys = list(jwks.get("keys") or [])
+    matching = [key for key in keys if not kid or key.get("kid") == kid]
+    if not matching:
+        matching = keys
+    last_error: Exception | None = None
+    claims: Dict[str, Any] | None = None
+    for key in matching:
+        try:
+            claims = jwt.decode(
+                token,
+                PyJWK.from_dict(dict(key)).key,
+                algorithms=["RS256"],
+                issuer=issuer,
+                audience=audience,
+                leeway=clock_tolerance_seconds,
+                options={"require": ["exp", "iss", "aud"]},
+            )
+            break
+        except jwt.InvalidTokenError as exc:
+            last_error = exc
+    if claims is None:
+        raise OidcError("untrusted_workflow", f"token rejected: {last_error}")
+    if now is None:
+        now = int(time.time())
+    exp = int(claims["exp"])
+    if exp + clock_tolerance_seconds < now:
+        raise OidcError("untrusted_workflow", "token expired")
+    if audience not in _audience_values(claims.get("aud")):
+        raise OidcError("untrusted_workflow", "audience mismatch")
+    return claims
+
+
+def assert_conditions(
+    claims: Mapping[str, Any],
+    *,
+    repository_owner_id: Optional[str],
+    repository_ids: list[str],
+    job_workflow_ref: Optional[str],
+    event_names: list[str],
+    repositories: list[str],
+) -> None:
+    """Match numeric ids, workflow ref, event, and repository ceiling."""
+    if repository_owner_id is not None:
+        got = str(claims.get("repository_owner_id") or "")
+        if got != str(repository_owner_id):
+            raise OidcError("untrusted_workflow", "repository_owner_id mismatch")
+    if repository_ids:
+        got = str(claims.get("repository_id") or "")
+        if got not in {str(item) for item in repository_ids}:
+            raise OidcError("untrusted_workflow", "repository_id mismatch")
+    ref = str(claims.get("job_workflow_ref") or "")
+    if job_workflow_ref and not fnmatch.fnmatch(ref, job_workflow_ref):
+        raise OidcError("untrusted_workflow", "job_workflow_ref mismatch")
+    event = str(claims.get("event_name") or "")
+    if event_names and event not in event_names:
+        raise OidcError("untrusted_workflow", "event_name mismatch")
+    repo = str(claims.get("repository") or "")
+    if not repo:
+        raise OidcError("untrusted_workflow", "repository claim missing")
+    if repositories and repo not in repositories:
+        raise OidcError("outside_ceiling", "repository is outside the ceiling")
+
+
+def load_jwks(
+    *,
+    jwks: Optional[Mapping[str, Any]],
+    jwks_url: Optional[str],
+    fetcher: Optional[Callable[[str], Mapping[str, Any]]] = None,
+) -> Mapping[str, Any]:
+    if jwks is not None:
+        return jwks
+    if not jwks_url:
+        raise ConfigError("exchange.jwks_url is required when no JWKS is supplied")
+    fetch = fetcher or fetch_jwks
+    return fetch(jwks_url)

--- a/github-actions/tests/test_exchange.py
+++ b/github-actions/tests/test_exchange.py
@@ -1,0 +1,298 @@
+"""OIDC exchange: mint, refuse, reuse, and role isolation."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import jwt
+import pytest
+from jwt.algorithms import RSAAlgorithm
+
+pytest.importorskip("tenuo_core")
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+from starlette.testclient import TestClient
+from tenuo_core import SigningKey, Warrant
+
+from tenuo_gha.app import Gateway
+from tenuo_gha.config import ConfigError, GatewayConfig
+from tenuo_gha.exchange import Exchange, ExchangeError
+from tenuo_gha.http import build_http
+
+
+AUDIENCE = "tenuo:org/acme"
+ISSUER = "https://token.actions.githubusercontent.com"
+
+
+def _rsa_jwks():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    jwk = json.loads(RSAAlgorithm.to_jwk(key.public_key()))
+    jwk["kid"] = "test"
+    jwk["use"] = "sig"
+    jwk["alg"] = "RS256"
+    return {"keys": [jwk]}, key
+
+
+def _claims(**overrides):
+    now = int(time.time())
+    base = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "exp": now + 300,
+        "iat": now,
+        "nbf": now,
+        "jti": "jti-1",
+        "repository": "acme/widgets",
+        "repository_id": "7890",
+        "repository_owner": "acme",
+        "repository_owner_id": "123456",
+        "job_workflow_ref": "acme/widgets/.github/workflows/triage.yml@refs/heads/main",
+        "event_name": "issues",
+        "run_id": "99",
+        "sub": "repo:acme/widgets:ref:refs/heads/main",
+    }
+    base.update(overrides)
+    return base
+
+
+def _token(key, **overrides) -> str:
+    return jwt.encode(_claims(**overrides), key, algorithm="RS256", headers={"kid": "test"})
+
+
+def _exchange_config(tmp_path: Path, issuer: SigningKey, environ: dict | None = None) -> GatewayConfig:
+    return GatewayConfig.from_mapping(
+        {
+            "version": 1,
+            "trust": {
+                "root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"],
+                "issuer": ISSUER,
+            },
+            "signing": {"provider": "memory"},
+            "ceiling": {"repositories": ["acme/widgets"]},
+            "tools": {"packs": ["github-triage"]},
+            "exchange": {
+                "audience": AUDIENCE,
+                "ttl_max": "15m",
+                "jwks_url": "https://example.invalid/jwks",
+                "conditions": {
+                    "repository_owner_id": "123456",
+                    "repository_id": ["7890"],
+                    "job_workflow_ref": "acme/*/.github/workflows/triage.yml@refs/heads/main",
+                    "event_name": ["issues", "pull_request"],
+                },
+            },
+            "receipts": {"path": str(tmp_path / "receipts.jsonl")},
+        },
+        environ={
+            "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+            "TENUO_ROLE": "exchange",
+            "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+            **(environ or {}),
+        },
+    )
+
+
+def test_combined_role_requires_the_escape(tmp_path):
+    issuer = SigningKey.generate()
+    with pytest.raises(ConfigError, match="TENUO_ALLOW_COMBINED_ROLES"):
+        GatewayConfig.from_mapping(
+            {
+                "version": 1,
+                "role": "both",
+                "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+                "signing": {"provider": "memory"},
+                "receipts": {"path": str(tmp_path / "r.jsonl")},
+            },
+            environ={
+                "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+                "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+            },
+        )
+
+
+def test_exchange_refuses_receipt_and_app_key_ids(tmp_path):
+    issuer = SigningKey.generate()
+    with pytest.raises(ConfigError, match="receipt or App"):
+        GatewayConfig.from_mapping(
+            {
+                "version": 1,
+                "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+                "signing": {
+                    "provider": "memory",
+                    "kms": {
+                        "receipt_key_id": "arn:aws:kms:us-east-1:1:key/receipt",
+                    },
+                },
+                "receipts": {"path": str(tmp_path / "r.jsonl")},
+            },
+            environ={
+                "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+                "TENUO_ROLE": "exchange",
+                "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+            },
+        )
+
+
+def test_gateway_refuses_issuer_key_id(tmp_path):
+    issuer = SigningKey.generate()
+    with pytest.raises(ConfigError, match="issuer key id"):
+        GatewayConfig.from_mapping(
+            {
+                "version": 1,
+                "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+                "signing": {
+                    "provider": "memory",
+                    "kms": {"issuer_key_id": "arn:aws:kms:us-east-1:1:key/issuer"},
+                },
+                "receipts": {"path": str(tmp_path / "r.jsonl")},
+            },
+            environ={
+                "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+                "TENUO_ROLE": "gateway",
+                "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+            },
+        )
+
+
+def test_fixture_jwt_mints_a_warrant(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    jwks, rsa_key = _rsa_jwks()
+    exchange = Exchange(_exchange_config(tmp_path, issuer), issuer_key=issuer, jwks=jwks)
+    result = exchange.mint(
+        _token(rsa_key),
+        {
+            "holder_public_key": holder.public_key.to_bytes().hex(),
+            "ttl_seconds": 900,
+            "capabilities": {
+                "github.get_issue": {"issue": 4127},
+                "github.add_comment": {"issue": 4127},
+            },
+        },
+    )
+    warrant = Warrant.from_base64(result.warrant)
+    assert result.warrant_id
+    assert result.expires_at
+    holder_pk = warrant.authorized_holder
+    holder_pk = holder_pk() if callable(holder_pk) else holder_pk
+    assert holder_pk.to_bytes() == holder.public_key.to_bytes()
+    import base64 as b64
+
+    args = {"repository": "acme/widgets", "issue": 4127}
+    sig = warrant.sign(holder, "github.get_issue", args, int(time.time()))
+    gateway = Gateway(
+        GatewayConfig.from_mapping(
+            {
+                "version": 1,
+                "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+                "signing": {"provider": "memory"},
+                "ceiling": {"repositories": ["acme/widgets"]},
+                "tools": {"packs": ["github-triage"]},
+                "receipts": {"path": str(tmp_path / "gw.jsonl")},
+            },
+            environ={
+                "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+                "TENUO_ROLE": "gateway",
+                "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+            },
+        )
+    )
+    verified = gateway.verify(
+        "github.get_issue",
+        args,
+        meta={"tenuo": {"warrant": result.warrant, "signature": b64.b64encode(bytes(sig)).decode()}},
+    )
+    assert verified.allowed
+
+
+def test_reused_token_is_forbidden(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    jwks, rsa_key = _rsa_jwks()
+    exchange = Exchange(_exchange_config(tmp_path, issuer), issuer_key=issuer, jwks=jwks)
+    body = {
+        "holder_public_key": holder.public_key.to_bytes().hex(),
+        "ttl_seconds": 60,
+        "capabilities": {"github.get_issue": {"issue": 1}},
+    }
+    token = _token(rsa_key)
+    exchange.mint(token, body)
+    with pytest.raises(ExchangeError, match="already exchanged") as caught:
+        exchange.mint(token, body)
+    assert caught.value.code == "token_reused"
+
+
+def test_ttl_above_max_is_refused(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    jwks, rsa_key = _rsa_jwks()
+    exchange = Exchange(_exchange_config(tmp_path, issuer), issuer_key=issuer, jwks=jwks)
+    with pytest.raises(ExchangeError) as caught:
+        exchange.mint(
+            _token(rsa_key),
+            {
+                "holder_public_key": holder.public_key.to_bytes().hex(),
+                "ttl_seconds": 3600,
+                "capabilities": {"github.get_issue": {"issue": 1}},
+            },
+        )
+    assert caught.value.code == "outside_ceiling"
+
+
+def test_tripwire_capability_is_refused(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    jwks, rsa_key = _rsa_jwks()
+    exchange = Exchange(_exchange_config(tmp_path, issuer), issuer_key=issuer, jwks=jwks)
+    with pytest.raises(ExchangeError) as caught:
+        exchange.mint(
+            _token(rsa_key),
+            {
+                "holder_public_key": holder.public_key.to_bytes().hex(),
+                "ttl_seconds": 60,
+                "capabilities": {"github.workflow_dispatch": {"workflow": "x.yml"}},
+            },
+        )
+    assert caught.value.code == "outside_ceiling"
+
+
+def test_foreign_repository_is_refused(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    jwks, rsa_key = _rsa_jwks()
+    exchange = Exchange(_exchange_config(tmp_path, issuer), issuer_key=issuer, jwks=jwks)
+    with pytest.raises(ExchangeError) as caught:
+        exchange.mint(
+            _token(rsa_key, repository="acme/payments-internal", repository_id="999"),
+            {
+                "holder_public_key": holder.public_key.to_bytes().hex(),
+                "ttl_seconds": 60,
+                "capabilities": {"github.get_issue": {"issue": 1}},
+            },
+        )
+    assert caught.value.code in {"outside_ceiling", "untrusted_workflow"}
+
+
+def test_http_exchange_mints(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    jwks, rsa_key = _rsa_jwks()
+    config = _exchange_config(tmp_path, issuer)
+    exchange = Exchange(config, issuer_key=issuer, jwks=jwks)
+    client = TestClient(build_http(config, exchange=exchange))
+    response = client.post(
+        "/v1/exchange",
+        headers={"Authorization": f"Bearer {_token(rsa_key, jti='http-1')}"},
+        json={
+            "holder_public_key": holder.public_key.to_bytes().hex(),
+            "ttl_seconds": 120,
+            "capabilities": {"github.get_issue": {"issue": 4127}},
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    Warrant.from_base64(payload["warrant"])
+    health = client.get("/health")
+    assert health.status_code == 200


### PR DESCRIPTION
## Summary
- `POST /v1/exchange` (and `/v1/exchange/github`) verifies a GitHub Actions OIDC JWT against a JWKS and mints a run warrant to the presented holder key.
- Capabilities outside the configured packs or ceiling, a TTL above `ttl_max`, and a reused JWT id are refused (`403`). A minted warrant verifies on the existing gateway path.
- `TENUO_ROLE=exchange|gateway`; `role=both` requires `TENUO_ALLOW_COMBINED_ROLES=1`. Exchange refuses receipt/App key ids; gateway refuses an issuer key id.

## Test plan
- [x] `pytest` in `github-actions/` (17 passed)
- [ ] Confirm PR targets `feat/m1-sdk-gateway-primitives`, not `main`