### PR TITLE
Add GitHub App triage tools behind warrant verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `role=both` needs `TENUO_ALLOW_COMBINED_ROLES=1`. The exchange role
   refuses receipt and App key ids; the gateway role refuses an issuer
   key id.
+- **GitHub App triage.** `credentials.github.provider=app` on the gateway
+  role mints an installation token in memory and runs `github-triage`
+  tools from the catalog. A denied call does not reach GitHub. Tokens
+  are not logged. `token` / PEM App keys remain startup errors.
 
 ### Changed
 

--- a/github-actions/pyproject.toml
+++ b/github-actions/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "cryptography>=42",
     "starlette>=0.37",
     "uvicorn>=0.30",
+    "httpx>=0.27",
 ]
 
 [project.scripts]

--- a/github-actions/tenuo_gha/app.py
+++ b/github-actions/tenuo_gha/app.py
@@ -1,4 +1,4 @@
-"""GitHub Actions gateway: warrant verify, file receipts, no GitHub calls."""
+"""GitHub Actions gateway: warrant verify, file receipts, optional GitHub calls."""
 
 from __future__ import annotations
 
@@ -10,9 +10,10 @@ from tenuo import Authorizer, PublicKey, SigningKey
 from tenuo.mcp import MCPVerificationResult, MCPVerifier, TENUO_TOOL_NOT_AUTHORIZED
 from tenuo.receipts import FileReceiptSink, ReceiptSigner
 
-from .catalog import TRIPWIRE_NAMES, ToolSpec, tools_for_packs
+from .catalog import TRIPWIRE_NAMES, ToolSpec, spec_by_name, tools_for_packs
 from .config import ConfigError, GatewayConfig
 from .exchange import Exchange
+from .github import GitHubError
 from .http import build_http
 
 
@@ -43,10 +44,13 @@ def _signing_key(config: GatewayConfig) -> SigningKey:
 class Gateway:
     """In-process gateway used by tests and by the HTTP entrypoint."""
 
-    def __init__(self, config: GatewayConfig) -> None:
+    def __init__(self, config: GatewayConfig, *, github: Any = None) -> None:
         if config.signing_provider == "kms":
             raise ConfigError("signing.provider=kms is not supported")
+        if config.github_app_id and github is None:
+            raise ConfigError("GitHub App signing is not configured")
         self.config = config
+        self.github = github
         self.tools = tools_for_packs(config.packs)
         roots = [_public_key(item) for item in config.root_public_keys]
         self.authorizer = Authorizer(trusted_roots=roots)
@@ -95,9 +99,29 @@ class Gateway:
     def flush_receipts(self) -> bool:
         return self.signer.flush()
 
+    def execute(
+        self,
+        tool: str,
+        arguments: Optional[Dict[str, Any]],
+        meta: Any = None,
+    ) -> tuple[MCPVerificationResult, Optional[Dict[str, Any]]]:
+        result = self.verify(tool, arguments, meta=meta)
+        if not result.allowed:
+            return result, None
+        spec = spec_by_name(tool, self.tools)
+        if spec is None or spec.tripwire:
+            return result, {"executed": False, "tool": tool}
+        if self.github is None:
+            return result, {"executed": False, "tool": tool}
+        try:
+            payload = self.github.call(spec, result.clean_arguments)
+        except GitHubError as exc:
+            return result, {"executed": False, "tool": tool, "error": str(exc)}
+        return result, payload if isinstance(payload, dict) else {"result": payload}
+
 
 def build_mcp(gateway: Gateway):
-    """FastMCP app: middleware verifies; handlers do not perform the tool."""
+    """FastMCP app: middleware verifies; handlers call GitHub only after allow."""
     from fastmcp import FastMCP
     from fastmcp.server.middleware.middleware import CallNext, Middleware, MiddlewareContext
     import mcp.types as mt
@@ -123,7 +147,14 @@ def build_mcp(gateway: Gateway):
 
     def _register(spec: ToolSpec) -> None:
         async def _handler(**kwargs: Any) -> Dict[str, Any]:
-            return {"executed": False, "mode": "verify_only", "tool": spec.name}
+            # Middleware already verified; call GitHub with clean arguments only.
+            if spec.tripwire or gateway.github is None:
+                return {"executed": False, "tool": spec.name}
+            try:
+                payload = gateway.github.call(spec, kwargs)
+            except GitHubError as exc:
+                return {"executed": False, "tool": spec.name, "error": str(exc)}
+            return payload if isinstance(payload, dict) else {"result": payload}
 
         _handler.__name__ = spec.name.replace(".", "_")
         _handler.__doc__ = spec.description

--- a/github-actions/tenuo_gha/app.py
+++ b/github-actions/tenuo_gha/app.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import base64
 import os
+from contextvars import ContextVar
 from typing import Any, Dict, Optional
 
 from tenuo import Authorizer, PublicKey, SigningKey
 from tenuo.mcp import MCPVerificationResult, MCPVerifier, TENUO_TOOL_NOT_AUTHORIZED
+
+_verified: ContextVar[Optional[MCPVerificationResult]] = ContextVar("tenuo_gha_verified", default=None)
 from tenuo.receipts import FileReceiptSink, ReceiptSigner
 
 from .catalog import TRIPWIRE_NAMES, ToolSpec, spec_by_name, tools_for_packs
@@ -94,10 +97,53 @@ class Gateway:
             )
             self.signer.emit_for_enforcement(denied)
             return denied
-        return self.verifier.verify(tool, arguments, meta=meta)
+        result = self.verifier.verify(tool, arguments, meta=meta)
+        if not result.allowed:
+            return result
+        return self._apply_repository_ceiling(result)
+
+    def _apply_repository_ceiling(self, result: MCPVerificationResult) -> MCPVerificationResult:
+        repository = (result.clean_arguments or {}).get("repository")
+        if repository is None:
+            return result
+        allowed = {str(item) for item in self.config.repositories}
+        if str(repository) in allowed:
+            return result
+        denied = MCPVerificationResult(
+            allowed=False,
+            tool=result.tool,
+            clean_arguments=dict(result.clean_arguments or {}),
+            constraints=dict(result.constraints or {}),
+            warrant_id=result.warrant_id,
+            denial_reason="gateway ceiling: repository is not enabled",
+            jsonrpc_error_code=-32001,
+            error_type="tool_not_allowed",
+            error_code=TENUO_TOOL_NOT_AUTHORIZED,
+            presented_chain=result.presented_chain,
+            verified_pop=result.verified_pop,
+            pop_auth_args=result.pop_auth_args,
+            authorizer=self.authorizer,
+        )
+        self.signer.emit_for_enforcement(denied)
+        return denied
 
     def flush_receipts(self) -> bool:
         return self.signer.flush()
+
+    def dispatch(self, result: MCPVerificationResult) -> Optional[Dict[str, Any]]:
+        """Call GitHub with the verifier's cleaned arguments after an allow."""
+        if not result.allowed:
+            return None
+        spec = spec_by_name(result.tool, self.tools)
+        if spec is None or spec.tripwire:
+            return {"executed": False, "tool": result.tool}
+        if self.github is None:
+            return {"executed": False, "tool": result.tool}
+        try:
+            payload = self.github.call(spec, result.clean_arguments)
+        except GitHubError as exc:
+            return {"executed": False, "tool": result.tool, "error": str(exc)}
+        return payload if isinstance(payload, dict) else {"result": payload}
 
     def execute(
         self,
@@ -108,16 +154,7 @@ class Gateway:
         result = self.verify(tool, arguments, meta=meta)
         if not result.allowed:
             return result, None
-        spec = spec_by_name(tool, self.tools)
-        if spec is None or spec.tripwire:
-            return result, {"executed": False, "tool": tool}
-        if self.github is None:
-            return result, {"executed": False, "tool": tool}
-        try:
-            payload = self.github.call(spec, result.clean_arguments)
-        except GitHubError as exc:
-            return result, {"executed": False, "tool": tool, "error": str(exc)}
-        return result, payload if isinstance(payload, dict) else {"result": payload}
+        return result, self.dispatch(result)
 
 
 def build_mcp(gateway: Gateway):
@@ -141,20 +178,23 @@ def build_mcp(gateway: Gateway):
             )
             if not result.allowed:
                 return _denial_tool_return(result)
-            return await call_next(context)
+            token = _verified.set(result)
+            fastmcp = context.fastmcp_context
+            if fastmcp is not None and hasattr(fastmcp, "set_state"):
+                fastmcp.set_state("tenuo_verified", result)
+            try:
+                return await call_next(context)
+            finally:
+                _verified.reset(token)
 
     mcp = FastMCP("tenuo-github-actions", middleware=[_Ceiling()])
 
     def _register(spec: ToolSpec) -> None:
         async def _handler(**kwargs: Any) -> Dict[str, Any]:
-            # Middleware already verified; call GitHub with clean arguments only.
-            if spec.tripwire or gateway.github is None:
+            result = _verified.get()
+            if result is None:
                 return {"executed": False, "tool": spec.name}
-            try:
-                payload = gateway.github.call(spec, kwargs)
-            except GitHubError as exc:
-                return {"executed": False, "tool": spec.name, "error": str(exc)}
-            return payload if isinstance(payload, dict) else {"result": payload}
+            return gateway.dispatch(result) or {"executed": False, "tool": spec.name}
 
         _handler.__name__ = spec.name.replace(".", "_")
         _handler.__doc__ = spec.description

--- a/github-actions/tenuo_gha/catalog.py
+++ b/github-actions/tenuo_gha/catalog.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 
 @dataclass(frozen=True)
@@ -13,19 +13,61 @@ class ToolSpec:
     arguments: Tuple[str, ...]
     tripwire: bool = False
     mutating: bool = False
+    method: str = "GET"
+    path: Optional[str] = None
+    body: Optional[Dict[str, str]] = None
+    response: Optional[Dict[str, str]] = None
 
 
 TRIAGE: Tuple[ToolSpec, ...] = (
-    ToolSpec("github.get_issue", "Read one issue.", ("repository", "issue")),
-    ToolSpec("github.list_issue_comments", "List comments on an issue.", ("repository", "issue")),
-    ToolSpec("github.add_comment", "Add a comment.", ("repository", "issue", "body"), mutating=True),
-    ToolSpec("github.add_labels", "Add labels.", ("repository", "issue", "labels"), mutating=True),
-    ToolSpec("github.remove_label", "Remove a label.", ("repository", "issue", "name"), mutating=True),
+    ToolSpec(
+        "github.get_issue",
+        "Read one issue.",
+        ("repository", "issue"),
+        path="/repos/{repository}/issues/{issue}",
+        response={"number": "number", "title": "title", "html_url": "html_url", "state": "state"},
+    ),
+    ToolSpec(
+        "github.list_issue_comments",
+        "List comments on an issue.",
+        ("repository", "issue"),
+        path="/repos/{repository}/issues/{issue}/comments",
+    ),
+    ToolSpec(
+        "github.add_comment",
+        "Add a comment.",
+        ("repository", "issue", "body"),
+        mutating=True,
+        method="POST",
+        path="/repos/{repository}/issues/{issue}/comments",
+        body={"body": "{body}"},
+        response={"comment_id": "id", "html_url": "html_url"},
+    ),
+    ToolSpec(
+        "github.add_labels",
+        "Add labels.",
+        ("repository", "issue", "labels"),
+        mutating=True,
+        method="POST",
+        path="/repos/{repository}/issues/{issue}/labels",
+        body={"labels": "{labels}"},
+    ),
+    ToolSpec(
+        "github.remove_label",
+        "Remove a label.",
+        ("repository", "issue", "name"),
+        mutating=True,
+        method="DELETE",
+        path="/repos/{repository}/issues/{issue}/labels/{name}",
+    ),
     ToolSpec(
         "github.close_issue",
         "Close an issue.",
         ("repository", "issue", "state_reason"),
         mutating=True,
+        method="PATCH",
+        path="/repos/{repository}/issues/{issue}",
+        body={"state": "closed", "state_reason": "{state_reason}"},
     ),
 )
 
@@ -59,3 +101,10 @@ def tools_for_packs(packs: List[str]) -> List[ToolSpec]:
             chosen.append(spec)
             seen.add(spec.name)
     return chosen
+
+
+def spec_by_name(name: str, tools: List[ToolSpec]) -> Optional[ToolSpec]:
+    for spec in tools:
+        if spec.name == name:
+            return spec
+    return None

--- a/github-actions/tenuo_gha/config.py
+++ b/github-actions/tenuo_gha/config.py
@@ -128,6 +128,9 @@ class GatewayConfig:
     issuer_key_id: Optional[str] = None
     receipt_key_id: Optional[str] = None
     github_app_key_id: Optional[str] = None
+    github_app_id: Optional[str] = None
+    github_api_url: str = "https://api.github.com"
+    github_installation_id: Optional[str] = None
     extras: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -147,16 +150,33 @@ class GatewayConfig:
         elif provider != "kms":
             raise ConfigError(f"unsupported signing.provider {provider!r}")
 
-        github_creds = (data.get("credentials") or {}).get("github") or {}
-        if github_creds:
-            raise ConfigError("credentials.github is not supported")
-        _assert_no_embedded_secrets(data)
-
         role = (environ.get("TENUO_ROLE") or data.get("role") or "gateway").strip()
         if role not in _ROLES:
             raise ConfigError(f"unsupported role {role!r}")
         if role == "both" and environ.get("TENUO_ALLOW_COMBINED_ROLES") != "1":
             raise ConfigError("role=both requires TENUO_ALLOW_COMBINED_ROLES=1")
+
+        github_creds = (data.get("credentials") or {}).get("github") or {}
+        github_app_id = None
+        github_api_url = "https://api.github.com"
+        github_installation_id = None
+        if github_creds:
+            if role == "exchange":
+                raise ConfigError("exchange role cannot be configured with credentials.github")
+            github_provider = github_creds.get("provider")
+            if github_provider != "app":
+                raise ConfigError("credentials.github.provider must be app")
+            if github_creds.get("token_env") or github_creds.get("token"):
+                raise ConfigError("token and token_env are not allowed")
+            if github_creds.get("app_private_key_env") or github_creds.get("app_private_key"):
+                raise ConfigError("app_private_key and app_private_key_env are not allowed")
+            github_app_id = str(github_creds.get("app_id") or "") or None
+            if not github_app_id:
+                raise ConfigError("credentials.github.app_id is required")
+            github_api_url = str(github_creds.get("api_url") or "https://api.github.com").rstrip("/")
+            if github_creds.get("installation_id") is not None:
+                github_installation_id = str(github_creds["installation_id"])
+        _assert_no_embedded_secrets(data)
 
         kms = signing.get("kms") or {}
         issuer_key_id = kms.get("issuer_key_id") or None
@@ -165,6 +185,8 @@ class GatewayConfig:
         if role == "exchange":
             if receipt_key_id or github_app_key_id:
                 raise ConfigError("exchange role cannot be configured with receipt or App key ids")
+            if github_creds:
+                raise ConfigError("exchange role cannot be configured with credentials.github")
         if role == "gateway":
             if issuer_key_id:
                 raise ConfigError("gateway role cannot be configured with an issuer key id")
@@ -217,6 +239,9 @@ class GatewayConfig:
             issuer_key_id=str(issuer_key_id) if issuer_key_id else None,
             receipt_key_id=str(receipt_key_id) if receipt_key_id else None,
             github_app_key_id=str(github_app_key_id) if github_app_key_id else None,
+            github_app_id=github_app_id,
+            github_api_url=github_api_url,
+            github_installation_id=github_installation_id,
             extras=data,
         )
 

--- a/github-actions/tenuo_gha/github.py
+++ b/github-actions/tenuo_gha/github.py
@@ -1,0 +1,128 @@
+"""GitHub App installation tokens and generated tool HTTP calls."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict, Optional, Tuple
+from urllib.parse import quote
+
+import httpx
+
+from .catalog import ToolSpec
+from .config import ConfigError, GatewayConfig
+
+MintToken = Callable[[str], Tuple[str, int]]
+SignAppJwt = Callable[[str], str]
+
+
+class GitHubError(RuntimeError):
+    """A GitHub API or token-mint failure. Never includes a token."""
+
+
+def _format_template(template: Any, arguments: Dict[str, Any]) -> Any:
+    if isinstance(template, str):
+        if template.startswith("{") and template.endswith("}") and template[1:-1] in arguments:
+            return arguments[template[1:-1]]
+        return template.format(**arguments)
+    if isinstance(template, dict):
+        return {key: _format_template(value, arguments) for key, value in template.items()}
+    if isinstance(template, list):
+        return [_format_template(item, arguments) for item in template]
+    return template
+
+
+def _project(payload: Any, mapping: Optional[Dict[str, str]]) -> Any:
+    if mapping is None or not isinstance(payload, dict):
+        return payload
+    return {out: payload.get(src) for out, src in mapping.items()}
+
+
+class GitHubApp:
+    """Mint and cache installation tokens. Tokens stay in this object."""
+
+    def __init__(
+        self,
+        config: GatewayConfig,
+        *,
+        client: Optional[httpx.Client] = None,
+        mint_token: Optional[MintToken] = None,
+        sign_app_jwt: Optional[SignAppJwt] = None,
+        now: Callable[[], int] = lambda: int(time.time()),
+    ) -> None:
+        if not config.github_app_id:
+            raise ConfigError("credentials.github.app_id is required")
+        self._app_id = config.github_app_id
+        self._api = config.github_api_url
+        self._installation_id = config.github_installation_id
+        self._client = client or httpx.Client(base_url=self._api, timeout=20.0)
+        self._mint_token = mint_token
+        self._sign_app_jwt = sign_app_jwt
+        self._now = now
+        self._cache: Dict[str, Tuple[str, int]] = {}
+
+    def token_for(self, repository: str) -> str:
+        now = self._now()
+        cached = self._cache.get(repository)
+        if cached and now < cached[1] - 300:
+            return cached[0]
+        token, expires_at = self._mint(repository)
+        self._cache[repository] = (token, expires_at)
+        return token
+
+    def _mint(self, repository: str) -> Tuple[str, int]:
+        if self._mint_token is not None:
+            return self._mint_token(repository)
+        if self._sign_app_jwt is None:
+            raise GitHubError("no App JWT signer is configured")
+        app_jwt = self._sign_app_jwt(self._app_id)
+        installation_id = self._installation_id or self._discover(repository, app_jwt)
+        owner, _, name = repository.partition("/")
+        response = self._client.post(
+            f"/app/installations/{installation_id}/access_tokens",
+            headers={
+                "Authorization": f"Bearer {app_jwt}",
+                "Accept": "application/vnd.github+json",
+            },
+            json={"repositories": [name]} if name else {},
+        )
+        if response.status_code >= 400:
+            raise GitHubError(f"installation token mint failed ({response.status_code})")
+        data = response.json()
+        token = data.get("token")
+        if not token or not isinstance(token, str):
+            raise GitHubError("installation token mint returned no token")
+        expires_at = self._now() + 3600
+        return token, expires_at
+
+    def _discover(self, repository: str, app_jwt: str) -> str:
+        owner, _, name = repository.partition("/")
+        response = self._client.get(
+            f"/repos/{quote(owner)}/{quote(name)}/installation",
+            headers={
+                "Authorization": f"Bearer {app_jwt}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        if response.status_code >= 400:
+            raise GitHubError(f"installation discovery failed ({response.status_code})")
+        installation_id = response.json().get("id")
+        if installation_id is None:
+            raise GitHubError("installation discovery returned no id")
+        return str(installation_id)
+
+    def call(self, spec: ToolSpec, arguments: Dict[str, Any]) -> Any:
+        if spec.tripwire or not spec.path:
+            raise GitHubError(f"{spec.name} is not executable")
+        token = self.token_for(str(arguments["repository"]))
+        path = spec.path.format(**{key: quote(str(value), safe="/") if key == "repository" else value for key, value in arguments.items()})
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        }
+        body = _format_template(spec.body, arguments) if spec.body else None
+        response = self._client.request(spec.method, path, headers=headers, json=body)
+        if response.status_code >= 400:
+            raise GitHubError(f"{spec.name} failed ({response.status_code})")
+        if response.status_code == 204 or not response.content:
+            return {"ok": True}
+        return _project(response.json(), spec.response)

--- a/github-actions/tenuo_gha/github.py
+++ b/github-actions/tenuo_gha/github.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from datetime import datetime
 from typing import Any, Callable, Dict, Optional, Tuple
 from urllib.parse import quote
 
@@ -17,6 +18,28 @@ SignAppJwt = Callable[[str], str]
 
 class GitHubError(RuntimeError):
     """A GitHub API or token-mint failure. Never includes a token."""
+
+
+def format_path(template: str, arguments: Dict[str, Any]) -> str:
+    """Percent-encode path arguments. Repository keeps its slash."""
+    encoded = {}
+    for key, value in arguments.items():
+        text = str(value)
+        encoded[key] = quote(text, safe="/") if key == "repository" else quote(text, safe="")
+    return template.format(**encoded)
+
+
+def parse_github_expiry(value: Any) -> int:
+    """Unix timestamp from GitHub's ``expires_at`` field."""
+    if isinstance(value, (int, float)) and value > 0:
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        raw = value.strip().replace("Z", "+00:00")
+        try:
+            return int(datetime.fromisoformat(raw).timestamp())
+        except ValueError:
+            pass
+    raise GitHubError("installation token mint returned no expiry")
 
 
 def _format_template(template: Any, arguments: Dict[str, Any]) -> Any:
@@ -69,6 +92,14 @@ class GitHubApp:
         self._cache[repository] = (token, expires_at)
         return token
 
+    def _http(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        # Blocking GitHub HTTP is acceptable for a single-tenant process.
+        # An async client can replace this later without changing call().
+        try:
+            return self._client.request(method, url, **kwargs)
+        except httpx.HTTPError:
+            raise GitHubError("GitHub request failed (network)") from None
+
     def _mint(self, repository: str) -> Tuple[str, int]:
         if self._mint_token is not None:
             return self._mint_token(repository)
@@ -77,7 +108,8 @@ class GitHubApp:
         app_jwt = self._sign_app_jwt(self._app_id)
         installation_id = self._installation_id or self._discover(repository, app_jwt)
         owner, _, name = repository.partition("/")
-        response = self._client.post(
+        response = self._http(
+            "POST",
             f"/app/installations/{installation_id}/access_tokens",
             headers={
                 "Authorization": f"Bearer {app_jwt}",
@@ -91,13 +123,13 @@ class GitHubApp:
         token = data.get("token")
         if not token or not isinstance(token, str):
             raise GitHubError("installation token mint returned no token")
-        expires_at = self._now() + 3600
-        return token, expires_at
+        return token, parse_github_expiry(data.get("expires_at"))
 
     def _discover(self, repository: str, app_jwt: str) -> str:
         owner, _, name = repository.partition("/")
-        response = self._client.get(
-            f"/repos/{quote(owner)}/{quote(name)}/installation",
+        response = self._http(
+            "GET",
+            f"/repos/{quote(owner, safe='')}/{quote(name, safe='')}/installation",
             headers={
                 "Authorization": f"Bearer {app_jwt}",
                 "Accept": "application/vnd.github+json",
@@ -114,13 +146,13 @@ class GitHubApp:
         if spec.tripwire or not spec.path:
             raise GitHubError(f"{spec.name} is not executable")
         token = self.token_for(str(arguments["repository"]))
-        path = spec.path.format(**{key: quote(str(value), safe="/") if key == "repository" else value for key, value in arguments.items()})
+        path = format_path(spec.path, arguments)
         headers = {
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github+json",
         }
         body = _format_template(spec.body, arguments) if spec.body else None
-        response = self._client.request(spec.method, path, headers=headers, json=body)
+        response = self._http(spec.method, path, headers=headers, json=body)
         if response.status_code >= 400:
             raise GitHubError(f"{spec.name} failed ({response.status_code})")
         if response.status_code == 204 or not response.content:

--- a/github-actions/tests/test_github_triage.py
+++ b/github-actions/tests/test_github_triage.py
@@ -1,0 +1,201 @@
+"""Allowed triage calls hit GitHub; denials do not."""
+
+from __future__ import annotations
+
+import base64
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+pytest.importorskip("tenuo_core")
+
+from tenuo import Exact, Pattern, Range
+from tenuo.mcp import TENUO_CONSTRAINT_VIOLATION
+from tenuo_core import SigningKey, Warrant
+
+from tenuo_gha.app import Gateway
+from tenuo_gha.config import ConfigError, GatewayConfig
+from tenuo_gha.github import GitHubApp
+
+
+def _config(tmp_path: Path, issuer: SigningKey, *, with_app: bool = True) -> GatewayConfig:
+    raw: dict = {
+        "version": 1,
+        "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+        "signing": {"provider": "memory"},
+        "ceiling": {"repositories": ["acme/widgets"]},
+        "tools": {"packs": ["github-triage"]},
+        "receipts": {"path": str(tmp_path / "receipts.jsonl")},
+    }
+    if with_app:
+        raw["credentials"] = {
+            "github": {
+                "provider": "app",
+                "app_id": "123",
+                "api_url": "https://api.github.com",
+                "installation_id": "9",
+            }
+        }
+    return GatewayConfig.from_mapping(
+        raw,
+        environ={
+            "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+            "TENUO_ROLE": "gateway",
+            "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+        },
+    )
+
+
+def _warrant(issuer: SigningKey, holder: SigningKey) -> Warrant:
+    return (
+        Warrant.mint_builder()
+        .capability("github.get_issue", repository=Exact("acme/widgets"), issue=Range(4127, 4127))
+        .capability(
+            "github.add_comment",
+            repository=Exact("acme/widgets"),
+            issue=Range(4127, 4127),
+            body=Pattern("*"),
+        )
+        .holder(holder.public_key)
+        .ttl(900)
+        .mint(issuer)
+    )
+
+
+def _meta(warrant: Warrant, key: SigningKey, tool: str, args: dict) -> dict:
+    sig = warrant.sign(key, tool, args, int(time.time()))
+    return {
+        "tenuo": {
+            "warrant": warrant.to_base64(),
+            "signature": base64.b64encode(bytes(sig)).decode(),
+        }
+    }
+
+
+def _mock_github(tmp_path: Path, issuer: SigningKey, recorded: list) -> tuple[Gateway, GitHubApp]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorded.append((request.method, request.url.path, request.read()))
+        if request.method == "POST" and request.url.path.endswith("/comments"):
+            return httpx.Response(
+                201,
+                json={"id": 77, "html_url": "https://github.com/acme/widgets/issues/4127#issuecomment-77"},
+            )
+        if request.method == "GET" and "/issues/" in request.url.path:
+            return httpx.Response(
+                200,
+                json={"number": 4127, "title": "bug", "html_url": "https://github.com/acme/widgets/issues/4127", "state": "open"},
+            )
+        return httpx.Response(404, json={"message": "not mocked"})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.github.com")
+    config = _config(tmp_path, issuer)
+    github = GitHubApp(
+        config,
+        client=client,
+        mint_token=lambda _repo: ("installation-token", int(time.time()) + 3600),
+    )
+    return Gateway(config, github=github), github
+
+
+def test_app_provider_is_allowed_on_gateway(tmp_path):
+    issuer = SigningKey.generate()
+    config = _config(tmp_path, issuer)
+    assert config.github_app_id == "123"
+
+
+def test_app_without_client_refuses_to_construct(tmp_path):
+    issuer = SigningKey.generate()
+    with pytest.raises(ConfigError, match="GitHub App signing"):
+        Gateway(_config(tmp_path, issuer))
+
+
+def test_exchange_role_refuses_github_credentials(tmp_path):
+    issuer = SigningKey.generate()
+    with pytest.raises(ConfigError, match="exchange role"):
+        GatewayConfig.from_mapping(
+            {
+                "version": 1,
+                "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+                "signing": {"provider": "memory"},
+                "credentials": {"github": {"provider": "app", "app_id": "1"}},
+                "receipts": {"path": str(tmp_path / "r.jsonl")},
+            },
+            environ={
+                "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+                "TENUO_ROLE": "exchange",
+                "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+            },
+        )
+
+
+def test_allowed_comment_hits_github(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    recorded: list = []
+    gateway, _ = _mock_github(tmp_path, issuer, recorded)
+    warrant = _warrant(issuer, holder)
+    args = {"repository": "acme/widgets", "issue": 4127, "body": "looks good"}
+    result, payload = gateway.execute(
+        "github.add_comment",
+        args,
+        meta=_meta(warrant, holder, "github.add_comment", args),
+    )
+    assert result.allowed
+    assert payload == {
+        "comment_id": 77,
+        "html_url": "https://github.com/acme/widgets/issues/4127#issuecomment-77",
+    }
+    assert recorded
+    assert recorded[0][0] == "POST"
+    assert "/repos/acme/widgets/issues/4127/comments" in recorded[0][1]
+
+
+def test_cross_repo_read_does_not_call_github(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    recorded: list = []
+    gateway, _ = _mock_github(tmp_path, issuer, recorded)
+    warrant = _warrant(issuer, holder)
+    args = {"repository": "acme/payments-internal", "issue": 1}
+    result, payload = gateway.execute(
+        "github.get_issue",
+        args,
+        meta=_meta(warrant, holder, "github.get_issue", args),
+    )
+    assert not result.allowed
+    assert result.error_code == TENUO_CONSTRAINT_VIOLATION
+    assert payload is None
+    assert recorded == []
+    assert gateway.flush_receipts()
+    text = Path(tmp_path / "receipts.jsonl").read_text(encoding="utf-8")
+    assert text.strip()
+
+
+def test_token_is_not_in_github_error_text(tmp_path):
+    issuer = SigningKey.generate()
+    config = _config(tmp_path, issuer)
+
+    def fail(_repo: str):
+        raise RuntimeError("mint failed")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"message": "bad credentials"})
+
+    github = GitHubApp(
+        config,
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler),
+            base_url="https://api.github.com",
+        ),
+        mint_token=lambda _repo: ("installation-token", int(time.time()) + 3600),
+    )
+    from tenuo_gha.catalog import spec_by_name, tools_for_packs
+    from tenuo_gha.github import GitHubError
+
+    spec = spec_by_name("github.get_issue", tools_for_packs(["github-triage"]))
+    with pytest.raises(GitHubError) as caught:
+        github.call(spec, {"repository": "acme/widgets", "issue": 1})
+    assert "installation-token" not in str(caught.value)

--- a/github-actions/tests/test_github_triage.py
+++ b/github-actions/tests/test_github_triage.py
@@ -12,12 +12,12 @@ import pytest
 pytest.importorskip("tenuo_core")
 
 from tenuo import Exact, Pattern, Range
-from tenuo.mcp import TENUO_CONSTRAINT_VIOLATION
+from tenuo.mcp import TENUO_CONSTRAINT_VIOLATION, TENUO_TOOL_NOT_AUTHORIZED
 from tenuo_core import SigningKey, Warrant
 
 from tenuo_gha.app import Gateway
 from tenuo_gha.config import ConfigError, GatewayConfig
-from tenuo_gha.github import GitHubApp
+from tenuo_gha.github import GitHubApp, GitHubError, format_path, parse_github_expiry
 
 
 def _config(tmp_path: Path, issuer: SigningKey, *, with_app: bool = True) -> GatewayConfig:
@@ -76,7 +76,7 @@ def _meta(warrant: Warrant, key: SigningKey, tool: str, args: dict) -> dict:
 
 def _mock_github(tmp_path: Path, issuer: SigningKey, recorded: list) -> tuple[Gateway, GitHubApp]:
     def handler(request: httpx.Request) -> httpx.Response:
-        recorded.append((request.method, request.url.path, request.read()))
+        recorded.append((request.method, request.url.raw_path.decode(), request.read()))
         if request.method == "POST" and request.url.path.endswith("/comments"):
             return httpx.Response(
                 201,
@@ -87,6 +87,8 @@ def _mock_github(tmp_path: Path, issuer: SigningKey, recorded: list) -> tuple[Ga
                 200,
                 json={"number": 4127, "title": "bug", "html_url": "https://github.com/acme/widgets/issues/4127", "state": "open"},
             )
+        if request.method == "DELETE" and "/labels/" in request.url.path:
+            return httpx.Response(204)
         return httpx.Response(404, json={"message": "not mocked"})
 
     transport = httpx.MockTransport(handler)
@@ -199,3 +201,136 @@ def test_token_is_not_in_github_error_text(tmp_path):
     with pytest.raises(GitHubError) as caught:
         github.call(spec, {"repository": "acme/widgets", "issue": 1})
     assert "installation-token" not in str(caught.value)
+
+
+def test_wide_warrant_is_still_stopped_by_repository_ceiling(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    recorded: list = []
+    gateway, _ = _mock_github(tmp_path, issuer, recorded)
+    warrant = (
+        Warrant.mint_builder()
+        .capability("github.get_issue", repository=Exact("acme/canary"), issue=Range(1, 1))
+        .holder(holder.public_key)
+        .ttl(900)
+        .mint(issuer)
+    )
+    args = {"repository": "acme/canary", "issue": 1}
+    result, payload = gateway.execute(
+        "github.get_issue",
+        args,
+        meta=_meta(warrant, holder, "github.get_issue", args),
+    )
+    assert not result.allowed
+    assert result.error_code == TENUO_TOOL_NOT_AUTHORIZED
+    assert "repository is not enabled" in (result.denial_reason or "")
+    assert payload is None
+    assert recorded == []
+    assert gateway.flush_receipts()
+    assert (tmp_path / "receipts.jsonl").read_text(encoding="utf-8").strip()
+
+
+def test_remove_label_encodes_slash_in_the_path(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    recorded: list = []
+    gateway, _ = _mock_github(tmp_path, issuer, recorded)
+    warrant = (
+        Warrant.mint_builder()
+        .capability(
+            "github.remove_label",
+            repository=Exact("acme/widgets"),
+            issue=Range(4127, 4127),
+            name=Exact("triage/demo"),
+        )
+        .holder(holder.public_key)
+        .ttl(900)
+        .mint(issuer)
+    )
+    args = {"repository": "acme/widgets", "issue": 4127, "name": "triage/demo"}
+    result, payload = gateway.execute(
+        "github.remove_label",
+        args,
+        meta=_meta(warrant, holder, "github.remove_label", args),
+    )
+    assert result.allowed
+    assert payload == {"ok": True}
+    assert recorded
+    assert recorded[0][0] == "DELETE"
+    assert recorded[0][1].endswith("/labels/triage%2Fdemo")
+    assert "/labels/triage/demo" not in recorded[0][1]
+
+
+def test_path_encoding_keeps_repository_slash():
+    path = format_path(
+        "/repos/{repository}/issues/{issue}/labels/{name}",
+        {"repository": "acme/widgets", "issue": 4127, "name": "triage/demo"},
+    )
+    assert path == "/repos/acme/widgets/issues/4127/labels/triage%2Fdemo"
+
+
+def test_network_error_is_a_github_error(tmp_path):
+    issuer = SigningKey.generate()
+    config = _config(tmp_path, issuer)
+
+    def boom(request: httpx.Request):
+        raise httpx.ConnectError("connection refused", request=request)
+
+    github = GitHubApp(
+        config,
+        client=httpx.Client(
+            transport=httpx.MockTransport(boom),
+            base_url="https://api.github.com",
+        ),
+        mint_token=lambda _repo: ("installation-token", int(time.time()) + 3600),
+    )
+    from tenuo_gha.catalog import spec_by_name, tools_for_packs
+
+    spec = spec_by_name("github.get_issue", tools_for_packs(["github-triage"]))
+    with pytest.raises(GitHubError, match="network") as caught:
+        github.call(spec, {"repository": "acme/widgets", "issue": 1})
+    assert "installation-token" not in str(caught.value)
+    assert "connection refused" not in str(caught.value)
+
+
+def test_installation_token_expiry_is_parsed(tmp_path):
+    issuer = SigningKey.generate()
+    config = _config(tmp_path, issuer)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/access_tokens")
+        return httpx.Response(
+            201,
+            json={"token": "ghs_not_a_real_token", "expires_at": "2099-01-15T12:00:00Z"},
+        )
+
+    github = GitHubApp(
+        config,
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler),
+            base_url="https://api.github.com",
+        ),
+        sign_app_jwt=lambda _app_id: "app-jwt",
+    )
+    token = github.token_for("acme/widgets")
+    assert token == "ghs_not_a_real_token"
+    _cached_token, expires_at = github._cache["acme/widgets"]
+    assert expires_at == parse_github_expiry("2099-01-15T12:00:00Z")
+    assert expires_at > int(time.time()) + 3600 * 24
+
+
+def test_dispatch_uses_cleaned_arguments(tmp_path):
+    issuer = SigningKey.generate()
+    holder = SigningKey.generate()
+    recorded: list = []
+    gateway, _ = _mock_github(tmp_path, issuer, recorded)
+    warrant = _warrant(issuer, holder)
+    args = {"repository": "acme/widgets", "issue": 4127, "body": "looks good"}
+    result = gateway.verify("github.add_comment", args, meta=_meta(warrant, holder, "github.add_comment", args))
+    assert result.allowed
+    payload = gateway.dispatch(result)
+    assert payload == {
+        "comment_id": 77,
+        "html_url": "https://github.com/acme/widgets/issues/4127#issuecomment-77",
+    }
+    assert recorded

--- a/github-actions/tests/test_verify_only.py
+++ b/github-actions/tests/test_verify_only.py
@@ -72,7 +72,7 @@ def test_memory_keys_require_the_escape(tmp_path):
 
 def test_github_credentials_are_a_startup_error(tmp_path):
     issuer = SigningKey.generate()
-    with pytest.raises(ConfigError, match="credentials.github"):
+    with pytest.raises(ConfigError, match="must be app"):
         GatewayConfig.from_mapping(
             {
                 "version": 1,


### PR DESCRIPTION
## Summary
- Gateway role accepts `credentials.github.provider=app` only. Token and PEM App keys are still startup errors. The exchange role still refuses any GitHub credentials.
- Catalog entries for `github-triage` carry HTTP method, path, and response projection. After an allow, the gateway mints an in-memory installation token and calls GitHub. A deny never reaches the API.
- Tokens are not included in error text. App JWT signing is injected (tests supply a mint); no PEM is loaded.

## Test plan
- [x] `pytest` in `github-actions/` (23 passed)
- [x] Allowed `github.add_comment` hits the mock API
- [x] Cross-repo `github.get_issue` is a constraint denial, no HTTP, receipt written
- [ ] Confirm PR targets `feat/gha-exchange`