### PR TITLE
Add holder process and stdio shim for GitHub Actions

### DIFF
--- a/github-actions/README.md
+++ b/github-actions/README.md
@@ -1,6 +1,7 @@
 # Tenuo for GitHub Actions
 
-Checks warrants and writes file receipts. Tool handlers do not call GitHub.
+Checks warrants and writes file receipts. The holder process keeps the run key
+behind a Unix socket; `mcp_config` launches a stdio shim that never sees it.
 
 ```bash
 PYTHONPATH=github-actions python -m tenuo_gha.check
@@ -8,4 +9,7 @@ PYTHONPATH=github-actions python -m tenuo_gha.check
 TENUO_ALLOW_INSECURE_MEMORY_KEYS=1 \
 TENUO_ROOT_PUBLIC_KEY=<hex> \
 python -m tenuo_gha --config github-actions/examples/gateway.yaml
+
+python -m tenuo_gha hold --socket /tmp/tenuo.sock
+python -m tenuo_gha shim --socket /tmp/tenuo.sock --gateway-url http://127.0.0.1:8000
 ```

--- a/github-actions/action.yml
+++ b/github-actions/action.yml
@@ -1,0 +1,26 @@
+name: Tenuo
+description: Start a holder process and write mcp_config for the agent step
+inputs:
+  gateway_url:
+    required: true
+    description: Shared gateway URL
+  exchange_url:
+    required: false
+    description: Shared exchange URL. Omitted, the gateway URL is used.
+outputs:
+  mcp_config:
+    description: Path to mcp-config.json
+    value: ${{ steps.start.outputs.mcp_config }}
+runs:
+  using: composite
+  steps:
+    - id: start
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${RUNNER_TEMP}/tenuo"
+        python -m tenuo_gha action \
+          --gateway-url "${{ inputs.gateway_url }}" \
+          --mcp-config "${RUNNER_TEMP}/tenuo/mcp-config.json" \
+          --socket "${RUNNER_TEMP}/tenuo/holder.sock" \
+          --pid "${RUNNER_TEMP}/tenuo/holder.pid"

--- a/github-actions/pyproject.toml
+++ b/github-actions/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
 
 [project.scripts]
 tenuo-gha = "tenuo_gha.app:main"
+tenuo-gha-hold = "tenuo_gha.holder:main"
+tenuo-gha-shim = "tenuo_gha.shim:main"
 
 [build-system]
 requires = ["setuptools>=68"]

--- a/github-actions/tenuo_gha/__main__.py
+++ b/github-actions/tenuo_gha/__main__.py
@@ -1,4 +1,27 @@
-from .app import main
+"""``python -m tenuo_gha [hold|shim|action]`` — default is the HTTP server."""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] in {"hold", "holder", "shim", "action"}:
+        mode = sys.argv.pop(1)
+        if mode in {"hold", "holder"}:
+            from .holder import main as hold
+            hold()
+            return
+        if mode == "shim":
+            from .shim import main as shim
+            shim()
+            return
+        from .action import main as action
+        action()
+        return
+    from .app import main as serve
+    serve()
+
 
 if __name__ == "__main__":
     main()

--- a/github-actions/tenuo_gha/action.py
+++ b/github-actions/tenuo_gha/action.py
@@ -1,0 +1,155 @@
+"""Job entry: start the holder, write mcp_config, tear down on exit."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List, Mapping, Optional
+
+from .config import assert_no_runtime_secrets
+from .holder import HolderClient, HolderError, HolderServer, assert_no_holder_secret
+
+
+def guardrails(environ: Optional[Mapping[str, str]] = None) -> None:
+    env = environ if environ is not None else os.environ
+    assert_no_holder_secret(dict(env))
+    assert_no_runtime_secrets(env)
+
+
+def write_mcp_config(
+    path: "str | Path",
+    *,
+    socket: str,
+    gateway_url: str,
+    command: Optional[List[str]] = None,
+) -> Path:
+    dest = Path(path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    argv = command or [sys.executable, "-m", "tenuo_gha", "shim"]
+    dest.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "tenuo": {
+                        "command": argv[0],
+                        "args": argv[1:],
+                        "env": {
+                            "TENUO_HOLDER_SOCKET": socket,
+                            "TENUO_GATEWAY_URL": gateway_url,
+                        },
+                    }
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return dest
+
+
+def start_holder(socket_path: "str | Path") -> HolderServer:
+    server = HolderServer(socket_path)
+    server.start()
+    return server
+
+
+def wait_for_socket(socket_path: "str | Path", *, timeout: float = 5.0) -> None:
+    deadline = time.time() + timeout
+    last: Optional[Exception] = None
+    while time.time() < deadline:
+        if Path(socket_path).exists():
+            try:
+                HolderClient(socket_path).public_key_hex()
+                return
+            except (OSError, HolderError) as exc:
+                last = exc
+        time.sleep(0.05)
+    raise HolderError(f"holder socket did not come up: {last}")
+
+
+def spawn_holder(
+    socket_path: "str | Path",
+    *,
+    pid_path: Optional["str | Path"] = None,
+    python: str = sys.executable,
+) -> None:
+    """Start a detached holder. The caller does not keep the secret."""
+    cmd = [python, "-m", "tenuo_gha", "hold", "--socket", str(socket_path), "--daemon"]
+    if pid_path:
+        cmd.extend(["--pid", str(pid_path)])
+    env = os.environ.copy()
+    env.pop("TENUO_HOLDER_SECRET", None)
+    env.pop("TENUO_HOLDER_FD", None)
+    subprocess.Popen(
+        cmd,
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    wait_for_socket(socket_path)
+
+
+def public_key_hex(socket_path: "str | Path") -> str:
+    return HolderClient(socket_path).public_key_hex()
+
+
+def deliver_warrant(socket_path: "str | Path", warrant_b64: str) -> None:
+    HolderClient(socket_path).set_warrant(warrant_b64)
+
+
+def stop_holder(socket_path: "str | Path", pid_path: Optional["str | Path"] = None) -> None:
+    try:
+        HolderClient(socket_path).shutdown()
+    except (OSError, HolderError):
+        pass
+    if pid_path:
+        path = Path(pid_path)
+        if path.exists():
+            try:
+                os.kill(int(path.read_text(encoding="utf-8").strip()), 15)
+            except (OSError, ValueError):
+                pass
+            path.unlink(missing_ok=True)
+
+
+def main() -> None:
+    """Start a detached holder and print public material plus mcp_config."""
+    import argparse
+    import tempfile
+
+    parser = argparse.ArgumentParser(description="Start a Tenuo holder for this job")
+    parser.add_argument("--gateway-url", default=os.environ.get("TENUO_GATEWAY_URL", "http://127.0.0.1:8000"))
+    parser.add_argument("--socket", default="")
+    parser.add_argument("--mcp-config", default="")
+    parser.add_argument("--pid", default="")
+    args = parser.parse_args()
+    guardrails()
+    work = Path(tempfile.mkdtemp(prefix="tenuo-"))
+    socket_path = Path(args.socket) if args.socket else work / "holder.sock"
+    config_path = Path(args.mcp_config) if args.mcp_config else work / "mcp-config.json"
+    pid_path = Path(args.pid) if args.pid else work / "holder.pid"
+    spawn_holder(socket_path, pid_path=pid_path)
+    write_mcp_config(config_path, socket=str(socket_path), gateway_url=args.gateway_url)
+    payload = {
+        "public_key": public_key_hex(socket_path),
+        "mcp_config": str(config_path),
+        "socket": str(socket_path),
+        "pid": str(pid_path),
+    }
+    print(json.dumps(payload))
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as handle:
+            handle.write(f"mcp_config={payload['mcp_config']}\n")
+            handle.write(f"public_key={payload['public_key']}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/github-actions/tenuo_gha/app.py
+++ b/github-actions/tenuo_gha/app.py
@@ -178,13 +178,19 @@ def main() -> None:
     config = GatewayConfig.from_yaml(args.config)
 
     exchange = None
+    gateway = None
     mcp_app = None
     if config.role in {"exchange", "both"}:
         exchange = Exchange(config)
     if config.role in {"gateway", "both"}:
-        mcp_app = build_mcp(Gateway(config)).http_app()
+        gateway = Gateway(config)
+        mcp_app = build_mcp(gateway).http_app()
 
-    uvicorn.run(build_http(config, exchange=exchange, mcp_app=mcp_app), host=args.host, port=args.port)
+    uvicorn.run(
+        build_http(config, exchange=exchange, gateway=gateway, mcp_app=mcp_app),
+        host=args.host,
+        port=args.port,
+    )
 
 
 if __name__ == "__main__":

--- a/github-actions/tenuo_gha/config.py
+++ b/github-actions/tenuo_gha/config.py
@@ -19,6 +19,7 @@ _FORBIDDEN_NAMES = frozenset(
         "TENUO_GITHUB_APP_PRIVATE_KEY",
         "TENUO_ISSUER_KEY",
         "TENUO_HOLDER_SECRET",
+        "TENUO_HOLDER_FD",
     }
 )
 

--- a/github-actions/tenuo_gha/holder.py
+++ b/github-actions/tenuo_gha/holder.py
@@ -1,0 +1,307 @@
+"""Holder process: key and warrant stay here; the socket never returns the secret."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from tenuo.mcp import derive_terminal_leaf
+from tenuo_core import SigningKey, Warrant, encode_warrant_stack
+
+from .catalog import PACKS, TRIPWIRE_NAMES
+
+
+class HolderError(ValueError):
+    """Holder refused a request. Never includes key material."""
+
+
+def assert_no_holder_secret(environ: Optional[Dict[str, str]] = None) -> None:
+    env = environ if environ is not None else os.environ
+    if env.get("TENUO_HOLDER_SECRET"):
+        raise HolderError("TENUO_HOLDER_SECRET is not allowed")
+    if env.get("TENUO_HOLDER_FD"):
+        raise HolderError("TENUO_HOLDER_FD is not allowed")
+
+
+def _warrant_tools(warrant: Warrant) -> List[str]:
+    tools = getattr(warrant, "tools", None)
+    if callable(tools):
+        tools = tools()
+    if tools:
+        return [str(item) for item in tools]
+    caps = getattr(warrant, "capabilities", None)
+    if callable(caps):
+        caps = caps()
+    if isinstance(caps, dict):
+        return [str(item) for item in caps.keys()]
+    return []
+
+
+def _encode_stack(warrants: List[Warrant]) -> str:
+    try:
+        return encode_warrant_stack(warrants)
+    except Exception:
+        return warrants[-1].to_base64()
+
+
+class Holder:
+    """In-process holder used by the socket server and by tests."""
+
+    def __init__(self, *, allowlist: Optional[List[str]] = None, key: Optional[SigningKey] = None) -> None:
+        assert_no_holder_secret()
+        self._key = key or SigningKey.generate()
+        self._warrant: Optional[Warrant] = None
+        self._allowlist = allowlist
+
+    def public_key_hex(self) -> str:
+        return self._key.public_key.to_bytes().hex()
+
+    def set_warrant(self, warrant_b64: str) -> None:
+        self._warrant = Warrant.from_base64(warrant_b64)
+
+    def tools(self) -> List[str]:
+        if self._warrant is None:
+            return []
+        named = set(_warrant_tools(self._warrant))
+        catalog = {spec.name for pack in PACKS.values() for spec in pack}
+        chosen = sorted((named & catalog) - TRIPWIRE_NAMES)
+        if self._allowlist is not None:
+            chosen = [name for name in chosen if name in self._allowlist]
+        return chosen
+
+    def envelope(self, tool: str, arguments: Dict[str, Any]) -> Dict[str, str]:
+        if self._warrant is None:
+            raise HolderError("no warrant has been set")
+        ts = int(time.time())
+        try:
+            leaf, leaf_key = derive_terminal_leaf(self._warrant, self._key, tool, arguments)
+            sig = leaf.sign(leaf_key, tool, arguments, ts)
+            stack = _encode_stack([self._warrant, leaf])
+        except Exception:
+            # Widening and unknown tools still present the parent so the
+            # gateway can emit a signed denial. Do not return the secret.
+            try:
+                sig = self._warrant.sign(self._key, tool, arguments, ts)
+                stack = _encode_stack([self._warrant])
+            except Exception as exc:
+                raise HolderError("could not sign") from exc
+        return {
+            "warrant": stack,
+            "signature": base64.b64encode(bytes(sig)).decode(),
+        }
+
+
+def _handle(holder: Holder, message: Dict[str, Any]) -> Dict[str, Any]:
+    op = message.get("op")
+    if op == "public_key":
+        return {"ok": True, "public_key": holder.public_key_hex()}
+    if op == "set_warrant":
+        raw = message.get("warrant")
+        if not isinstance(raw, str) or not raw:
+            return {"ok": False, "error": "warrant is required"}
+        holder.set_warrant(raw)
+        return {"ok": True}
+    if op == "tools":
+        return {"ok": True, "tools": holder.tools()}
+    if op == "envelope":
+        tool = message.get("tool")
+        arguments = message.get("arguments") or {}
+        if not isinstance(tool, str) or not tool:
+            return {"ok": False, "error": "tool is required"}
+        if not isinstance(arguments, dict):
+            return {"ok": False, "error": "arguments must be a mapping"}
+        try:
+            payload = holder.envelope(tool, arguments)
+        except HolderError as exc:
+            return {"ok": False, "error": str(exc)}
+        payload["ok"] = True
+        return payload
+    if op == "shutdown":
+        return {"ok": True, "shutdown": True}
+    if op == "export_key":
+        return {"ok": False, "error": "not supported"}
+    return {"ok": False, "error": f"unknown op {op!r}"}
+
+
+class HolderServer:
+    """JSON-line Unix socket in front of a Holder."""
+
+    def __init__(self, path: "str | Path", holder: Optional[Holder] = None) -> None:
+        assert_no_holder_secret()
+        self.path = Path(path)
+        self.holder = holder or Holder()
+        self._sock: Optional[socket.socket] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        if self.path.exists():
+            self.path.unlink()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        bind = str(self.path)
+        if len(bind) > 100:
+            raise HolderError("holder socket path is too long")
+        self._sock.bind(bind)
+        os.chmod(self.path, 0o600)
+        self._sock.listen(8)
+        self._sock.settimeout(0.2)
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        assert self._sock is not None
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            with conn:
+                self._one(conn)
+
+    def _one(self, conn: socket.socket) -> None:
+        buf = b""
+        while not self._stop.is_set():
+            chunk = conn.recv(4096)
+            if not chunk:
+                return
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                if not line.strip():
+                    continue
+                try:
+                    message = json.loads(line.decode("utf-8"))
+                except json.JSONDecodeError:
+                    conn.sendall(b'{"ok":false,"error":"invalid json"}\n')
+                    continue
+                reply = _handle(self.holder, message)
+                conn.sendall((json.dumps(reply) + "\n").encode("utf-8"))
+                if reply.get("shutdown"):
+                    self._stop.set()
+                    return
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        if self.path.exists():
+            self.path.unlink()
+
+    def __enter__(self) -> "HolderServer":
+        self.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+
+class HolderClient:
+    """Talk to a HolderServer. Holds no secret."""
+
+    def __init__(self, path: "str | Path") -> None:
+        assert_no_holder_secret()
+        self.path = str(path)
+
+    def _rpc(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(self.path)
+        try:
+            sock.sendall((json.dumps(payload) + "\n").encode("utf-8"))
+            buf = b""
+            while b"\n" not in buf:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    raise HolderError("holder socket closed")
+                buf += chunk
+            reply = json.loads(buf.split(b"\n", 1)[0].decode("utf-8"))
+        finally:
+            sock.close()
+        if not reply.get("ok"):
+            raise HolderError(str(reply.get("error") or "holder refused"))
+        return reply
+
+    def public_key_hex(self) -> str:
+        return str(self._rpc({"op": "public_key"})["public_key"])
+
+    def set_warrant(self, warrant_b64: str) -> None:
+        self._rpc({"op": "set_warrant", "warrant": warrant_b64})
+
+    def tools(self) -> List[str]:
+        return list(self._rpc({"op": "tools"})["tools"])
+
+    def envelope(self, tool: str, arguments: Dict[str, Any]) -> Dict[str, str]:
+        reply = self._rpc({"op": "envelope", "tool": tool, "arguments": arguments})
+        return {"warrant": str(reply["warrant"]), "signature": str(reply["signature"])}
+
+    def shutdown(self) -> None:
+        try:
+            self._rpc({"op": "shutdown"})
+        except OSError:
+            pass
+
+
+def daemonize() -> None:
+    """Detach so the holder is not a child of the process that started it."""
+    if os.fork() > 0:
+        os._exit(0)
+    os.setsid()
+    if os.fork() > 0:
+        os._exit(0)
+    os.umask(0o077)
+    devnull = os.open(os.devnull, os.O_RDWR)
+    os.dup2(devnull, 0)
+    os.dup2(devnull, 1)
+    os.dup2(devnull, 2)
+    if devnull > 2:
+        os.close(devnull)
+
+
+def main() -> None:
+    import argparse
+    import signal
+
+    parser = argparse.ArgumentParser(description="Tenuo holder process")
+    parser.add_argument("--socket", required=True)
+    parser.add_argument("--pid", default="")
+    parser.add_argument("--daemon", action="store_true")
+    args = parser.parse_args()
+    assert_no_holder_secret()
+    if args.daemon:
+        daemonize()
+    if args.pid:
+        Path(args.pid).write_text(str(os.getpid()), encoding="utf-8")
+    allow = os.environ.get("TENUO_TOOL_ALLOWLIST")
+    allowlist = [item.strip() for item in allow.split(",") if item.strip()] if allow else None
+    server = HolderServer(args.socket, Holder(allowlist=allowlist))
+
+    def _stop(*_sig: object) -> None:
+        server.stop()
+
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+    server.start()
+    try:
+        while not server._stop.wait(timeout=1.0):
+            pass
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/github-actions/tenuo_gha/http.py
+++ b/github-actions/tenuo_gha/http.py
@@ -25,9 +25,13 @@ def build_http(
     config: GatewayConfig,
     *,
     exchange: Optional[Exchange] = None,
+    gateway: Any = None,
     mcp_app: Any = None,
 ) -> Starlette:
-    ready = {"exchange": exchange is not None, "gateway": mcp_app is not None}
+    ready = {
+        "exchange": exchange is not None,
+        "gateway": gateway is not None or mcp_app is not None,
+    }
 
     async def health(_request: Request) -> Response:
         return JSONResponse({"status": "ok"})
@@ -57,11 +61,41 @@ def build_http(
             }
         )
 
+    async def call_handler(request: Request) -> Response:
+        if gateway is None:
+            return JSONResponse({"error": "not_found", "detail": "gateway is not served"}, status_code=404)
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return JSONResponse({"error": "outside_ceiling", "detail": "body must be JSON"}, status_code=400)
+        if not isinstance(body, dict):
+            return JSONResponse({"error": "outside_ceiling", "detail": "body must be a mapping"}, status_code=400)
+        tool = body.get("tool")
+        arguments = body.get("arguments") or {}
+        if not isinstance(tool, str) or not tool:
+            return JSONResponse({"error": "outside_ceiling", "detail": "tool is required"}, status_code=400)
+        if not isinstance(arguments, dict):
+            return JSONResponse({"error": "outside_ceiling", "detail": "arguments must be a mapping"}, status_code=400)
+        result, payload = gateway.execute(tool, arguments, meta=body.get("meta"))
+        if not result.allowed:
+            return JSONResponse(
+                {
+                    "allowed": False,
+                    "error_code": result.error_code,
+                    "error_type": result.error_type,
+                    "denial_reason": result.denial_reason,
+                    "detail": result.denial_reason,
+                },
+                status_code=403,
+            )
+        return JSONResponse({"allowed": True, "result": payload or {}})
+
     routes = [
         Route("/health", health, methods=["GET"]),
         Route("/ready", ready_probe, methods=["GET"]),
         Route("/v1/exchange", exchange_handler, methods=["POST"]),
         Route("/v1/exchange/github", exchange_handler, methods=["POST"]),
+        Route("/v1/call", call_handler, methods=["POST"]),
     ]
     if mcp_app is not None:
         routes.append(Mount("/", app=mcp_app))

--- a/github-actions/tenuo_gha/shim.py
+++ b/github-actions/tenuo_gha/shim.py
@@ -1,0 +1,103 @@
+"""Stdio MCP shim. Talks to the holder socket; holds no secret."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .holder import HolderClient, assert_no_holder_secret
+
+
+class ShimError(RuntimeError):
+    """Shim could not complete a call. Never includes holder material."""
+
+
+def call_gateway(
+    gateway_url: str,
+    tool: str,
+    arguments: Dict[str, Any],
+    envelope: Dict[str, str],
+    *,
+    client: Optional[httpx.Client] = None,
+) -> Dict[str, Any]:
+    """POST the holder envelope to the gateway. Logs no arguments."""
+    own = client is None
+    http = client or httpx.Client(timeout=20.0)
+    try:
+        response = http.post(
+            gateway_url.rstrip("/") + "/v1/call",
+            json={
+                "tool": tool,
+                "arguments": arguments,
+                "meta": {"tenuo": envelope},
+            },
+        )
+    finally:
+        if own:
+            http.close()
+    try:
+        payload = response.json()
+    except json.JSONDecodeError as exc:
+        raise ShimError(f"gateway returned non-JSON ({response.status_code})") from exc
+    if response.status_code >= 400 or not payload.get("allowed", False):
+        code = payload.get("error_code") or payload.get("error") or "denied"
+        _log_line(tool, allowed=False, code=str(code))
+        return {
+            "allowed": False,
+            "error_code": code,
+            "message": f"DENIED ({code}): {payload.get('detail') or payload.get('denial_reason') or 'denied'}",
+        }
+    _log_line(tool, allowed=True, code="allow")
+    return {"allowed": True, "result": payload.get("result") or {}}
+
+
+def _log_line(tool: str, *, allowed: bool, code: str) -> None:
+    sys.stderr.write(
+        json.dumps({"tool": tool, "outcome": "allow" if allowed else "deny", "code": code}) + "\n"
+    )
+
+
+def build_mcp(holder: HolderClient, gateway_url: str, *, client: Optional[httpx.Client] = None):
+    from fastmcp import FastMCP
+
+    mcp = FastMCP("tenuo")
+    for name in holder.tools():
+
+        def _bind(tool_name: str):
+            async def _handler(**kwargs: Any) -> Dict[str, Any]:
+                envelope = holder.envelope(tool_name, kwargs)
+                outcome = call_gateway(gateway_url, tool_name, kwargs, envelope, client=client)
+                if not outcome.get("allowed"):
+                    return {"isError": True, "error_code": outcome.get("error_code"), "message": outcome.get("message")}
+                result = outcome.get("result")
+                return result if isinstance(result, dict) else {"result": result}
+
+            _handler.__name__ = tool_name.replace(".", "_")
+            return _handler
+
+        mcp.tool(name=name)(_bind(name))
+    return mcp
+
+
+def main() -> None:
+    import argparse
+
+    assert_no_holder_secret()
+    parser = argparse.ArgumentParser(description="Tenuo MCP shim")
+    parser.add_argument("--socket", default=os.environ.get("TENUO_HOLDER_SOCKET"))
+    parser.add_argument("--gateway-url", default=os.environ.get("TENUO_GATEWAY_URL"))
+    args = parser.parse_args()
+    if not args.socket:
+        raise SystemExit("TENUO_HOLDER_SOCKET is required")
+    if not args.gateway_url:
+        raise SystemExit("TENUO_GATEWAY_URL is required")
+    holder = HolderClient(args.socket)
+    build_mcp(holder, args.gateway_url).run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/github-actions/tests/test_holder_shim.py
+++ b/github-actions/tests/test_holder_shim.py
@@ -1,0 +1,325 @@
+"""Holder process keeps the key; the shim and agent never see it."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+from starlette.testclient import TestClient
+
+pytest.importorskip("tenuo_core")
+
+from tenuo import Exact, Pattern, Range
+from tenuo.mcp import TENUO_CONSTRAINT_VIOLATION, TENUO_TOOL_NOT_AUTHORIZED
+from tenuo_core import PublicKey, SigningKey, Warrant
+
+from tenuo_gha.action import deliver_warrant, guardrails, spawn_holder, start_holder, stop_holder, write_mcp_config
+from tenuo_gha.app import Gateway
+from tenuo_gha.config import ConfigError, GatewayConfig
+from tenuo_gha.github import GitHubApp
+from tenuo_gha.holder import Holder, HolderClient, HolderError, HolderServer, _handle
+from tenuo_gha.http import build_http
+from tenuo_gha.shim import call_gateway
+
+
+def _config(tmp_path: Path, issuer: SigningKey, *, with_app: bool = True) -> GatewayConfig:
+    raw: dict = {
+        "version": 1,
+        "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+        "signing": {"provider": "memory"},
+        "ceiling": {"repositories": ["acme/widgets"]},
+        "tools": {"packs": ["github-triage"]},
+        "receipts": {"path": str(tmp_path / "receipts.jsonl")},
+    }
+    if with_app:
+        raw["credentials"] = {
+            "github": {
+                "provider": "app",
+                "app_id": "123",
+                "api_url": "https://api.github.com",
+                "installation_id": "9",
+            }
+        }
+    return GatewayConfig.from_mapping(
+        raw,
+        environ={
+            "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+            "TENUO_ROLE": "gateway",
+            "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+        },
+    )
+
+
+def _warrant(issuer: SigningKey, holder_hex: str) -> Warrant:
+    holder_pub = PublicKey.from_bytes(bytes.fromhex(holder_hex))
+    return (
+        Warrant.mint_builder()
+        .capability("github.get_issue", repository=Exact("acme/widgets"), issue=Range(4127, 4127))
+        .capability(
+            "github.add_comment",
+            repository=Exact("acme/widgets"),
+            issue=Range(4127, 4127),
+            body=Pattern("*"),
+        )
+        .holder(holder_pub)
+        .ttl(900)
+        .mint(issuer)
+    )
+
+
+def _mock_github(tmp_path: Path, issuer: SigningKey, recorded: list) -> Gateway:
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorded.append((request.method, request.url.path, request.read()))
+        if request.method == "POST" and request.url.path.endswith("/comments"):
+            return httpx.Response(
+                201,
+                json={"id": 77, "html_url": "https://github.com/acme/widgets/issues/4127#issuecomment-77"},
+            )
+        return httpx.Response(404, json={"message": "not mocked"})
+
+    github = GitHubApp(
+        _config(tmp_path, issuer),
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler),
+            base_url="https://api.github.com",
+        ),
+        mint_token=lambda _repo: ("installation-token", int(time.time()) + 3600),
+    )
+    return Gateway(_config(tmp_path, issuer), github=github)
+
+
+def test_holder_secret_env_refuses_before_construct(monkeypatch):
+    monkeypatch.setenv("TENUO_HOLDER_SECRET", "should-never-be-read")
+    with pytest.raises(HolderError, match="TENUO_HOLDER_SECRET"):
+        Holder()
+
+
+def test_holder_fd_env_is_a_startup_error(monkeypatch):
+    monkeypatch.setenv("TENUO_HOLDER_FD", "3")
+    with pytest.raises(HolderError, match="TENUO_HOLDER_FD"):
+        Holder()
+
+
+def test_config_refuses_holder_fd(tmp_path):
+    issuer = SigningKey.generate()
+    with pytest.raises(ConfigError, match="TENUO_HOLDER_FD"):
+        GatewayConfig.from_mapping(
+            {
+                "version": 1,
+                "trust": {"root_public_keys": ["${TENUO_ROOT_PUBLIC_KEY}"]},
+                "signing": {"provider": "memory"},
+                "receipts": {"path": str(tmp_path / "r.jsonl")},
+            },
+            environ={
+                "TENUO_ALLOW_INSECURE_MEMORY_KEYS": "1",
+                "TENUO_ROOT_PUBLIC_KEY": issuer.public_key.to_bytes().hex(),
+                "TENUO_HOLDER_FD": "3",
+            },
+        )
+
+
+def test_guardrails_refuse_holder_secret():
+    with pytest.raises(HolderError, match="TENUO_HOLDER_SECRET"):
+        guardrails({"TENUO_HOLDER_SECRET": "x", "PATH": "/usr/bin"})
+
+
+def test_export_key_is_not_supported():
+    holder = Holder()
+    reply = _handle(holder, {"op": "export_key"})
+    assert reply == {"ok": False, "error": "not supported"}
+    dumped = json.dumps(reply)
+    assert "secret" not in dumped
+    assert holder.public_key_hex() not in dumped
+
+
+def _sock(name: str) -> Path:
+    path = Path(f"/tmp/tenuo-htest-{name}.sock")
+    if path.exists():
+        path.unlink()
+    return path
+
+
+def test_socket_mode_is_owner_only():
+    path = _sock("mode")
+    with HolderServer(path) as server:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+        client = HolderClient(path)
+        assert len(client.public_key_hex()) == 64
+        server.stop()
+
+
+def test_tools_are_the_warrant_catalog_intersection():
+    issuer = SigningKey.generate()
+    holder = Holder()
+    warrant = _warrant(issuer, holder.public_key_hex())
+    holder.set_warrant(warrant.to_base64())
+    tools = holder.tools()
+    assert "github.get_issue" in tools
+    assert "github.add_comment" in tools
+    assert "github.workflow_dispatch" not in tools
+    assert "github.get_file_contents" not in tools
+
+
+def test_allowlist_filters_advertised_tools():
+    issuer = SigningKey.generate()
+    holder = Holder(allowlist=["github.get_issue"])
+    holder.set_warrant(_warrant(issuer, holder.public_key_hex()).to_base64())
+    assert holder.tools() == ["github.get_issue"]
+
+
+def test_holder_envelope_allows_a_bound_comment(tmp_path):
+    issuer = SigningKey.generate()
+    recorded: list = []
+    gateway = _mock_github(tmp_path, issuer, recorded)
+    path = _sock("comment")
+    with HolderServer(path) as server:
+        client = HolderClient(path)
+        deliver_warrant(path, _warrant(issuer, client.public_key_hex()).to_base64())
+        args = {"repository": "acme/widgets", "issue": 4127, "body": "looks good"}
+        envelope = client.envelope("github.add_comment", args)
+        assert "signature" in envelope
+        assert envelope["warrant"]
+        result, payload = gateway.execute(
+            "github.add_comment",
+            args,
+            meta={"tenuo": envelope},
+        )
+        assert result.allowed
+        assert payload == {
+            "comment_id": 77,
+            "html_url": "https://github.com/acme/widgets/issues/4127#issuecomment-77",
+        }
+        assert recorded
+        server.stop()
+
+
+def test_holder_widening_still_presents_parent(tmp_path):
+    issuer = SigningKey.generate()
+    recorded: list = []
+    gateway = _mock_github(tmp_path, issuer, recorded)
+    holder = Holder()
+    holder.set_warrant(_warrant(issuer, holder.public_key_hex()).to_base64())
+    args = {"repository": "acme/payments-internal", "issue": 1}
+    envelope = holder.envelope("github.get_issue", args)
+    result, payload = gateway.execute("github.get_issue", args, meta={"tenuo": envelope})
+    assert not result.allowed
+    assert result.error_code == TENUO_CONSTRAINT_VIOLATION
+    assert result.presented_chain
+    assert payload is None
+    assert recorded == []
+    assert gateway.flush_receipts()
+    assert (tmp_path / "receipts.jsonl").read_text(encoding="utf-8").strip()
+
+
+def test_tripwire_envelope_is_denied_without_github(tmp_path):
+    issuer = SigningKey.generate()
+    recorded: list = []
+    gateway = _mock_github(tmp_path, issuer, recorded)
+    holder = Holder()
+    holder.set_warrant(_warrant(issuer, holder.public_key_hex()).to_base64())
+    args = {"repository": "acme/widgets", "workflow": "release.yml"}
+    envelope = holder.envelope("github.workflow_dispatch", args)
+    result, payload = gateway.execute("github.workflow_dispatch", args, meta={"tenuo": envelope})
+    assert not result.allowed
+    assert result.error_code == TENUO_TOOL_NOT_AUTHORIZED
+    assert payload is None
+    assert recorded == []
+
+
+def test_http_call_uses_the_holder_envelope(tmp_path):
+    issuer = SigningKey.generate()
+    recorded: list = []
+    gateway = _mock_github(tmp_path, issuer, recorded)
+    holder = Holder()
+    holder.set_warrant(_warrant(issuer, holder.public_key_hex()).to_base64())
+    args = {"repository": "acme/widgets", "issue": 4127, "body": "ship it"}
+    envelope = holder.envelope("github.add_comment", args)
+    client = TestClient(build_http(gateway.config, gateway=gateway))
+    response = client.post(
+        "/v1/call",
+        json={"tool": "github.add_comment", "arguments": args, "meta": {"tenuo": envelope}},
+    )
+    assert response.status_code == 200
+    assert response.json()["allowed"] is True
+    assert response.json()["result"]["comment_id"] == 77
+
+
+def test_shim_posts_envelope_and_maps_denial(tmp_path):
+    issuer = SigningKey.generate()
+    recorded: list = []
+    gateway = _mock_github(tmp_path, issuer, recorded)
+    holder = Holder()
+    holder.set_warrant(_warrant(issuer, holder.public_key_hex()).to_base64())
+    args = {"repository": "acme/payments-internal", "issue": 1}
+    envelope = holder.envelope("github.get_issue", args)
+    starlette = TestClient(build_http(gateway.config, gateway=gateway))
+
+    class _Http:
+        def post(self, url, json=None):
+            return starlette.post("/v1/call", json=json)
+
+        def close(self) -> None:
+            return None
+
+    outcome = call_gateway("http://test", "github.get_issue", args, envelope, client=_Http())
+    assert outcome["allowed"] is False
+    assert "DENIED" in outcome["message"]
+    assert TENUO_CONSTRAINT_VIOLATION in outcome["message"]
+    assert recorded == []
+
+
+def test_mcp_config_has_no_secret(tmp_path):
+    path = write_mcp_config(
+        tmp_path / "mcp-config.json",
+        socket=str(tmp_path / "holder.sock"),
+        gateway_url="https://gateway.example",
+    )
+    text = path.read_text(encoding="utf-8")
+    payload = json.loads(text)
+    env = payload["mcpServers"]["tenuo"]["env"]
+    assert env["TENUO_HOLDER_SOCKET"].endswith("holder.sock")
+    assert env["TENUO_GATEWAY_URL"] == "https://gateway.example"
+    assert "TENUO_HOLDER_SECRET" not in env
+    assert "TENUO_HOLDER_FD" not in text
+    assert "ghs_" not in text
+
+
+def test_long_socket_path_is_refused():
+    path = Path("/tmp") / ("tenuo-" + ("x" * 120) + ".sock")
+    with pytest.raises(HolderError, match="too long"):
+        HolderServer(path).start()
+
+
+def test_detached_holder_is_not_this_process():
+    path = _sock("daemon")
+    pid_path = Path("/tmp/tenuo-htest-daemon.pid")
+    if pid_path.exists():
+        pid_path.unlink()
+    spawn_holder(path, pid_path=pid_path)
+    try:
+        pid = int(pid_path.read_text(encoding="utf-8").strip())
+        ppid = int(subprocess.check_output(["ps", "-o", "ppid=", "-p", str(pid)], text=True).strip())
+        assert ppid != os.getpid()
+        client = HolderClient(path)
+        assert len(client.public_key_hex()) == 64
+    finally:
+        stop_holder(path, pid_path)
+
+
+def test_in_process_action_delivers_warrant_to_holder(tmp_path):
+    issuer = SigningKey.generate()
+    path = _sock("action")
+    server = start_holder(path)
+    try:
+        client = HolderClient(path)
+        deliver_warrant(path, _warrant(issuer, client.public_key_hex()).to_base64())
+        assert "github.get_issue" in client.tools()
+    finally:
+        server.stop()


### PR DESCRIPTION
## Summary
- Detached holder process generates the run key in its own memory and serves envelopes over a Unix socket (`0600`). `TENUO_HOLDER_SECRET` and `TENUO_HOLDER_FD` are startup errors; there is no export-key operation.
- Stdio shim talks to the socket and posts `{tool, arguments, meta.tenuo}` to `POST /v1/call`. The gateway verifies, then calls GitHub only on allow. Widening still presents the parent so a signed denial receipt can be written.
- Thin composite `action.yml` starts the holder and writes `mcp_config` with the socket path and gateway URL only.

## Test plan
- [x] `cd github-actions && python -m pytest -q` (40 passed)
- [ ] Confirm a later job step can launch the shim from `mcp_config` without holder material in its environment
- [ ] OIDC exchange → `deliver_warrant` → agent tool call is a follow-on; this PR does not mint from the action yet