### PR TITLE
docs: add TypeScript contributor workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ security model.
 ### Prerequisites
 
 - Node.js 20 or newer
-- Corepack and pnpm 9.15.9, as pinned by `tenuo-ts/package.json`
+- pnpm 9.15.9, as pinned by `tenuo-ts/package.json`
 
 Rust and `wasm-pack` are not required for ordinary TypeScript-only changes. The
 generated Node.js WASM package is committed so contributors can install, test,
@@ -52,13 +52,34 @@ and run examples without compiling Rust first.
 
 ### Install
 
+Node.js 20 through 24 normally include Corepack:
+
 ```bash
 cd tenuo-ts
 corepack enable
+```
+
+Corepack is no longer distributed with Node.js 25 and newer. On those versions,
+or when `corepack` is unavailable, install the pinned pnpm version directly:
+
+```bash
+npm install --global pnpm@9.15.9
+```
+
+Then install the workspace dependencies:
+
+```bash
+cd tenuo-ts
 pnpm install
 ```
 
-Run all TypeScript commands below from `tenuo-ts/`.
+Run all subsequent TypeScript commands from `tenuo-ts/`.
+
+> The root Makefile targets are not substitutes for these commands.
+> `make build-wasm` builds the Explorer's browser target, not the Node.js WASM
+> package under `packages/core/src/generated/`, and `make test-ts` skips when
+> `tenuo-ts/node_modules` is absent. For the Node.js SDK, install dependencies
+> first and use the `pnpm` commands below, including `pnpm build:wasm`.
 
 ### Fast development loop
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,113 +1,270 @@
 # Contributing to Tenuo
 
-Thank you for your interest in contributing to Tenuo! We welcome contributions from the community.
+Thank you for contributing to Tenuo. This repository contains Rust, Python, and
+TypeScript projects with different development requirements. You only need the
+toolchain for the part you are changing.
 
-## Development Setup
+## Before you start
+
+Except for small typo fixes and obvious documentation corrections, open an
+issue before writing code. Describe the problem and expected behavior so we can
+align on the approach and avoid duplicate work.
+
+Good places to begin:
+
+- [`good first issue`](https://github.com/tenuo-ai/tenuo/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
+- [`help wanted`](https://github.com/tenuo-ai/tenuo/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)
+- [`typescript`](https://github.com/tenuo-ai/tenuo/issues?q=is%3Aissue%20state%3Aopen%20label%3Atypescript)
+
+Security vulnerabilities should not be filed as public issues. Follow
+[`SECURITY.md`](SECURITY.md) instead.
+
+## Clone the repository
+
+```bash
+git clone https://github.com/tenuo-ai/tenuo.git
+cd tenuo
+```
+
+Choose the setup below for the project you are changing.
+
+## TypeScript and JavaScript SDK
+
+The TypeScript workspace publishes two Node.js packages:
+
+```text
+tenuo-ts/
+  packages/core/   @tenuo/core — tools, sessions, policies, and WASM enforcement
+  packages/mcp/    @tenuo/mcp  — official MCP v2 server adapter
+```
+
+Start with the [TypeScript SDK guide](tenuo-ts/README.md) for the public API and
+security model.
 
 ### Prerequisites
 
-- **Rust**: Latest stable version (install via [rustup](https://rustup.rs/))
-- **Python**: 3.9 or higher
-- **maturin**: For building Python bindings (`uv pip install maturin`)
+- Node.js 20 or newer
+- Corepack and pnpm 9.15.9, as pinned by `tenuo-ts/package.json`
 
-### Setting up the Environment
+Rust and `wasm-pack` are not required for ordinary TypeScript-only changes. The
+generated Node.js WASM package is committed so contributors can install, test,
+and run examples without compiling Rust first.
 
-1.  Clone the repository:
-    ```bash
-    git clone https://github.com/tenuo-ai/tenuo.git
-    cd tenuo
-    ```
-
-2.  Create a virtual environment for Python:
-    ```bash
-    python3 -m venv .venv
-    source .venv/bin/activate
-    # Install uv (fast package installer)
-    pip install uv
-    uv pip install -e ".[dev]"
-    ```
-
-3.  Build the project:
-    ```bash
-    maturin develop
-    ```
-
-## Running Tests
-
-We provide a script to run all checks (formatting, linting, tests, security audit):
+### Install
 
 ```bash
-./scripts/check.sh
+cd tenuo-ts
+corepack enable
+pnpm install
 ```
 
-Please ensure this script passes before submitting a Pull Request.
+Run all TypeScript commands below from `tenuo-ts/`.
 
-### Running Individual Tests
+### Fast development loop
 
-- **Rust Tests**:
-    ```bash
-    cargo test
-    ```
+For changes to TypeScript source, tests, examples, or documentation:
 
-- **Python Tests**:
-    ```bash
-    pytest tenuo-python/tests
-    ```
+```bash
+pnpm typecheck
+pnpm --filter @tenuo/core test
+pnpm --filter @tenuo/mcp test
+```
 
-## Building Integrations
+Run a single test file while iterating:
 
-If you're adding support for a new framework (e.g., LlamaIndex, AutoGPT):
+```bash
+pnpm --filter @tenuo/core exec vitest run test/core.test.ts
+pnpm --filter @tenuo/mcp exec vitest run test/guard.test.ts
+```
 
-- Review the [Python Integration Guide](tenuo-python/docs/integration-guide.md) for required API patterns and invariant tests
-- Study existing integrations: [OpenAI](tenuo-python/tenuo/openai.py), [ADK](tenuo-python/tenuo/google_adk/guard.py), [LangChain](tenuo-python/tenuo/integrations/langchain.py)
-- Ensure all runtime authorization uses Rust core via wire format
-- Test against the 6 core invariants (monotonic attenuation, fail-closed, expiry, etc.)
+Run one named test or suite:
 
-## Integration Maintenance
+```bash
+pnpm --filter @tenuo/core exec vitest run test/core.test.ts -t "narrow"
+```
 
-We track upstream API changes in OpenAI, CrewAI, AutoGen, LangChain, and LangGraph via automated CI:
+Vitest watch mode is also available in either package:
 
-- **Dependabot** (`.github/dependabot.yml`) — weekly dependency update PRs
-- **Compatibility matrix** (`.github/workflows/integration-compatibility-matrix.yml`) — tests min + latest versions weekly
-- **Release monitor** (`.github/workflows/monitor-upstream-releases.yml`) — daily checks for new upstream releases
-- **Smoke tests** (`tenuo-python/tests/integration/test_smoke.py`) — verifies API contracts
+```bash
+pnpm --filter @tenuo/core test:watch
+pnpm --filter @tenuo/mcp test:watch
+```
 
-### Responding to Breaking Changes
+### Full WASM-backed validation
 
-1. Review upstream changelog
-2. Run smoke tests: `pytest tests/integration/test_smoke.py -k <integration>`
-3. Update integration code if needed
-4. Update `docs/compatibility-matrix.md`
-5. Test examples
-6. Update version constraints in `pyproject.toml` if needed
+Run the full workspace test before opening a pull request that changes runtime
+behavior:
 
-| Priority | Definition | Response Time |
-|----------|------------|---------------|
-| **P0** | Blocks users, no workaround | 48 hours |
-| **P1** | Workaround exists | 1 week |
-| **P2** | Minor impact | Next release |
+```bash
+pnpm test
+```
 
-## Code Style
+This rebuilds `tenuo-wasm`, then runs both package suites. It additionally
+requires:
 
-- **Rust**: We use `rustfmt`. The check script will verify formatting.
-- **Python**: We use `black` and `isort`.
+- The latest stable Rust toolchain
+- The `wasm32-unknown-unknown` Rust target
+- `wasm-pack`
 
-## Before You Start
+One possible setup is:
 
-**Open an issue first.** Before writing code, create a GitHub issue describing what you want to change and why. This lets us align on approach, avoid duplicate work, and save you time if the change doesn't fit the project direction. Bug reports, feature proposals, and doc improvements all benefit from a quick discussion before a PR.
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack
+```
 
-Small typo fixes and obvious doc corrections can skip this step.
+Rebuild the generated package directly after changing `tenuo-wasm`:
 
-## Pull Request Process
+```bash
+pnpm build:wasm
+```
 
-1.  Open an issue describing the change (see above).
-2.  Fork the repository and create your branch from `main`.
-3.  If you've added code that should be tested, add tests.
-4.  Ensure the test suite passes (`./scripts/check.sh`).
-5.  Make sure your code lints.
-6.  Reference the issue in your PR description (e.g., "Closes #123").
-7.  Issue that pull request!
+Do not edit files under `packages/core/src/generated/` by hand. Commit generated
+changes only when the Rust/WASM source changed.
+
+### Build and test package tarballs
+
+Changes to exports, public types, package metadata, WASM loading, or MCP peer
+dependencies should also test the packages as an external consumer:
+
+```bash
+pnpm --filter @tenuo/core build
+pnpm --filter @tenuo/core pack:smoke
+pnpm --filter @tenuo/mcp build
+pnpm --filter @tenuo/mcp pack:smoke
+```
+
+The smoke scripts create temporary projects and install packed tarballs. They
+catch problems that workspace imports can hide.
+
+### Run the MCP scenarios
+
+```bash
+pnpm example:mcp          # quarterly-close wire scenario
+pnpm example:mcp:host     # official MCP v1 recipe
+pnpm example:mcp:adapter  # @tenuo/mcp v2 adapter tests
+```
+
+### TypeScript contribution rules
+
+- Keep `@tenuo/core` independent of agent frameworks and MCP framework
+  packages. Framework-specific code belongs in an adapter package.
+- Authorization decisions must continue to run in Rust/WASM. TypeScript may
+  validate configuration and adapt transports, but it must not recreate the
+  policy engine.
+- A protected tool implementation must never run before an allow decision.
+- Treat host schemas such as Zod as validation, not authorization policy.
+- Preserve fail-closed behavior for missing sessions, invalid warrants,
+  untrusted roots, replay-store failures, and malformed inputs.
+- Do not add passthrough, audit-and-run, or mock-authorizer paths.
+- Public API changes need type-level tests as well as runtime tests.
+- Keep error messages useful without exposing secrets or original handler
+  exceptions to remote clients.
+
+If a proposed change affects warrant formats, canonicalization, signatures,
+delegation, approvals, revocation, receipts, or replay protection, call that out
+on the issue before implementation. Those changes require protocol and security
+review.
+
+## Rust core
+
+### Prerequisites
+
+- Latest stable Rust toolchain, installed with [rustup](https://rustup.rs/)
+
+Run formatting, linting, and tests from the repository root:
+
+```bash
+cd tenuo-core
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+```
+
+Changes shared with the TypeScript SDK may also require rebuilding
+`tenuo-wasm`; see [Full WASM-backed validation](#full-wasm-backed-validation).
+
+## Python SDK
+
+### Prerequisites
+
+- Python 3.9 or newer
+- Latest stable Rust toolchain
+- `uv` and `maturin`
+
+Create an environment from the repository root:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install uv
+uv pip install -e "./tenuo-python[dev]"
+cd tenuo-python
+maturin develop
+```
+
+Run the Python tests from `tenuo-python/`:
+
+```bash
+python -m pytest
+```
+
+The repository-level check script runs the broader Rust, Python, and Explorer
+validation:
+
+```bash
+cd ..
+./scripts/check.sh --check
+```
+
+It is intentionally broader than the TypeScript workflow and requires the
+corresponding toolchains.
+
+## Framework integrations
+
+Before adding or changing an integration:
+
+- Review the [Python Integration Guide](tenuo-python/docs/integration-guide.md)
+  for enforcement patterns and invariants.
+- Study a maintained integration with a similar lifecycle.
+- Keep authorization at the actual dispatch boundary.
+- Test fail-closed behavior, expiry, narrowing, and handler non-execution after
+  denial.
+- Add a compatibility test for the supported upstream version range.
+
+Upstream API changes are monitored through Dependabot, the compatibility
+matrix, and release-monitor workflows. When responding to a breaking change:
+
+1. Review the upstream changelog.
+2. Reproduce the failure with a focused compatibility test.
+3. Update the integration without weakening enforcement.
+4. Update `docs/compatibility-matrix.md` when the supported range changes.
+5. Run the relevant examples and package tests.
+
+## Pull request process
+
+1. Start from the latest `main` and create a focused branch.
+2. Keep the pull request scoped to one issue or closely related change.
+3. Add tests for behavior and public type changes.
+4. Run the checks for the project you changed.
+5. Update examples and documentation when the public experience changes.
+6. Reference the issue in the pull request description, for example
+   `Closes #123`.
+7. Explain any security-boundary or compatibility implications explicitly.
+
+CI runs additional cross-language, integration, packaging, and security checks.
+A contributor is not expected to install every repository toolchain for a
+change confined to one project.
+
+## Code style
+
+- Rust: `rustfmt` and Clippy
+- Python: Ruff and mypy
+- TypeScript: the repository TypeScript configuration and existing local style
+
+Avoid unrelated formatting or cleanup in a focused pull request.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [Apache-2.0 License](LICENSE).
+By contributing, you agree that your contributions will be licensed under the
+[Apache-2.0 License](LICENSE).

--- a/tenuo-ts/README.md
+++ b/tenuo-ts/README.md
@@ -479,45 +479,11 @@ For the legacy `@modelcontextprotocol/sdk` v1 API, use the maintained recipe in
 
 ## Develop the SDK
 
-From the repository root:
-
-```bash
-cd tenuo-ts
-corepack enable
-pnpm install
-```
-
-For TypeScript-only changes, use the committed WASM build and run the fast
-checks directly:
-
-```bash
-pnpm typecheck
-pnpm --filter @tenuo/core test
-pnpm --filter @tenuo/mcp test
-```
-
-Run the full suite before opening a pull request:
-
-```bash
-pnpm test
-pnpm --filter @tenuo/core build
-pnpm --filter @tenuo/core pack:smoke
-pnpm --filter @tenuo/mcp build
-pnpm --filter @tenuo/mcp pack:smoke
-```
-
-`pnpm test` rebuilds the Node.js WASM package and therefore requires Rust,
-`wasm32-unknown-unknown`, and `wasm-pack`. Run `pnpm build:wasm` explicitly
-after changing `tenuo-wasm`. Consumers installing from npm do not need Rust or
-`wasm-pack`; the generated WASM is included in `@tenuo/core`.
-
-Useful MCP examples:
-
-```bash
-pnpm example:mcp          # quarterly-close wire scenario
-pnpm example:mcp:host     # official v1 host recipe
-pnpm example:mcp:adapter  # @tenuo/mcp v2 adapter
-```
+See the repository's
+[TypeScript contributor workflow](../CONTRIBUTING.md#typescript-and-javascript-sdk)
+for installation, focused tests, examples, Node.js WASM rebuilding, and package
+smoke tests. That contributor guide is the canonical source for development
+commands.
 
 Publishing is performed by the GitHub Actions release workflow so npm can
 attach provenance. Both TypeScript packages remain on the `beta` dist-tag until


### PR DESCRIPTION
## Summary

- make contributor setup language-specific instead of requiring every toolchain
- add the Node.js, Corepack, and pnpm setup for the TypeScript workspace
- document the fast TypeScript loop, focused Vitest commands, full WASM validation, package smoke tests, and MCP scenarios
- explain the core/MCP package boundary and the security invariants TypeScript contributions must preserve
- clarify that repository-wide Rust/Python/Explorer checks are broader than a TypeScript-only change

This gives contributors picking up the new TypeScript starter issues a reliable path from clone to focused test run.

## Validation

- `git diff --check`
- verified all referenced local paths
- verified documented command and script names against the workspace package manifests

Documentation-only change; no runtime behavior changed.