### PR TITLE
docs(ts): add Vitest recipe for protected tool tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,7 @@ catch problems that workspace imports can hide.
 pnpm example:mcp          # quarterly-close wire scenario
 pnpm example:mcp:host     # official MCP v1 recipe
 pnpm example:mcp:adapter  # @tenuo/mcp v2 adapter tests
+pnpm example:vitest-protected-tools  # Vitest protected-tools public-API recipe
 ```
 
 ### TypeScript contribution rules

--- a/tenuo-ts/README.md
+++ b/tenuo-ts/README.md
@@ -101,7 +101,6 @@ await readFile.execute(
 );
 ```
 
-
 For a focused Vitest pattern that asserts allow and denial through public APIs (stable `code` / `field`, inner-tool spy, per-test session scope), see [`packages/core/examples/vitest-protected-tools`](packages/core/examples/vitest-protected-tools/README.md).
 
 ## Mental model

--- a/tenuo-ts/README.md
+++ b/tenuo-ts/README.md
@@ -101,6 +101,9 @@ await readFile.execute(
 );
 ```
 
+
+For a focused Vitest pattern that asserts allow and denial through public APIs (stable `code` / `field`, inner-tool spy, per-test session scope), see [`packages/core/examples/vitest-protected-tools`](packages/core/examples/vitest-protected-tools/README.md).
+
 ## Mental model
 
 Every protected call has three relevant inputs:

--- a/tenuo-ts/package.json
+++ b/tenuo-ts/package.json
@@ -9,7 +9,8 @@
     "example:mcp": "pnpm --filter @tenuo/core exec vitest run test/mcp.test.ts -t quarterly-close",
     "example:mcp:host": "pnpm --filter @tenuo/core exec vitest run test/mcp-host.smoke.test.ts",
     "example:mcp:adapter": "pnpm --filter @tenuo/mcp test",
-    "test:mutation": "stryker run stryker.core.config.mjs && stryker run stryker.mcp.config.mjs"
+    "test:mutation": "stryker run stryker.core.config.mjs && stryker run stryker.mcp.config.mjs",
+    "example:vitest-protected-tools": "pnpm --filter @tenuo/core exec vitest run examples/vitest-protected-tools/protected-tools.test.ts"
   },
   "engines": {
     "node": ">=20"

--- a/tenuo-ts/packages/core/README.md
+++ b/tenuo-ts/packages/core/README.md
@@ -79,5 +79,7 @@ or an async Redis `checkAndRecord`) to reject an exact replayed PoP; that is
 opt-in. PoP v1 is otherwise replayable in-window, including approval-gated
 calls. Pass `nonceStore` on those tools if an approval must be one-use.
 
+Testing tip: copy the Vitest recipe in `examples/vitest-protected-tools` to assert authorization boundaries with only public APIs.
+
 See the [workspace README](../../README.md) for the full API, refuse list, and
 how to rebuild WASM from this monorepo.

--- a/tenuo-ts/packages/core/examples/vitest-protected-tools/README.md
+++ b/tenuo-ts/packages/core/examples/vitest-protected-tools/README.md
@@ -1,0 +1,39 @@
+# Vitest recipe: testing protected tools
+
+Application authors need a clear pattern for asserting authorization boundaries
+around protected tools. This recipe shows how to do that with Vitest and only
+`@tenuo/core` public APIs — no `src/testkit.ts`, no generated WASM imports, and
+no private package paths.
+
+## What it covers
+
+- An allowed invocation calls the inner tool and returns its result
+- A denied invocation throws AuthorizationDeniedError
+- Denial is asserted through stable fields (code, field), not the full message
+- The denied invocation never calls the inner tool (Vitest spy)
+- Session scope is established with withSession and cleaned up per test
+- createTenuo.devRoot() is used under Vitest normal NODE_ENV=test guard
+
+Authorization still runs in the real WASM-backed SDK. The recipe does not mock
+authorization decisions or add testing bypasses.
+
+## Run
+
+From tenuo-ts/:
+
+```bash
+pnpm example:vitest-protected-tools
+```
+
+The package test suite also picks up this file via Vitest include examples/**/*.test.ts.
+
+## Consumer copy-paste
+
+After installing `@tenuo/core`, change the import in
+protected-tools.test.ts from `../../src/index.ts` to `@tenuo/core`. Keep the
+rest of the file as-is.
+
+## Related
+
+- Protect your first tool: ../../../README.md#protect-your-first-tool
+- Package README: ../../README.md

--- a/tenuo-ts/packages/core/examples/vitest-protected-tools/protected-tools.test.ts
+++ b/tenuo-ts/packages/core/examples/vitest-protected-tools/protected-tools.test.ts
@@ -53,18 +53,6 @@ describe("Vitest recipe: protected tools via public APIs", () => {
   });
 
   it("denies an out-of-scope call without invoking the inner tool", async () => {
-    await expect(
-      tenuo.withSession(session, () => readFile.execute({ path: "/etc/passwd" })),
-    ).rejects.toMatchObject({
-      name: "AuthorizationDeniedError",
-      code: "TENUO_CONSTRAINT_VIOLATION",
-      field: "path",
-    });
-
-    expect(execute).not.toHaveBeenCalled();
-  });
-
-  it("asserts denial through stable fields, not the full message text", async () => {
     let caught: unknown;
     try {
       await tenuo.withSession(session, () =>

--- a/tenuo-ts/packages/core/examples/vitest-protected-tools/protected-tools.test.ts
+++ b/tenuo-ts/packages/core/examples/vitest-protected-tools/protected-tools.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Consumer recipe: Vitest + protected tools via public APIs only.
+ *
+ * After installing @tenuo/core, import from that package instead of ../../src/index.ts.
+ *
+ * From tenuo-ts: pnpm example:vitest-protected-tools
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AuthorizationDeniedError,
+  createTenuo,
+  under,
+  type Session,
+  type Tenuo,
+} from "../../src/index.ts";
+
+describe("Vitest recipe: protected tools via public APIs", () => {
+  let tenuo: Tenuo;
+  let execute: ReturnType<typeof vi.fn<(args: { path: string }) => Promise<string>>>;
+  let readFile: { execute: (args: { path: string }) => Promise<string> };
+  let session: Session;
+
+  beforeEach(() => {
+    // Vitest sets NODE_ENV=test, so createTenuo.devRoot() is allowed.
+    tenuo = createTenuo({ root: createTenuo.devRoot() });
+    tenuo.ready();
+
+    execute = vi.fn(async ({ path }: { path: string }) => `contents of ${path}`);
+    readFile = tenuo.tool(
+      { execute },
+      {
+        capability: "read_file",
+        allow: { path: under("/data") },
+      },
+    );
+    session = tenuo.session({ tools: [readFile] });
+  });
+
+  afterEach(() => {
+    // withSession uses AsyncLocalStorage.run; context ends with the callback.
+    vi.clearAllMocks();
+  });
+
+  it("allows an in-scope call, invokes the inner tool, and returns its result", async () => {
+    const contents = await tenuo.withSession(session, () =>
+      readFile.execute({ path: "/data/q3.pdf" }),
+    );
+
+    expect(contents).toBe("contents of /data/q3.pdf");
+    expect(execute).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledWith({ path: "/data/q3.pdf" });
+  });
+
+  it("denies an out-of-scope call without invoking the inner tool", async () => {
+    await expect(
+      tenuo.withSession(session, () => readFile.execute({ path: "/etc/passwd" })),
+    ).rejects.toMatchObject({
+      name: "AuthorizationDeniedError",
+      code: "TENUO_CONSTRAINT_VIOLATION",
+      field: "path",
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("asserts denial through stable fields, not the full message text", async () => {
+    let caught: unknown;
+    try {
+      await tenuo.withSession(session, () =>
+        readFile.execute({ path: "/etc/passwd" }),
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AuthorizationDeniedError);
+    const denied = caught as AuthorizationDeniedError;
+    expect(denied.code).toBe("TENUO_CONSTRAINT_VIOLATION");
+    expect(denied.field).toBe("path");
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/tenuo-ts/packages/core/vitest.config.ts
+++ b/tenuo-ts/packages/core/vitest.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   root: fileURLToPath(new URL(".", import.meta.url)),
   test: {
     environment: "node",
-    include: ["test/**/*.test.ts"],
+    include: ["test/**/*.test.ts", "examples/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
Adds Vitest recipe for protected tools via public APIs only (allow/deny, stable error fields, withSession, one-command runner). Closes #591.