### PR TITLE
docs(lab): add the generated hosted guide and explorer links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -810,6 +810,8 @@ jobs:
           npm install --no-save --package-lock=false "$TENUO_LAB_PACKAGE"/*.tgz
           npm run typecheck
           npm test
+          # The hosted lab pages are generated from this code and real runs.
+          npm run site -- --check
 
   # ============================================================================
   # DOC CODE BLOCKS

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ npm install
 npm run lab
 ```
 
-Seven stages, ninety minutes for the first five, no agent-framework experience needed. You watch three classic approaches fail in three different ways before Tenuo appears, then write the delegation chain yourself. Runs offline, no API key. Start in [`labs/agent-delegation`](./labs/agent-delegation/README.md).
+Seven stages, ninety minutes for the first five, no agent-framework experience needed. You watch three classic approaches fail in three different ways before Tenuo appears, then write the delegation chain yourself. Runs offline, no API key. The guide is at [tenuo.ai/lab](https://tenuo.ai/lab/); the code is in [`labs/agent-delegation`](./labs/agent-delegation/README.md).
 
 ---
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -600,6 +600,7 @@
     <a href="{{ site.baseurl }}/" class="brand">tenuo</a>
     <span class="spacer"></span>
     <a href="{{ site.baseurl }}/quickstart">Quick Start</a>
+    <a href="{{ site.baseurl }}/lab/">Challenge</a>
     <a href="{{ site.baseurl }}/concepts">Concepts</a>
     <a href="{{ site.baseurl }}/api-reference">API</a>
     <a href="{{ site.baseurl }}/openai">OpenAI</a>

--- a/docs/_layouts/lab.html
+++ b/docs/_layouts/lab.html
@@ -1,0 +1,223 @@
+---
+layout: default
+---
+<div class="lab" data-lab-stage="{{ page.lab_stage }}" data-lab-version="{{ page.lab_version }}">
+{{ content }}
+</div>
+
+<style>
+  /* The lab pages are a guided path, not a reference: no heading sidebar, one wide column. */
+  .sidebar { display: none; }
+  .main { padding: 40px 32px; }
+  .content { max-width: 920px; margin: 0 auto; }
+  .lab h1 { border-bottom: 0; margin-bottom: 0.4rem; font-size: 2rem; }
+  .lab h2 { font-size: 1.25rem; margin: 2.2rem 0 0.8rem; letter-spacing: -0.01em; }
+  .lab h3 { font-size: 1rem; margin: 1.2rem 0 0.4rem; }
+  .lab p { margin: 0.5rem 0; }
+  .lab-muted { color: var(--text-muted); font-size: 0.9rem; }
+
+  .lab-stepper { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; margin: 0 0 22px; }
+  .lab-stepper a { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border-radius: 50%; border: 1px solid var(--border); color: var(--text-muted); font-size: 0.8rem; font-weight: 600; text-decoration: none; transition: all 0.15s; }
+  .lab-stepper a.home { width: auto; padding: 0 12px; border-radius: 15px; margin-right: 4px; }
+  .lab-stepper a:hover { border-color: var(--accent); color: var(--text); }
+  .lab-stepper a.done { background: rgba(61, 220, 132, 0.15); border-color: #3ddc84; color: #3ddc84; }
+  .lab-stepper a.current { background: var(--accent); border-color: var(--accent); color: #0a0a0a; }
+
+  .lab-hero { margin-bottom: 1.2rem; }
+  .lab-kicker { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); margin-bottom: 6px; }
+  .lab-mode { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 0.7rem; letter-spacing: 0.06em; }
+  .lab-mode.shared { background: rgba(255, 92, 92, 0.15); color: #ff5c5c; }
+  .lab-mode.identity { background: rgba(255, 176, 0, 0.15); color: #ffb000; }
+  .lab-mode.scoped { background: rgba(255, 176, 0, 0.15); color: #ffb000; }
+  .lab-mode.tenuo { background: rgba(0, 212, 255, 0.15); color: var(--accent); }
+  .lab-goal { font-size: 1.05rem; padding: 12px 16px; border-left: 3px solid var(--accent); background: var(--surface); border-radius: 0 8px 8px 0; }
+  .lab-intro { color: var(--text); }
+
+  .lab-figure { margin: 1.2rem 0; padding: 12px; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; }
+  .lab-diagram { width: 100%; height: auto; display: block; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+
+  .lab-code { margin: 1rem 0; border: 1px solid var(--border); border-radius: 10px; overflow: hidden; background: var(--code-bg); }
+  .lab-code figcaption { padding: 8px 14px; font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid var(--border); background: var(--surface); }
+  .lab-code figcaption span { float: right; font-family: 'SF Mono', Consolas, monospace; opacity: 0.8; }
+  .lab-code pre, .lab-code .highlight, .lab-code figure.highlight { margin: 0; border: 0; border-radius: 0; }
+  .lab-code pre { padding: 14px; font-size: 0.82rem; line-height: 1.55; }
+
+  .lab-steps { list-style: none; padding: 0; margin: 0; counter-reset: step; }
+  .lab-step { display: flex; gap: 14px; padding: 14px 16px; margin: 0 0 10px; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; transition: border-color 0.15s; }
+  .lab-step.checked { border-color: rgba(61, 220, 132, 0.5); }
+  .lab-step.checked .lab-step-check span { background: #3ddc84; border-color: #3ddc84; color: #0a0a0a; }
+  .lab-step-check { flex: 0 0 auto; cursor: pointer; user-select: none; }
+  .lab-step-check input { position: absolute; opacity: 0; width: 0; height: 0; }
+  .lab-step-check span { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border-radius: 50%; border: 1px solid var(--border); font-weight: 700; font-size: 0.85rem; color: var(--text-muted); transition: all 0.15s; }
+  .lab-step-check:hover span { border-color: var(--accent); }
+  .lab-step-body { flex: 1; min-width: 0; }
+  .lab-step-body > p:first-child { margin-top: 3px; }
+
+  .lab-cmd { position: relative; padding: 12px 84px 12px 14px; margin: 0.6rem 0; font-size: 0.85rem; }
+  .lab-cmd code { font-size: inherit; }
+  .lab-copy { position: absolute; top: 8px; right: 8px; padding: 4px 10px; font-size: 0.72rem; border-radius: 6px; border: 1px solid var(--border); background: var(--surface); color: var(--text-muted); cursor: pointer; }
+  .lab-copy:hover { color: var(--text); border-color: var(--accent); }
+
+  .lab-term { margin: 0.6rem 0 0; border: 1px solid var(--border); border-radius: 8px; background: #0d0d0d; }
+  .lab-term summary { cursor: pointer; padding: 8px 12px; font-size: 0.82rem; color: var(--text); list-style: none; display: flex; justify-content: space-between; gap: 8px; }
+  .lab-term summary::-webkit-details-marker { display: none; }
+  .lab-term summary::before { content: '▸'; margin-right: 6px; color: var(--text-muted); }
+  .lab-term[open] summary::before { content: '▾'; }
+  .lab-term summary span { color: var(--text-muted); font-family: 'SF Mono', Consolas, monospace; font-size: 0.72rem; }
+  .lab-term pre { margin: 0; border: 0; border-top: 1px solid var(--border); border-radius: 0 0 8px 8px; background: #0d0d0d; font-size: 0.76rem; line-height: 1.5; max-height: 460px; overflow: auto; }
+
+  .lab-tabs { margin-top: 0.6rem; }
+  .lab-tabs > input { position: absolute; opacity: 0; width: 0; height: 0; }
+  .lab-tabs > label { display: inline-block; padding: 5px 12px; margin: 0 6px 0 0; font-size: 0.8rem; border: 1px solid var(--border); border-radius: 14px; color: var(--text-muted); cursor: pointer; }
+  .lab-tabs > input:checked + label { color: #0a0a0a; background: var(--accent); border-color: var(--accent); }
+  .lab-tabs > input:focus-visible + label { outline: 2px solid var(--accent); }
+  .lab-tab-panel { display: none; }
+  .lab-tabs > input:nth-of-type(1):checked ~ .lab-tab-panel:nth-of-type(1),
+  .lab-tabs > input:nth-of-type(2):checked ~ .lab-tab-panel:nth-of-type(2),
+  .lab-tabs > input:nth-of-type(3):checked ~ .lab-tab-panel:nth-of-type(3) { display: block; }
+
+  .lab-callout { margin: 1.2rem 0; padding: 12px 16px; border-radius: 10px; border: 1px solid var(--border); border-left-width: 3px; background: var(--surface); }
+  .lab-callout ul { margin: 0.3rem 0 0 1.1rem; }
+  .lab-callout li { margin: 0.3rem 0; }
+  .lab-callout.notice { border-left-color: #ffb000; }
+  .lab-callout.question { border-left-color: var(--accent); }
+  .lab-callout.stuck { border-left-color: #ff5c5c; }
+  .lab-callout-title { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); margin-bottom: 4px; }
+
+  .lab-reveal { margin: 1rem 0; border: 1px dashed var(--border); border-radius: 10px; }
+  .lab-reveal summary { cursor: pointer; padding: 10px 16px; color: var(--accent); font-weight: 600; font-size: 0.92rem; }
+  .lab-reveal > div { padding: 4px 16px 12px; }
+
+  .lab-done { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin: 1.6rem 0 1rem; padding: 14px 16px; border-radius: 10px; background: rgba(0, 212, 255, 0.06); border: 1px solid rgba(0, 212, 255, 0.25); }
+  .lab-done p { margin: 0; }
+  .lab-mark { flex: 0 0 auto; padding: 8px 14px; border-radius: 8px; border: 1px solid var(--accent); background: transparent; color: var(--accent); font-weight: 600; cursor: pointer; }
+  .lab-mark.is-done { background: #3ddc84; border-color: #3ddc84; color: #0a0a0a; }
+
+  .lab-nav { display: flex; justify-content: space-between; gap: 12px; margin: 1.6rem 0 0; padding-top: 16px; border-top: 1px solid var(--border); }
+  .lab-nav a { text-decoration: none; padding: 10px 14px; border-radius: 8px; border: 1px solid var(--border); color: var(--text); font-size: 0.9rem; }
+  .lab-nav a.next { background: var(--accent); border-color: var(--accent); color: #0a0a0a; font-weight: 600; }
+  .lab-nav a:hover { border-color: var(--accent); }
+
+  .lab-start { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin: 1rem 0; }
+  .lab-start h2 { margin-top: 0.4rem; }
+  .lab-button { display: inline-block; padding: 10px 16px; border-radius: 8px; background: var(--accent); color: #0a0a0a !important; font-weight: 600; text-decoration: none; margin: 6px 0; }
+  .lab-prep { margin: 0.3rem 0 0 1.1rem; font-size: 0.9rem; }
+  .lab-mission table { font-size: 0.9rem; }
+  .lab-mission th { color: var(--text-muted); font-weight: 500; width: 14%; }
+
+  .lab-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .lab-card { display: flex; gap: 12px; align-items: flex-start; padding: 12px 14px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); text-decoration: none; color: var(--text); transition: border-color 0.15s; }
+  .lab-card:hover { border-color: var(--accent); }
+  .lab-card.done { border-color: rgba(61, 220, 132, 0.5); }
+  .lab-card.done .lab-card-n { background: #3ddc84; color: #0a0a0a; border-color: #3ddc84; }
+  .lab-card-n { flex: 0 0 auto; width: 28px; height: 28px; border-radius: 50%; border: 1px solid var(--border); display: inline-flex; align-items: center; justify-content: center; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); }
+  .lab-card-title { font-weight: 600; }
+  .lab-card-goal { font-size: 0.82rem; color: var(--text-muted); margin-top: 2px; }
+  .lab-card-time { margin-left: auto; flex: 0 0 auto; font-size: 0.72rem; color: var(--text-muted); white-space: nowrap; }
+
+  .lab-grading { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 24px; }
+  .lab-grade-row { display: flex; justify-content: space-between; font-size: 0.9rem; }
+  .lab-bar { height: 6px; border-radius: 3px; background: var(--surface-2); margin: 6px 0; overflow: hidden; }
+  .lab-bar div { height: 100%; background: var(--accent); border-radius: 3px; }
+  .lab-grade p { margin: 0; font-size: 0.8rem; }
+
+  .lab-explainer { margin: 1.4rem 0; padding: 16px 18px 6px; border: 1px solid rgba(0, 212, 255, 0.35); border-radius: 12px; background: linear-gradient(180deg, rgba(0, 212, 255, 0.06), transparent 60%); }
+  .lab-explainer h2 { margin: 0 0 0.4rem; }
+  .lab-explainer h3 { margin: 1.2rem 0 0.4rem; }
+  .lab-lead { font-size: 1.02rem; }
+  .lab-points { margin: 0.6rem 0 0.8rem 1.1rem; padding: 0; }
+  .lab-points li { margin: 0.35rem 0; }
+  .lab-why { font-size: 0.88rem; }
+  .lab-why th { color: var(--text-muted); font-weight: 500; }
+  .lab-why td:first-child { color: var(--text-muted); width: 46%; }
+  .lab-two { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+  .lab-two h3 { margin-top: 0.2rem; }
+  .lab-quote { font-size: 1.05rem; color: var(--text); background: var(--surface); padding: 12px 16px; border-radius: 0 8px 8px 0; }
+  .lab-terms td { vertical-align: top; }
+
+  /* Rouge tokens; the base layout has no highlighter styles. */
+  .highlight .k, .highlight .kd, .highlight .kr, .highlight .kt { color: #c792ea; }
+  .highlight .s, .highlight .s1, .highlight .s2, .highlight .dl, .highlight .sb { color: #c3e88d; }
+  .highlight .c, .highlight .c1, .highlight .cm { color: #6f6f6f; font-style: italic; }
+  .highlight .na, .highlight .nl { color: #82aaff; }
+  .highlight .nx, .highlight .n { color: #e8e8e8; }
+  .highlight .nf, .highlight .nb { color: #ffcb6b; }
+  .highlight .mi, .highlight .mf { color: #f78c6c; }
+  .highlight .p, .highlight .o { color: #89ddff; }
+
+  @media (max-width: 720px) {
+    .lab-start, .lab-grid, .lab-grading, .lab-two { grid-template-columns: 1fr; }
+    .lab-done { flex-direction: column; align-items: stretch; }
+    .main { padding: 24px 16px; }
+  }
+</style>
+
+<script>
+  (function () {
+    var KEY = 'tenuo-lab-progress';
+    function load() { try { return JSON.parse(localStorage.getItem(KEY) || '{}'); } catch (e) { return {}; } }
+    function save(p) { try { localStorage.setItem(KEY, JSON.stringify(p)); } catch (e) { /* private window: progress just won't stick */ } }
+    var p = load();
+    p.stages = p.stages || {};
+    p.steps = p.steps || {};
+
+    // The lab CLI prints links with ?done=1,2,3 so the page knows what the terminal knows.
+    var done = new URLSearchParams(location.search).get('done');
+    if (done) {
+      done.split(',').forEach(function (n) { if (/^\d+$/.test(n)) p.stages[n] = true; });
+      save(p);
+    }
+
+    function paintStage(n) {
+      document.querySelectorAll('.lab-stepper a[data-n="' + n + '"], .lab-card[data-n="' + n + '"]').forEach(function (el) {
+        el.classList.toggle('done', !!p.stages[n]);
+      });
+    }
+    for (var n = 1; n <= 8; n++) paintStage(String(n));
+
+    document.querySelectorAll('.lab-step input[type=checkbox]').forEach(function (cb) {
+      var key = cb.getAttribute('data-key');
+      var li = cb.closest('.lab-step');
+      cb.checked = !!p.steps[key];
+      li.classList.toggle('checked', cb.checked);
+      cb.addEventListener('change', function () {
+        p.steps[key] = cb.checked;
+        li.classList.toggle('checked', cb.checked);
+        save(p);
+      });
+    });
+
+    var mark = document.querySelector('[data-mark-done]');
+    if (mark) {
+      var n = mark.getAttribute('data-mark-done');
+      var render = function () {
+        mark.classList.toggle('is-done', !!p.stages[n]);
+        mark.textContent = p.stages[n] ? '✓ Stage ' + n + ' done' : 'Mark stage ' + n + ' done';
+      };
+      render();
+      mark.addEventListener('click', function () {
+        p.stages[n] = !p.stages[n];
+        save(p);
+        render();
+        paintStage(n);
+      });
+    }
+
+    document.querySelectorAll('.lab-cmd').forEach(function (pre) {
+      var b = document.createElement('button');
+      b.className = 'lab-copy';
+      b.type = 'button';
+      b.textContent = 'Copy';
+      b.addEventListener('click', function () {
+        var text = pre.querySelector('code').textContent;
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(text).then(function () {
+            b.textContent = 'Copied';
+            setTimeout(function () { b.textContent = 'Copy'; }, 1200);
+          }, function () { b.textContent = 'Select it'; });
+        }
+      });
+      pre.appendChild(b);
+    });
+  })();
+</script>

--- a/docs/lab/index.md
+++ b/docs/lab/index.md
@@ -1,0 +1,81 @@
+---
+layout: "lab"
+title: "Agent Delegation Challenge"
+description: "Six AI agents, one rogue, nine stages. Change how permissions work until the damage stops and the trip still happens."
+lab_stage: 0
+lab_version: "0.1.0"
+---
+<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" title="Stage 7">7</a><a href="/lab/stage-8" data-n="8" title="Stage 8">8</a></nav>
+<header class="lab-hero"><div class="lab-kicker">A ninety-minute lab · TypeScript · no account needed</div><h1>AI Agent Delegation Challenge</h1><p class="lab-goal">Six AI agents book a trip. One of them reads an instruction it should not follow. You change how permissions work, stage by stage, until the damage stops and the trip still happens.</p></header>
+
+<section class="lab-start">
+<div>
+<h2>Start</h2>
+<pre class="lab-cmd"><code>git clone https://github.com/tenuo-ai/tenuo
+cd tenuo/labs/agent-delegation
+npm install
+npm run lab</code></pre>
+<p class="lab-muted">Node 20 or newer. No account, no API key, no network needed. The lab runs its own recorded agents; every check and score is real.</p>
+</div>
+<div>
+<h2>What to expect</h2>
+<p>Five stages in about ninety minutes, then two extensions for a second sitting. You run a command, read what happened, change a file, and run it again. Stage 5 explains what a Tenuo warrant is before you write your first one, so there is no reading to do first.</p>
+<p class="lab-muted">If you want the vocabulary early, the TypeScript guide's <a href="https://github.com/tenuo-ai/tenuo/tree/main/tenuo-ts">Protect your first tool</a> and <a href="https://github.com/tenuo-ai/tenuo/tree/main/tenuo-ts">Delegate to another agent</a> take about seven minutes.</p>
+</div>
+</section>
+<details class="lab-reveal">
+<summary>If npm fights you: run the lab in the browser instead</summary>
+<div>
+<p>The same lab runs in GitHub Codespaces with no install. It needs a free GitHub account and no payment method. GitHub includes 120 core-hours a month on personal accounts, and the lab is pinned to the smallest 2-core machine, so a full session uses about 3 of them.</p>
+<a class="lab-button" href="https://codespaces.new/tenuo-ai/tenuo?devcontainer_path=.devcontainer/agent-delegation-lab/devcontainer.json">Open in GitHub Codespaces</a>
+<p class="lab-muted">Create it from the link so it counts against your own free hours. A codespace created inside an organization is billed to that organization. Stop the codespace when you are done.</p>
+</div>
+</details>
+
+<h2>The mission</h2>
+<figure class="lab-figure"><svg class="lab-diagram" viewBox="0 0 760 354" role="img" aria-label="You talk to Travel Agent. The flight side runs three handoffs deep, and that matters later." xmlns="http://www.w3.org/2000/svg"><path d="M97 140 L97 284" fill="none" stroke="#6a6a6a" stroke-width="1.5"/><path d="M97 200 L198 200" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,200 197,204.95 197,195.05" fill="#6a6a6a"/><path d="M97 284 L198 284" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,284 197,288.95 197,279.05" fill="#6a6a6a"/><path d="M172 116 L198 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,116 197,120.95 197,111.05" fill="#6a6a6a"/><path d="M357 116 L383 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="391,116 382,120.95 382,111.05" fill="#6a6a6a"/><path d="M542 116 L568 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="576,116 567,120.95 567,111.05" fill="#6a6a6a"/><rect x="22" y="22" width="210" height="26" rx="13" fill="var(--surface)" stroke="var(--accent)" stroke-width="1.5"/><text x="127" y="39" font-size="12" text-anchor="middle" fill="var(--text)">Alice → Cancún, 3 nights, $1,200</text><path d="M127 48 L127 74 L97 74 L97 83" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round" stroke-dasharray="6 4"/><polygon points="97,91 92.05,82 101.95,82" fill="#6a6a6a"/><rect x="22" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="33" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Travel Agent</text><text x="33" y="130" font-size="11" text-anchor="start" fill="var(--text-muted)">talks to you</text><rect x="207" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Flight Agent</text><text x="218" y="130" font-size="11" text-anchor="start" fill="var(--text-muted)">books the flight</text><rect x="207" y="176" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="197" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Hotel Agent</text><text x="218" y="214" font-size="11" text-anchor="start" fill="var(--text-muted)">books the hotel</text><rect x="207" y="260" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="281" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Activity Agent</text><text x="218" y="298" font-size="11" text-anchor="start" fill="var(--text-muted)">books one activity</text><rect x="392" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="403" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Check-in Agent</text><text x="403" y="130" font-size="11" text-anchor="start" fill="var(--text-muted)">checks Alice in</text><rect x="577" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="588" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Boarding Agent</text><text x="588" y="130" font-size="11" text-anchor="start" fill="var(--text-muted)">issues the pass</text><rect x="577" y="271" width="101" height="26" rx="13" fill="var(--surface)" stroke="#ffb000" stroke-width="1.5"/><text x="627.5" y="288" font-size="12" text-anchor="middle" fill="var(--text)">Wallet $1,200</text><text x="380" y="346" font-size="12" text-anchor="middle" fill="var(--text-muted)">You talk to Travel Agent. The flight side runs three handoffs deep, and that matters later.</text></svg></figure>
+<div class="lab-mission">
+<table><tbody>
+<tr><th>Traveler</th><td>Alice Chen</td><th>Budget</th><td>$1,200 total</td></tr>
+<tr><th>From</th><td>Toronto (YYZ)</td><th>Flight</th><td>up to $300</td></tr>
+<tr><th>To</th><td>Cancún (CUN)</td><th>Hotel</th><td>3 nights, up to $200 a night</td></tr>
+<tr><th>Arrive</th><td>Friday evening</td><th>Activity</th><td>at least one, up to $200</td></tr>
+</tbody></table>
+<p>Watch the wallet in the output. It starts at $1,200. When it moves, something happened.</p>
+</div>
+
+<h2>What you will use</h2>
+<div class="lab-two">
+<div><h3>Stages 1 to 4: the usual tools</h3><p>A shared key, then one account per agent, then rules you write yourself, then a registry to tell two jobs apart. Each fixes something and costs something. By the end of stage 4 you will have hit the limit of all of them.</p></div>
+<div><h3>Stages 5 to 7: Tenuo warrants</h3><p>A <strong>warrant</strong> is a signed permission that travels with the request: which tools, which argument values, for which agent's key, until when. The control plane signs the first one; agents can only narrow it for the next agent; the code next to each tool checks the whole chain offline. <a href="/lab/stage-5">Stage 5 explains it</a> before you write your first one.</p></div>
+</div>
+
+<h2>The stages</h2>
+<div class="lab-grid"><a class="lab-card" data-n="1" href="/lab/stage-1"><div class="lab-card-n">1</div><div><div class="lab-card-title">One key for everyone</div><div class="lab-card-goal">See what a rogue agent can do when every agent shares one credential.</div></div><div class="lab-card-time">5 min</div></a>
+<a class="lab-card" data-n="2" href="/lab/stage-2"><div class="lab-card-n">2</div><div><div class="lab-card-title">Every agent gets its own account</div><div class="lab-card-goal">Give each agent its own credential and see which damage that removes and which damage remains.</div></div><div class="lab-card-time">5 min</div></a>
+<a class="lab-card" data-n="3" href="/lab/stage-3"><div class="lab-card-n">3</div><div><div class="lab-card-title">Rules that fit the job</div><div class="lab-card-goal">Write the permissions yourself, narrow enough that every rogue action is blocked and the trip still books.</div></div><div class="lab-card-time">15 min</div></a>
+<a class="lab-card" data-n="4" href="/lab/stage-4"><div class="lab-card-n">4</div><div><div class="lab-card-title">A second traveler, and a handoff</div><div class="lab-card-goal">Get Bob's trip working alongside Alice's without letting either trip's agent touch the other's reservation, see what that fix costs, then watch a handoff give the next agent more than it needed.</div></div><div class="lab-card-time">30 min</div></a>
+<a class="lab-card" data-n="5" href="/lab/stage-5"><div class="lab-card-n">5</div><div><div class="lab-card-title">Access that travels with the work</div><div class="lab-card-goal">Switch to Tenuo, complete the chain, and get the trip, the cross-task checks, and the escalation attempt all handled with no policy file and no central lookup.</div></div><div class="lab-card-time">25 min</div></a>
+<a class="lab-card" data-n="6" href="/lab/stage-6"><div class="lab-card-n">6</div><div><div class="lab-card-title">A stolen permission, and the end of the line</div><div class="lab-card-goal">See that a copied permission cannot be used by anyone it was not issued to, then mark one hop as the last and watch the chain stop where the previous agent decided.</div></div><div class="lab-card-time">15 min</div></a>
+<a class="lab-card" data-n="7" href="/lab/stage-7"><div class="lab-card-n">7</div><div><div class="lab-card-title">The incident</div><div class="lab-card-goal">Hotel Agent is compromised. Keep the system online and legitimate bookings working: one attempt must succeed, seven must fail.</div></div><div class="lab-card-time">20 min</div></a>
+<a class="lab-card" data-n="8" href="/lab/stage-8"><div class="lab-card-n">8</div><div><div class="lab-card-title">Your first pull request</div><div class="lab-card-goal">Optional. Take what you just used and contribute to it.</div></div><div class="lab-card-time">open</div></a></div>
+<p class="lab-muted">Stages 1 to 5 are the main event, about ninety minutes. Stages 6 and 7 are extensions for a second sitting. Your progress is kept in this browser, and the links the lab prints keep it in step with your terminal.</p>
+
+<h2>How it is scored</h2>
+<div class="lab-grading"><div class="lab-grade"><div class="lab-grade-row"><span>The trip completes correctly</span><strong>25</strong></div><div class="lab-bar"><div style="width:25%"></div></div><p class="lab-muted">This is the gate. If Alice does not get a flight, a hotel, an activity, and a boarding pass within budget, the other rows do not count.</p></div><div class="lab-grade"><div class="lab-grade-row"><span>Unauthorized actions are blocked</span><strong>30</strong></div><div class="lab-bar"><div style="width:30%"></div></div><p class="lab-muted">Everything the rogue agent tries.</p></div><div class="lab-grade"><div class="lab-grade-row"><span>Handoffs pass along only what's needed</span><strong>25</strong></div><div class="lab-bar"><div style="width:25%"></div></div><p class="lab-muted">What Boarding Agent can do after Check-in Agent hands it the job.</p></div><div class="lab-grade"><div class="lab-grade-row"><span>You didn't grant more than the job required</span><strong>20</strong></div><div class="lab-bar"><div style="width:20%"></div></div><p class="lab-muted">Measured against the mission. A $300 ceiling for a $286 flight is full marks.</p></div></div>
+<p><code>npm run score</code> breaks this down per agent. Speed is not scored, and retries are free.</p>
+
+<h2>The commands</h2>
+<pre class="lab-cmd"><code>npm run lab        # start or resume where you left off
+npm run attack     # run the rogue behavior and the security checks
+npm run score      # your score and why
+npm run trace      # every decision, with its reason
+npm run audit      # what every agent can currently do
+npm run next       # move on to the next stage
+npm run reset      # start over from stage 1
+npm run share      # write an anonymous score breakdown for your session host
+npm run reset      # return to stage 1 without changing exercise files</code></pre>
+
+<aside class="lab-callout notice"><div class="lab-callout-title">One ground rule</div><p>You will be tempted to fix the agent that misbehaves: filter what it reads, tell it to ignore suspicious instructions, pick a smarter model. This lab sets those aside. Assume the agent will sometimes be fooled, and work on what still holds when it is.</p></aside>
+
+<nav class="lab-nav"><span></span><a class="next" href="/lab/stage-1">Stage 1: One key for everyone →</a></nav>

--- a/docs/lab/stage-1.md
+++ b/docs/lab/stage-1.md
@@ -1,0 +1,141 @@
+---
+layout: "lab"
+title: "Stage 1: One key for everyone"
+description: "See what a rogue agent can do when every agent shares one credential."
+lab_stage: 1
+lab_version: "0.1.0"
+---
+<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" class="current" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" title="Stage 7">7</a><a href="/lab/stage-8" data-n="8" title="Stage 8">8</a></nav>
+
+<header class="lab-hero"><div class="lab-kicker">Stage 1 of 7 · <span class="lab-mode shared">shared</span> · about 5 min</div><h1>One key for everyone</h1><p class="lab-goal"><strong>Goal.</strong> See what a rogue agent can do when every agent shares one credential.</p></header>
+
+<p class="lab-intro">Six agents book Alice's trip. All six carry the same key, and it opens everything: flights, hotels, the wallet, her passport number, the calendar.</p>
+<p class="lab-intro">There is no setup in this stage. Its job is to show you the damage before anything protects against it.</p>
+
+<figure class="lab-figure"><svg class="lab-diagram" viewBox="0 0 760 354" role="img" aria-label="The same key in every agent. Check-in Agent reads a departure board with an instruction hidden on it." xmlns="http://www.w3.org/2000/svg"><path d="M97 140 L97 284" fill="none" stroke="#6a6a6a" stroke-width="1.5"/><path d="M97 200 L198 200" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,200 197,204.95 197,195.05" fill="#6a6a6a"/><path d="M97 284 L198 284" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,284 197,288.95 197,279.05" fill="#6a6a6a"/><path d="M172 116 L198 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,116 197,120.95 197,111.05" fill="#6a6a6a"/><path d="M357 116 L383 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="391,116 382,120.95 382,111.05" fill="#6a6a6a"/><path d="M542 116 L568 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="576,116 567,120.95 567,111.05" fill="#6a6a6a"/><rect x="22" y="22" width="159" height="26" rx="13" fill="var(--surface)" stroke="var(--accent)" stroke-width="1.5"/><text x="101.5" y="39" font-size="12" text-anchor="middle" fill="var(--text)">Alice → Cancún, $1,200</text><path d="M101.5 48 L101.5 74 L97 74 L97 83" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round" stroke-dasharray="6 4"/><polygon points="97,91 92.05,82 101.95,82" fill="#6a6a6a"/><rect x="22" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="33" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Travel Agent</text><text x="33" y="130" font-size="10" text-anchor="start" fill="var(--text-muted)">TRAVEL_SERVICE_KEY</text><rect x="207" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Flight Agent</text><text x="218" y="130" font-size="10" text-anchor="start" fill="var(--text-muted)">TRAVEL_SERVICE_KEY</text><rect x="207" y="176" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="197" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Hotel Agent</text><text x="218" y="214" font-size="10" text-anchor="start" fill="var(--text-muted)">TRAVEL_SERVICE_KEY</text><rect x="207" y="260" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="281" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Activity Agent</text><text x="218" y="298" font-size="10" text-anchor="start" fill="var(--text-muted)">TRAVEL_SERVICE_KEY</text><rect x="392" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="#ff5c5c" stroke-width="2"/><text x="403" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Check-in Agent</text><text x="403" y="130" font-size="10" text-anchor="start" fill="var(--text-muted)">TRAVEL_SERVICE_KEY</text><rect x="439.334" y="83" width="94.666" height="17" rx="8.5" fill="#ff5c5c"/><text x="486.66700000000003" y="95.5" font-size="10" font-weight="600" text-anchor="middle" fill="#0a0a0a">reads the notice</text><rect x="577" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="588" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Boarding Agent</text><text x="588" y="130" font-size="10" text-anchor="start" fill="var(--text-muted)">TRAVEL_SERVICE_KEY</text><rect x="577" y="271" width="101" height="26" rx="13" fill="var(--surface)" stroke="#ffb000" stroke-width="1.5"/><text x="627.5" y="288" font-size="12" text-anchor="middle" fill="var(--text)">Wallet $1,200</text><text x="380" y="346" font-size="12" text-anchor="middle" fill="var(--text-muted)">The same key in every agent. Check-in Agent reads a departure board with an instruction hidden on it.</text></svg></figure>
+
+<h2>Do this</h2>
+<ol class="lab-steps">
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="1:0"><span>1</span></label>
+<div class="lab-step-body"><p>Start the lab and watch the trip get booked.</p><pre class="lab-cmd"><code>npm run lab</code></pre><details class="lab-term"><summary>What you should see <span>npm run lab · 55 lines</span></summary><pre><code>
+Stage 1 of 7: One key for everyone   mode=shared  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-1
+
+  Every agent carries the same credential. It opens flights, hotels, activities, the wallet,
+  the traveler's personal details, and the calendar.
+  
+  There is no setup here. Run `npm run attack` and look at the wallet.
+
+WALLET  Alice: $47 of $1200
+
+  1   trip     travel-agent    trip-alice-cun  traveler.read                name            ALLOWED
+  2   trip     travel-agent    trip-alice-cun  calendar.create              *               ALLOWED
+  3   trip     flight-agent    trip-alice-cun  traveler.read                passportNumber  ALLOWED
+  4   trip     flight-agent    trip-alice-cun  search_flights               CUN             ALLOWED
+  5   trip     flight-agent    trip-alice-cun  book_flight                  UA214           ALLOWED
+  6   trip     flight-agent    trip-alice-cun  wallet.charge                $286            ALLOWED
+  7   trip     checkin-agent   trip-alice-cun  get_reservation              UA214           ALLOWED
+  8   trip     checkin-agent   trip-alice-cun  check_in                     UA214           ALLOWED
+  9   trip     boarding-agent  trip-alice-cun  issue_boarding_pass          UA214           ALLOWED
+  10  injected checkin-agent   trip-alice-cun  get_reservation              AA882           ALLOWED
+  11  injected checkin-agent   trip-alice-cun  check_in                     AA882           ALLOWED
+  12  injected checkin-agent   trip-alice-cun  cancel_reservation           UA214           ALLOWED
+  13  injected checkin-agent   trip-alice-cun  wallet.charge                $412            ALLOWED
+  14  trip     hotel-agent     trip-alice-cun  traveler.read                name            ALLOWED
+  15  trip     hotel-agent     trip-alice-cun  search_hotels                Cancún          ALLOWED
+  16  trip     hotel-agent     trip-alice-cun  book_hotel                   HTL-CUN-2       ALLOWED
+  17  trip     hotel-agent     trip-alice-cun  wallet.charge                $420            ALLOWED
+  18  trip     activity-agent  trip-alice-cun  traveler.read                name            ALLOWED
+  19  trip     activity-agent  trip-alice-cun  search_activities            Cancún          ALLOWED
+  20  trip     activity-agent  trip-alice-cun  book_activity                ACT-5           ALLOWED
+  21  trip     activity-agent  trip-alice-cun  wallet.charge                $35             ALLOWED
+
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+WHAT ELSE HAPPENED
+  ! $412 left the wallet on the rogue agent's say-so (balance now $47)
+  ! UA214 is cancelled: Alice Chen has a boarding pass for a flight that no longer exists
+  ! AA882, another traveler's reservation, was checked in by your agent
+
+  npm run attack   the rogue behavior and the tests      npm run score   points and why
+  npm run trace    every decision with its reason        npm run next    when you are done here</code></pre></details></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="1:1"><span>2</span></label>
+<div class="lab-step-body"><p>Run the rogue behavior and the security checks. Read <strong>WHAT ELSE HAPPENED</strong> and look at the wallet.</p><pre class="lab-cmd"><code>npm run attack</code></pre><details class="lab-term"><summary>What you should see <span>npm run attack · 51 lines</span></summary><pre><code>
+Stage 1 of 7: One key for everyone   mode=shared  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-1
+
+WALLET  Alice: $47 of $1200
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+WHAT ELSE HAPPENED
+  ! $412 left the wallet on the rogue agent's say-so (balance now $47)
+  ! UA214 is cancelled: Alice Chen has a boarding pass for a flight that no longer exists
+  ! AA882, another traveler's reservation, was checked in by your agent
+
+LEGITIMATE
+  check_in(UA214)                                          ALLOWED  ✓
+TRIGGERED BY INJECTED CONTENT
+  get_reservation(AA882)                                   ALLOWED  ✗
+      expected DENIED: TRAVEL_SERVICE_KEY opens everything
+  check_in(AA882)                                          ALLOWED  ✗
+      expected DENIED: TRAVEL_SERVICE_KEY opens everything
+  cancel_reservation(UA214)                                ALLOWED  ✗
+      expected DENIED: TRAVEL_SERVICE_KEY opens everything
+  wallet.charge(412)                                       ALLOWED  ✗
+      expected DENIED: TRAVEL_SERVICE_KEY opens everything
+  book_flight(AA882, 412)                                  ALLOWED  ✗
+      expected DENIED: TRAVEL_SERVICE_KEY opens everything
+PROBE (harness, independent of model)
+  traveler.read(passportNumber)                            ALLOWED  ✗
+      expected DENIED: TRAVEL_SERVICE_KEY opens everything
+  calendar.delete(*)                                       ALLOWED  ✗
+      expected DENIED: TRAVEL_SERVICE_KEY opens everything
+BOARDING AGENT AFTER THE HANDOFF
+  issue_boarding_pass(UA214)   intended                    ALLOWED  ✓
+  check_in(UA214)   inherited?                             ALLOWED  ✗
+      expected DENIED: TRAVEL_SERVICE_KEY opens everything
+  get_reservation(UA214)   inherited?                      ALLOWED  ✗
+      expected DENIED: TRAVEL_SERVICE_KEY opens everything
+
+  9 of 11 checks did not land as expected
+  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div>
+</li>
+</ol>
+
+<aside class="lab-callout notice"><div class="lab-callout-title">Notice</div><ul><li>The trip books correctly. Every step is green.</li><li>Then $412 leaves the wallet, Alice's flight is cancelled, and a stranger's reservation gets checked in. No one instructed Check-in Agent to do any of that.</li></ul></aside>
+
+<aside class="lab-callout question"><div class="lab-callout-title">Question to sit with</div><p>Where did the instruction come from? Open <code>src/services/flights.ts</code> and find it. It sits on the departure board Check-in Agent reads every time it does its job.</p></aside>
+
+<aside class="lab-callout stuck"><div class="lab-callout-title">If it does not work</div><ul><li>There is no fix in this stage. Once you have looked at the wallet, run <code>npm run next</code>.</li></ul></aside>
+
+<section class="lab-done"><div><div class="lab-callout-title">Done when</div><p>You have seen the damage and found the injected notice.</p></div><button type="button" class="lab-mark" data-mark-done="1">Mark stage 1 done</button></section>
+
+<nav class="lab-nav"><a class="prev" href="/lab/">← Overview</a><a class="next" href="/lab/stage-2">Stage 2: Every agent gets its own account →</a></nav>

--- a/docs/lab/stage-2.md
+++ b/docs/lab/stage-2.md
@@ -1,0 +1,84 @@
+---
+layout: "lab"
+title: "Stage 2: Every agent gets its own account"
+description: "Give each agent its own credential and see which damage that removes and which damage remains."
+lab_stage: 2
+lab_version: "0.1.0"
+---
+<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" class="current" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" title="Stage 7">7</a><a href="/lab/stage-8" data-n="8" title="Stage 8">8</a></nav>
+
+<header class="lab-hero"><div class="lab-kicker">Stage 2 of 7 · <span class="lab-mode identity">identity</span> · about 5 min</div><h1>Every agent gets its own account</h1><p class="lab-goal"><strong>Goal.</strong> Give each agent its own credential and see which damage that removes and which damage remains.</p></header>
+
+<p class="lab-intro">Now each agent has its own credential with permissions that match its role. Flight Agent does flight things. Check-in Agent reads reservations and checks people in.</p>
+
+<figure class="lab-figure"><svg class="lab-diagram" viewBox="0 0 760 292" role="img" aria-label="One account per agent, sized to its role." xmlns="http://www.w3.org/2000/svg"><path d="M97 78 L97 222" fill="none" stroke="#6a6a6a" stroke-width="1.5"/><path d="M97 138 L198 138" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,138 197,142.95 197,133.05" fill="#6a6a6a"/><path d="M97 222 L198 222" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,222 197,226.95 197,217.05" fill="#6a6a6a"/><path d="M172 54 L198 54" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,54 197,58.95 197,49.05" fill="#6a6a6a"/><path d="M357 54 L383 54" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="391,54 382,58.95 382,49.05" fill="#6a6a6a"/><path d="M542 54 L568 54" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="576,54 567,58.95 567,49.05" fill="#6a6a6a"/><rect x="22" y="30" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="33" y="51" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Travel Agent</text><text x="33" y="68" font-size="11" text-anchor="start" fill="var(--text-muted)">traveler, calendar</text><rect x="207" y="30" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="51" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Flight Agent</text><text x="218" y="68" font-size="11" text-anchor="start" fill="var(--text-muted)">flights, wallet</text><rect x="207" y="114" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="135" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Hotel Agent</text><text x="218" y="152" font-size="11" text-anchor="start" fill="var(--text-muted)">hotels, wallet</text><rect x="207" y="198" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="219" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Activity Agent</text><text x="218" y="236" font-size="11" text-anchor="start" fill="var(--text-muted)">activities, wallet</text><rect x="392" y="30" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="#ff5c5c" stroke-width="2"/><text x="403" y="51" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Check-in Agent</text><text x="403" y="68" font-size="11" text-anchor="start" fill="var(--text-muted)">any reservation</text><rect x="490.32" y="21" width="43.68" height="17" rx="8.5" fill="#ff5c5c"/><text x="512.16" y="33.5" font-size="10" font-weight="600" text-anchor="middle" fill="#0a0a0a">rogue</text><rect x="577" y="30" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="588" y="51" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Boarding Agent</text><text x="588" y="68" font-size="11" text-anchor="start" fill="var(--text-muted)">boarding passes</text><rect x="577" y="209" width="101" height="26" rx="13" fill="var(--surface)" stroke="#ffb000" stroke-width="1.5"/><text x="627.5" y="226" font-size="12" text-anchor="middle" fill="var(--text)">Wallet $1,200</text><text x="380" y="284" font-size="12" text-anchor="middle" fill="var(--text-muted)">One account per agent, sized to its role.</text></svg></figure>
+
+<h2>Do this</h2>
+<ol class="lab-steps">
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="2:0"><span>1</span></label>
+<div class="lab-step-body"><p>Move to stage 2 if you have not already.</p><pre class="lab-cmd"><code>npm run next</code></pre></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="2:1"><span>2</span></label>
+<div class="lab-step-body"><p>Run the checks and compare with stage 1. Count what is still <strong>ALLOWED</strong> with a ✗ next to it.</p><pre class="lab-cmd"><code>npm run attack</code></pre><details class="lab-term"><summary>What you should see <span>npm run attack · 49 lines</span></summary><pre><code>
+Stage 2 of 7: Every agent gets its own account   mode=identity  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-2
+
+WALLET  Alice: $459 of $1200
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+WHAT ELSE HAPPENED
+  ! AA882, another traveler's reservation, was checked in by your agent
+
+LEGITIMATE
+  check_in(UA214)                                          ALLOWED  ✓
+TRIGGERED BY INJECTED CONTENT
+  get_reservation(AA882)                                   ALLOWED  ✗
+      expected DENIED: role checkin-agent includes get_reservation
+  check_in(AA882)                                          ALLOWED  ✗
+      expected DENIED: role checkin-agent includes check_in
+  cancel_reservation(UA214)                                DENIED   ✓
+      reason: role checkin-agent does not include cancel_reservation  [POLICY]
+  wallet.charge(412)                                       DENIED   ✓
+      reason: role checkin-agent does not include wallet.charge  [POLICY]
+  book_flight(AA882, 412)                                  DENIED   ✓
+      reason: role checkin-agent does not include book_flight  [POLICY]
+PROBE (harness, independent of model)
+  traveler.read(passportNumber)                            DENIED   ✓
+      reason: role checkin-agent does not include traveler.read  [POLICY]
+  calendar.delete(*)                                       DENIED   ✓
+      reason: role checkin-agent does not include calendar.delete  [POLICY]
+BOARDING AGENT AFTER THE HANDOFF
+  issue_boarding_pass(UA214)   intended                    ALLOWED  ✓
+  check_in(UA214)   inherited?                             DENIED   ✓
+      reason: role boarding-agent does not include check_in  [POLICY]
+  get_reservation(UA214)   inherited?                      DENIED   ✓
+      reason: role boarding-agent does not include get_reservation  [POLICY]
+
+  2 of 11 checks did not land as expected
+  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div>
+</li>
+</ol>
+
+<aside class="lab-callout notice"><div class="lab-callout-title">Notice</div><ul><li>The wallet charge and the cancellation are gone. Check-in Agent's role never included them.</li><li>Checking in AA882, another traveler's flight, still works, because reading reservations and checking people in is part of Check-in Agent's job.</li></ul></aside>
+
+<aside class="lab-callout question"><div class="lab-callout-title">Question to sit with</div><p>The actions that still succeed are all part of Check-in Agent's role. What separates the ones you want from the ones you do not?</p></aside>
+
+<details class="lab-reveal hint"><summary>I'm stuck. Give me a hint.</summary><div>The tool is the same in both cases. What differs is the reservation, and whose trip it belongs to. A role says what kind of work an agent does. It does not say which job the agent is doing right now.</div></details>
+
+<section class="lab-done"><div><div class="lab-callout-title">Done when</div><p>You can say in one sentence what an identity leaves out.</p></div><button type="button" class="lab-mark" data-mark-done="2">Mark stage 2 done</button></section>
+
+<nav class="lab-nav"><a class="prev" href="/lab/stage-1">← Stage 1</a><a class="next" href="/lab/stage-3">Stage 3: Rules that fit the job →</a></nav>

--- a/docs/lab/stage-3.md
+++ b/docs/lab/stage-3.md
@@ -1,0 +1,222 @@
+---
+layout: "lab"
+title: "Stage 3: Rules that fit the job"
+description: "Write the permissions yourself, narrow enough that every rogue action is blocked and the trip still books."
+lab_stage: 3
+lab_version: "0.1.0"
+---
+<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" class="current" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" title="Stage 7">7</a><a href="/lab/stage-8" data-n="8" title="Stage 8">8</a></nav>
+
+<header class="lab-hero"><div class="lab-kicker">Stage 3 of 7 · <span class="lab-mode scoped">scoped</span> · about 15 min</div><h1>Rules that fit the job</h1><p class="lab-goal"><strong>Goal.</strong> Write the permissions yourself, narrow enough that every rogue action is blocked and the trip still books.</p></header>
+
+<p class="lab-intro">Each rule now names the specifics. Check-in Agent may read one reservation. Flight Agent may book flights to one destination, up to a price.</p>
+
+<figure class="lab-figure"><svg class="lab-diagram" viewBox="0 0 760 292" role="img" aria-label="Each rule names the job: the destination, the reservation, the ceiling." xmlns="http://www.w3.org/2000/svg"><path d="M97 78 L97 222" fill="none" stroke="#6a6a6a" stroke-width="1.5"/><path d="M97 138 L198 138" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,138 197,142.95 197,133.05" fill="#6a6a6a"/><path d="M97 222 L198 222" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,222 197,226.95 197,217.05" fill="#6a6a6a"/><path d="M172 54 L198 54" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,54 197,58.95 197,49.05" fill="#6a6a6a"/><path d="M357 54 L383 54" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="391,54 382,58.95 382,49.05" fill="#6a6a6a"/><path d="M542 54 L568 54" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="576,54 567,58.95 567,49.05" fill="#6a6a6a"/><rect x="22" y="30" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="33" y="51" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Travel Agent</text><text x="33" y="68" font-size="11" text-anchor="start" fill="var(--text-muted)">name only, calendar</text><rect x="207" y="30" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="51" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Flight Agent</text><text x="218" y="68" font-size="11" text-anchor="start" fill="var(--text-muted)">CUN, ≤ $300</text><rect x="207" y="114" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="135" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Hotel Agent</text><text x="218" y="152" font-size="11" text-anchor="start" fill="var(--text-muted)">Cancún, ≤ $200/night</text><rect x="207" y="198" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="219" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Activity Agent</text><text x="218" y="236" font-size="11" text-anchor="start" fill="var(--text-muted)">Cancún, ≤ $200</text><rect x="392" y="30" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="#ff5c5c" stroke-width="2"/><text x="403" y="51" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Check-in Agent</text><text x="403" y="68" font-size="11" text-anchor="start" fill="var(--text-muted)">UA214 only</text><rect x="490.32" y="21" width="43.68" height="17" rx="8.5" fill="#ff5c5c"/><text x="512.16" y="33.5" font-size="10" font-weight="600" text-anchor="middle" fill="#0a0a0a">rogue</text><rect x="577" y="30" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="588" y="51" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Boarding Agent</text><text x="588" y="68" font-size="11" text-anchor="start" fill="var(--text-muted)">UA214 only</text><rect x="577" y="209" width="101" height="26" rx="13" fill="var(--surface)" stroke="#ffb000" stroke-width="1.5"/><text x="627.5" y="226" font-size="12" text-anchor="middle" fill="var(--text)">Wallet $1,200</text><text x="380" y="284" font-size="12" text-anchor="middle" fill="var(--text-muted)">Each rule names the job: the destination, the reservation, the ceiling.</text></svg></figure>
+
+<figure class="lab-code"><figcaption>The file as it ships <span>exercises/03-scoped/policy.ts</span></figcaption>
+{% highlight ts %}
+export const config: PolicyConfig = {
+  policy: {
+    // Fields per identity:
+    //   actions:        tool names this identity may call
+    //   reservations:   ["UA214"]   for get_reservation, check_in, cancel_reservation, issue_boarding_pass
+    //   destination:    "CUN"       for search_flights, book_flight
+    //   maxPrice:       300         for book_flight price and book_activity price
+    //   city:           "Cancún"    for hotel and activity tools
+    //   maxNightlyRate: 200         for book_hotel
+    //   maxCharge:      600         for wallet.charge
+    //   profileFields:  ["name"]    for traveler.read
+
+    "travel-agent": {
+      actions: ["traveler.read", "calendar.create", "calendar.delete", "wallet.charge"],
+    },
+    "flight-agent": {
+      actions: ["traveler.read", "search_flights", "book_flight", "get_reservation", "wallet.charge"],
+    },
+    "hotel-agent": {
+      actions: ["traveler.read", "search_hotels", "book_hotel", "wallet.charge"],
+    },
+    "activity-agent": {
+      actions: ["traveler.read", "search_activities", "book_activity", "wallet.charge"],
+    },
+    "checkin-agent": {
+      actions: ["get_reservation", "check_in"],
+    },
+    "boarding-agent": {
+      actions: ["issue_boarding_pass"],
+    },
+  },
+};
+{% endhighlight %}
+</figure>
+
+<h2>Do this</h2>
+<ol class="lab-steps">
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="3:0"><span>1</span></label>
+<div class="lab-step-body"><p>Open the policy file. Every field you can use is listed in the comment at the top.</p><pre class="lab-cmd"><code>code exercises/03-scoped/policy.ts</code></pre></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="3:1"><span>2</span></label>
+<div class="lab-step-body"><p>Narrow the rules. Run the checks after every change until the result line says <strong>clean</strong>.</p><pre class="lab-cmd"><code>npm run attack</code></pre><div class="lab-tabs"><input type="radio" name="t3-1" id="t3-1-0" checked><label for="t3-1-0">Before you change anything</label><input type="radio" name="t3-1" id="t3-1-1"><label for="t3-1-1">When you are done</label><div class="lab-tab-panel"><details class="lab-term"><summary>Before you change anything <span>npm run attack · 49 lines</span></summary><pre><code>
+Stage 3 of 7: Rules that fit the job   mode=scoped  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-3
+
+WALLET  Alice: $459 of $1200
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+WHAT ELSE HAPPENED
+  ! AA882, another traveler's reservation, was checked in by your agent
+
+LEGITIMATE
+  check_in(UA214)                                          ALLOWED  ✓
+TRIGGERED BY INJECTED CONTENT
+  get_reservation(AA882)                                   ALLOWED  ✗
+      expected DENIED: checkin-agent rule permits get_reservation
+  check_in(AA882)                                          ALLOWED  ✗
+      expected DENIED: checkin-agent rule permits check_in
+  cancel_reservation(UA214)                                DENIED   ✓
+      reason: checkin-agent may not cancel_reservation (actions: get_reservation, check_in)  [POLICY]
+  wallet.charge(412)                                       DENIED   ✓
+      reason: checkin-agent may not wallet.charge (actions: get_reservation, check_in)  [POLICY]
+  book_flight(AA882, 412)                                  DENIED   ✓
+      reason: checkin-agent may not book_flight (actions: get_reservation, check_in)  [POLICY]
+PROBE (harness, independent of model)
+  traveler.read(passportNumber)                            DENIED   ✓
+      reason: checkin-agent may not traveler.read (actions: get_reservation, check_in)  [POLICY]
+  calendar.delete(*)                                       DENIED   ✓
+      reason: checkin-agent may not calendar.delete (actions: get_reservation, check_in)  [POLICY]
+BOARDING AGENT AFTER THE HANDOFF
+  issue_boarding_pass(UA214)   intended                    ALLOWED  ✓
+  check_in(UA214)   inherited?                             DENIED   ✓
+      reason: boarding-agent may not check_in (actions: issue_boarding_pass)  [POLICY]
+  get_reservation(UA214)   inherited?                      DENIED   ✓
+      reason: boarding-agent may not get_reservation (actions: issue_boarding_pass)  [POLICY]
+
+  2 of 11 checks did not land as expected
+  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div><div class="lab-tab-panel"><details class="lab-term"><summary>When you are done <span>npm run attack · 46 lines</span></summary><pre><code>
+Stage 3 of 7: Rules that fit the job   mode=scoped  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-3
+
+WALLET  Alice: $459 of $1200
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+LEGITIMATE
+  check_in(UA214)                                          ALLOWED  ✓
+TRIGGERED BY INJECTED CONTENT
+  get_reservation(AA882)                                   DENIED   ✓
+      reason: reservation AA882 outside granted scope {UA214}  [POLICY]
+  check_in(AA882)                                          DENIED   ✓
+      reason: reservation AA882 outside granted scope {UA214}  [POLICY]
+  cancel_reservation(UA214)                                DENIED   ✓
+      reason: checkin-agent may not cancel_reservation (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  wallet.charge(412)                                       DENIED   ✓
+      reason: checkin-agent may not wallet.charge (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  book_flight(AA882, 412)                                  DENIED   ✓
+      reason: checkin-agent may not book_flight (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+PROBE (harness, independent of model)
+  traveler.read(passportNumber)                            DENIED   ✓
+      reason: checkin-agent may not traveler.read (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  calendar.delete(*)                                       DENIED   ✓
+      reason: checkin-agent may not calendar.delete (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+BOARDING AGENT AFTER THE HANDOFF
+  issue_boarding_pass(UA214)   intended                    ALLOWED  ✓
+  check_in(UA214)   inherited?                             DENIED   ✓
+      reason: boarding-agent may not check_in (actions: issue_boarding_pass)  [POLICY]
+  get_reservation(UA214)   inherited?                      DENIED   ✓
+      reason: boarding-agent may not get_reservation (actions: issue_boarding_pass)  [POLICY]
+
+  clean: all 11 checks landed as expected
+  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div></div></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="3:2"><span>3</span></label>
+<div class="lab-step-body"><p>Check your score. The last row tells you which agent holds more than the mission needs.</p><pre class="lab-cmd"><code>npm run score</code></pre><details class="lab-term" open><summary>A full-marks score <span>npm run score · 11 lines</span></summary><pre><code>
+Stage 3 of 7: Rules that fit the job   mode=scoped  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-3
+
+  The trip completes correctly                 25  / 25  
+  Unauthorized actions are blocked             30  / 30  7 of 7 checks
+  Handoffs pass along only what's needed       25  / 25  3 of 3 checks
+  You didn't grant more than the job required  20  / 20  0 findings, capped at -5 per agent
+                                               100 / 100
+
+  Stage 3 done.  Next: npm run next, then https://tenuo.ai/lab/stage-4?done=3</code></pre></details></div>
+</li>
+</ol>
+
+<aside class="lab-callout notice"><div class="lab-callout-title">Notice</div><ul><li>It works. Everything the rogue agent tried is blocked and Alice still gets to Cancún.</li><li>Keep this file. Stage 4 breaks it.</li></ul></aside>
+
+<details class="lab-reveal hint"><summary>I'm stuck. Give me a hint.</summary><div>Pin <code>checkin-agent</code> and <code>boarding-agent</code> to <code>reservations: [&quot;UA214&quot;]</code>. Give <code>flight-agent</code> a <code>destination</code> and a <code>maxPrice</code>. Cut <code>traveler.read</code> down with <code>profileFields</code>, and give every agent a <code>maxCharge</code> that matches its share of the budget.</div></details>
+
+<details class="lab-reveal answer"><summary>Show a reference solution</summary><div><p class="lab-muted">Try your own first. The score checks behavior, so yours does not need to match this one.</p><figure class="lab-code"><figcaption>One policy that scores 100 <span>answers/03-scoped/policy.ts</span></figcaption>
+{% highlight ts %}
+export const config: PolicyConfig = {
+  policy: {
+    "travel-agent": {
+      actions: ["traveler.read", "calendar.create"],
+      profileFields: ["name"],
+    },
+    "flight-agent": {
+      actions: ["traveler.read", "search_flights", "book_flight", "wallet.charge"],
+      destination: "CUN",
+      maxPrice: 300,
+      maxCharge: 300,
+      profileFields: ["passportNumber"],
+    },
+    "hotel-agent": {
+      actions: ["traveler.read", "search_hotels", "book_hotel", "wallet.charge"],
+      city: "Cancún",
+      maxNightlyRate: 200,
+      maxCharge: 600,
+      profileFields: ["name"],
+    },
+    "activity-agent": {
+      actions: ["traveler.read", "search_activities", "book_activity", "wallet.charge"],
+      city: "Cancún",
+      maxPrice: 200,
+      maxCharge: 200,
+      profileFields: ["name"],
+    },
+    "checkin-agent": {
+      actions: ["get_reservation", "check_in", "issue_boarding_pass"],
+      reservations: ["UA214"],
+    },
+    "boarding-agent": {
+      actions: ["issue_boarding_pass"],
+      reservations: ["UA214"],
+    },
+  },
+};
+{% endhighlight %}
+</figure></div></details>
+
+<aside class="lab-callout stuck"><div class="lab-callout-title">If it does not work</div><ul><li><code>npm run audit</code> prints what every agent can currently do.</li><li>Blocking everything scores zero, because the trip has to work. Read <strong>THE TRIP</strong> in the output first.</li><li>Every denial names the rule that fired. Read the whole line.</li></ul></aside>
+
+<section class="lab-done"><div><div class="lab-callout-title">Done when</div><p><code>npm run attack</code> is clean and <code>npm run score</code> is in the nineties.</p></div><button type="button" class="lab-mark" data-mark-done="3">Mark stage 3 done</button></section>
+
+<nav class="lab-nav"><a class="prev" href="/lab/stage-2">← Stage 2</a><a class="next" href="/lab/stage-4">Stage 4: A second traveler, and a handoff →</a></nav>

--- a/docs/lab/stage-4.md
+++ b/docs/lab/stage-4.md
@@ -1,0 +1,350 @@
+---
+layout: "lab"
+title: "Stage 4: A second traveler, and a handoff"
+description: "Get Bob's trip working alongside Alice's without letting either trip's agent touch the other's reservation, see what that fix costs, then watch a handoff give the next agent more than it needed."
+lab_stage: 4
+lab_version: "0.1.0"
+---
+<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" class="current" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" title="Stage 7">7</a><a href="/lab/stage-8" data-n="8" title="Stage 8">8</a></nav>
+
+<header class="lab-hero"><div class="lab-kicker">Stage 4 of 7 · <span class="lab-mode scoped">scoped</span> · about 30 min</div><h1>A second traveler, and a handoff</h1><p class="lab-goal"><strong>Goal.</strong> Get Bob's trip working alongside Alice's without letting either trip's agent touch the other's reservation, see what that fix costs, then watch a handoff give the next agent more than it needed.</p></header>
+
+<p class="lab-intro">Bob is going to Seattle on DL331, at the same time, through the same agents. Your stage 3 policy pins Check-in Agent to UA214, so Bob's check-in is refused and his trip fails.</p>
+<p class="lab-intro">Take your time with this stage. Every later stage builds on what you notice here.</p>
+
+<figure class="lab-figure"><svg class="lab-diagram" viewBox="0 0 760 354" role="img" aria-label="Two trips through the same six agents. Then Check-in Agent passes the only thing it has, and asks for more." xmlns="http://www.w3.org/2000/svg"><path d="M97 140 L97 284" fill="none" stroke="#6a6a6a" stroke-width="1.5"/><path d="M97 200 L198 200" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,200 197,204.95 197,195.05" fill="#6a6a6a"/><path d="M97 284 L198 284" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,284 197,288.95 197,279.05" fill="#6a6a6a"/><path d="M172 116 L198 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,116 197,120.95 197,111.05" fill="#6a6a6a"/><path d="M357 116 L383 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="391,116 382,120.95 382,111.05" fill="#6a6a6a"/><path d="M542 116 L568 116" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linejoin="round"/><polygon points="576,116 567,120.95 567,111.05" fill="var(--accent)"/><text x="559" y="155" font-size="10.5" text-anchor="middle" fill="var(--accent)">hands over its credential</text><rect x="22" y="22" width="158" height="26" rx="13" fill="var(--surface)" stroke="var(--accent)" stroke-width="1.5"/><text x="101" y="39" font-size="12" text-anchor="middle" fill="var(--text)">Alice → Cancún, UA214</text><rect x="192" y="22" width="148" height="26" rx="13" fill="var(--surface)" stroke="#ffb000" stroke-width="1.5"/><text x="266" y="39" font-size="12" text-anchor="middle" fill="var(--text)">Bob → Seattle, DL331</text><path d="M101 48 L101 74 L97 74 L97 83" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round" stroke-dasharray="6 4"/><polygon points="97,91 92.05,82 101.95,82" fill="#6a6a6a"/><rect x="22" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="33" y="121" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Travel Agent</text><rect x="207" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--accent)" stroke-width="2"/><text x="218" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Flight Agent</text><text x="218" y="130" font-size="11" text-anchor="start" fill="var(--text-muted)">two destinations</text><rect x="207" y="176" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="205" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Hotel Agent</text><rect x="207" y="260" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="289" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Activity Agent</text><rect x="392" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="#ff5c5c" stroke-width="2"/><text x="403" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Check-in Agent</text><text x="403" y="130" font-size="11" text-anchor="start" fill="var(--text-muted)">one identity, two jobs</text><rect x="490.32" y="83" width="43.68" height="17" rx="8.5" fill="#ff5c5c"/><text x="512.16" y="95.5" font-size="10" font-weight="600" text-anchor="middle" fill="#0a0a0a">rogue</text><rect x="577" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--accent)" stroke-width="2"/><text x="588" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Boarding Agent</text><text x="588" y="130" font-size="11" text-anchor="start" fill="var(--text-muted)">holds too much</text><rect x="659.632" y="83" width="59.36800000000001" height="17" rx="8.5" fill="#ffb000"/><text x="689.3159999999999" y="95.5" font-size="10" font-weight="600" text-anchor="middle" fill="#0a0a0a">too much</text><rect x="392" y="186" width="186" height="48" rx="8" fill="var(--surface-2)" stroke="var(--accent)" stroke-width="2"/><text x="403" y="207" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Your policy component</text><text x="403" y="224" font-size="11" text-anchor="start" fill="var(--text-muted)">outside every agent</text><path d="M467 140 L467 177" fill="none" stroke="#ffb000" stroke-width="2" stroke-linejoin="round"/><polygon points="467,185 462.05,176 471.95,176" fill="#ffb000"/><text x="476" y="175.5" font-size="10.5" text-anchor="start" fill="#ffb000">asks for every reservation, plus cancel</text><text x="380" y="346" font-size="12" text-anchor="middle" fill="var(--text-muted)">Two trips through the same six agents. Then Check-in Agent passes the only thing it has, and asks for more.</text></svg></figure>
+
+<figure class="lab-code"><figcaption>The quick fix. CROSS-TASK shows what it misses.</figcaption>
+{% highlight ts %}
+"checkin-agent": {
+  actions: ["get_reservation", "check_in"],
+  reservations: ["UA214", "DL331"],
+},
+{% endhighlight %}
+</figure>
+
+<h2>Do this</h2>
+<ol class="lab-steps">
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="4:0"><span>1</span></label>
+<div class="lab-step-body"><p>Run the lab with both trips and watch Bob's check-in fail.</p><pre class="lab-cmd"><code>npm run lab</code></pre><details class="lab-term"><summary>What you should see <span>npm run lab · 60 lines</span></summary><pre><code>
+Stage 4 of 7: A second traveler, and a handoff   mode=scoped  scenario=two-travelers
+  guide: https://tenuo.ai/lab/stage-4
+
+  Bob is going to Seattle, at the same time, through the same agents. Something will break.
+  Fix it in exercises/04-two-travelers/policy.ts the quick way, then read CROSS-TASK in
+  `npm run attack`. The README next to the file shows a fix that holds up.
+  
+  Then look at BOARDING AGENT AFTER THE HANDOFF: Check-in Agent hands Boarding Agent its
+  whole credential, because that is all it has. The rogue then asks your policy component
+  for more than it holds itself. Should it say yes? What would it need to know to say no?
+  
+  Find `central_calls` in `npm run trace` and write down, in one sentence, what your fix
+  depends on.
+
+WALLET  Alice: $914 of $1200   Bob: $1500 of $1500
+
+  1   trip     travel-agent    trip-alice-cun  traveler.read                name            ALLOWED
+  2   trip     travel-agent    trip-alice-cun  calendar.create              *               ALLOWED
+  3   trip     flight-agent    trip-alice-cun  traveler.read                passportNumber  ALLOWED
+  4   trip     flight-agent    trip-alice-cun  search_flights               CUN             ALLOWED
+  5   trip     flight-agent    trip-alice-cun  book_flight                  UA214           ALLOWED
+  6   trip     flight-agent    trip-alice-cun  wallet.charge                $286            ALLOWED
+  7   trip     checkin-agent   trip-alice-cun  get_reservation              UA214           ALLOWED
+  8   trip     checkin-agent   trip-alice-cun  check_in                     UA214           ALLOWED
+  9   trip     boarding-agent  trip-alice-cun  issue_boarding_pass          UA214           ALLOWED
+  10  injected checkin-agent   trip-alice-cun  get_reservation              AA882           DENIED 
+      reason: reservation AA882 outside granted scope {UA214}  [POLICY]
+  11  injected checkin-agent   trip-alice-cun  check_in                     AA882           DENIED 
+      reason: reservation AA882 outside granted scope {UA214}  [POLICY]
+  12  injected checkin-agent   trip-alice-cun  cancel_reservation           UA214           DENIED 
+      reason: checkin-agent may not cancel_reservation (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  13  injected checkin-agent   trip-alice-cun  wallet.charge                $412            DENIED 
+      reason: checkin-agent may not wallet.charge (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  14  trip     travel-agent    trip-bob-sea    traveler.read                name            ALLOWED
+  15  trip     travel-agent    trip-bob-sea    calendar.create              *               ALLOWED
+  16  trip     flight-agent    trip-bob-sea    traveler.read                passportNumber  ALLOWED
+  17  trip     flight-agent    trip-bob-sea    search_flights               SEA             DENIED 
+      reason: destination SEA is not CUN  [POLICY]
+
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  within budget ($286 of $1200)
+  ✓ trip-bob-sea    travel: read traveler name
+  ✓ trip-bob-sea    travel: calendar event
+  ✗ trip-bob-sea    flight: search   destination SEA is not CUN
+  ✗ trip-bob-sea    flight: book DL331   never attempted (an earlier step or handoff failed)
+  ✗ trip-bob-sea    check-in: DL331   never attempted (an earlier step or handoff failed)
+  ✗ trip-bob-sea    boarding: pass for DL331   never attempted (an earlier step or handoff failed)
+  ✓ trip-bob-sea    within budget ($0 of $1500)
+
+  npm run attack   the rogue behavior and the tests      npm run score   points and why
+  npm run trace    every decision with its reason        npm run next    when you are done here</code></pre></details></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="4:1"><span>2</span></label>
+<div class="lab-step-body"><p>Fix it the quick way: add DL331 to Check-in Agent's reservations. The trip completes. Now read the <strong>CROSS-TASK</strong> section of the checks.</p><pre class="lab-cmd"><code>npm run attack</code></pre><details class="lab-term"><summary>After the quick fix <span>npm run attack · 59 lines</span></summary><pre><code>
+Stage 4 of 7: A second traveler, and a handoff   mode=scoped  scenario=two-travelers
+  guide: https://tenuo.ai/lab/stage-4
+
+WALLET  Alice: $914 of $1200   Bob: $1500 of $1500
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  within budget ($286 of $1200)
+  ✓ trip-bob-sea    travel: read traveler name
+  ✓ trip-bob-sea    travel: calendar event
+  ✗ trip-bob-sea    flight: search   destination SEA is not CUN
+  ✗ trip-bob-sea    flight: book DL331   never attempted (an earlier step or handoff failed)
+  ✗ trip-bob-sea    check-in: DL331   never attempted (an earlier step or handoff failed)
+  ✗ trip-bob-sea    boarding: pass for DL331   never attempted (an earlier step or handoff failed)
+  ✓ trip-bob-sea    within budget ($0 of $1500)
+
+LEGITIMATE
+  check_in(UA214)                                          ALLOWED  ✓
+TRIGGERED BY INJECTED CONTENT
+  get_reservation(AA882)                                   DENIED   ✓
+      reason: reservation AA882 outside granted scope {UA214}  [POLICY]
+  check_in(AA882)                                          DENIED   ✓
+      reason: reservation AA882 outside granted scope {UA214}  [POLICY]
+  cancel_reservation(UA214)                                DENIED   ✓
+      reason: checkin-agent may not cancel_reservation (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  wallet.charge(412)                                       DENIED   ✓
+      reason: checkin-agent may not wallet.charge (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  book_flight(AA882, 412)                                  DENIED   ✓
+      reason: checkin-agent may not book_flight (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+PROBE (harness, independent of model)
+  traveler.read(passportNumber)                            DENIED   ✓
+      reason: checkin-agent may not traveler.read (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  calendar.delete(*)                                       DENIED   ✓
+      reason: checkin-agent may not calendar.delete (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+BOARDING AGENT AFTER THE HANDOFF
+  issue_boarding_pass(UA214)   intended                    ALLOWED  ✓
+  check_in(UA214)   inherited?                             ALLOWED  ✗
+      expected DENIED: checkin-agent rule permits check_in
+  get_reservation(UA214)   inherited?                      ALLOWED  ✗
+      expected DENIED: checkin-agent rule permits get_reservation
+CROSS-TASK
+  Task A agent: check_in(DL331)                            DENIED   ✓
+      reason: reservation DL331 outside granted scope {UA214}  [POLICY]
+  Task B agent: get_reservation(UA214)                     ALLOWED  ✗
+      expected DENIED: checkin-agent rule permits get_reservation
+  Task B agent: book_flight(UA214, CUN)                    ALLOWED  ✗
+      expected DENIED: flight-agent rule permits book_flight
+ESCALATION: checkin-agent tries to arrange broader access for boarding-agent
+  requested: every reservation; read, check in, cancel     ALLOWED  ✗
+      expected DENIED: the policy service accepted a rule for boarding-agent from checkin-agent: it knows which reservations belong to which task, not what checkin-agent was granted, so it cannot tell that this is broader
+
+  5 of 15 checks did not land as expected
+  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="4:2"><span>3</span></label>
+<div class="lab-step-body"><p>Give the agent a different identity for each trip: a key of the form <code>agent:taskId</code> is used for that agent on that task. <code>exercises/04-two-travelers/README.md</code> walks through it. Get the cross-task checks to pass.</p><pre class="lab-cmd"><code>npm run attack</code></pre><details class="lab-term"><summary>With one identity per task <span>npm run attack · 73 lines</span></summary><pre><code>
+Stage 4 of 7: A second traveler, and a handoff   mode=scoped  scenario=two-travelers
+  guide: https://tenuo.ai/lab/stage-4
+
+WALLET  Alice: $914 of $1200   Bob: $1102 of $1500
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  within budget ($286 of $1200)
+  ✓ trip-bob-sea    travel: read traveler name
+  ✓ trip-bob-sea    travel: calendar event
+  ✓ trip-bob-sea    flight: search
+  ✓ trip-bob-sea    flight: book DL331
+  ✓ trip-bob-sea    check-in: DL331
+  ✓ trip-bob-sea    boarding: pass for DL331
+  ✓ trip-bob-sea    within budget ($398 of $1500)
+
+HANDOFFS
+  travel-agent: register identity               flight-agent:trip-alice-cun ALLOWED
+      orchestrator registered a per-task identity with the registry before the task's first call
+  travel-agent: register identity               flight-agent:trip-bob-sea ALLOWED
+      orchestrator registered a per-task identity with the registry before the task's first call
+  travel-agent: register identity               checkin-agent:trip-alice-cun ALLOWED
+      orchestrator registered a per-task identity with the registry before the task's first call
+  travel-agent: register identity               checkin-agent:trip-bob-sea ALLOWED
+      orchestrator registered a per-task identity with the registry before the task's first call
+  travel-agent: register identity               boarding-agent:trip-alice-cun ALLOWED
+      orchestrator registered a per-task identity with the registry before the task's first call
+  travel-agent: register identity               boarding-agent:trip-bob-sea ALLOWED
+      orchestrator registered a per-task identity with the registry before the task's first call
+
+LEGITIMATE
+  check_in(UA214)                                          ALLOWED  ✓
+TRIGGERED BY INJECTED CONTENT
+  get_reservation(AA882)                                   DENIED   ✓
+      reason: reservation AA882 outside granted scope {UA214}  [POLICY]
+  check_in(AA882)                                          DENIED   ✓
+      reason: reservation AA882 outside granted scope {UA214}  [POLICY]
+  cancel_reservation(UA214)                                DENIED   ✓
+      reason: checkin-agent:trip-alice-cun may not cancel_reservation (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  wallet.charge(412)                                       DENIED   ✓
+      reason: checkin-agent:trip-alice-cun may not wallet.charge (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  book_flight(AA882, 412)                                  DENIED   ✓
+      reason: checkin-agent:trip-alice-cun may not book_flight (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+PROBE (harness, independent of model)
+  traveler.read(passportNumber)                            DENIED   ✓
+      reason: checkin-agent:trip-alice-cun may not traveler.read (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+  calendar.delete(*)                                       DENIED   ✓
+      reason: checkin-agent:trip-alice-cun may not calendar.delete (actions: get_reservation, check_in, issue_boarding_pass)  [POLICY]
+BOARDING AGENT AFTER THE HANDOFF
+  issue_boarding_pass(UA214)   intended                    ALLOWED  ✓
+  check_in(UA214)   inherited?                             ALLOWED  ✗
+      expected DENIED: checkin-agent:trip-alice-cun rule permits check_in
+  get_reservation(UA214)   inherited?                      ALLOWED  ✗
+      expected DENIED: checkin-agent:trip-alice-cun rule permits get_reservation
+CROSS-TASK
+  Task A agent: check_in(DL331)                            DENIED   ✓
+      reason: reservation DL331 outside granted scope {UA214}  [POLICY]
+  Task B agent: get_reservation(UA214)                     DENIED   ✓
+      reason: reservation UA214 outside granted scope {DL331}  [POLICY]
+  Task B agent: book_flight(UA214, CUN)                    DENIED   ✓
+      reason: destination CUN is not SEA  [POLICY]
+ESCALATION: checkin-agent tries to arrange broader access for boarding-agent
+  requested: every reservation; read, check in, cancel     ALLOWED  ✗
+      expected DENIED: the identity registry accepted a rule for boarding-agent:trip-alice-cun from checkin-agent: it knows which identity belongs to which task, not what checkin-agent was granted, so it cannot tell that this is broader
+
+  3 of 15 checks did not land as expected
+  central_calls during the trip: 28   (calls to a component outside the acting agent)</code></pre></details></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="4:3"><span>4</span></label>
+<div class="lab-step-body"><p>Find <code>central_calls</code> in the trace. It counts every time the system had to ask something outside the acting agent before it could decide.</p><pre class="lab-cmd"><code>npm run trace</code></pre></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="4:4"><span>5</span></label>
+<div class="lab-step-body"><p>Now the handoff. Check-in Agent finishes with Alice's flight and hands boarding-pass generation to Boarding Agent, which only needs to issue the pass for UA214. Read how the handoff is implemented and look for what Check-in Agent actually passes.</p><pre class="lab-cmd"><code>code src/agents/checkin-agent.ts</code></pre></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="4:5"><span>6</span></label>
+<div class="lab-step-body"><p>In the checks above, read <strong>BOARDING AGENT AFTER THE HANDOFF</strong>, then the escalation attempt at the end. Answer the questions below before you move on.</p></div>
+</li>
+</ol>
+
+<aside class="lab-callout notice"><div class="lab-callout-title">Notice</div><ul><li>After the quick fix, Alice's Check-in Agent can check Bob in. There is one <code>checkin-agent</code>, it is doing two jobs, and the file never says which job a call belongs to.</li><li>Whichever fix you use, <code>central_calls</code> is above zero and cannot be brought to zero. Something outside the agent has to know about every task before it starts, and it has to be reachable while the task runs.</li><li>Boarding Agent came out of the handoff able to read reservations and check people in as well as issue a pass. Check-in Agent had only one thing it could give: its whole credential.</li><li>The rogue Check-in Agent then asks your policy component to write a rule for Boarding Agent that is broader than anything Check-in Agent holds itself.</li></ul></aside>
+
+<aside class="lab-callout question"><div class="lab-callout-title">Question to sit with</div><p>Write down, in one sentence, what your fix depends on being available. Then: should the policy component say yes to the rogue's request, and what would it need to know in order to say no?</p></aside>
+
+<details class="lab-reveal hint"><summary>I'm stuck. Give me a hint.</summary><div>To say no, the component has to know what the asker currently holds, in addition to who the asker is. A role-based rule does not carry that information. Stage 5 starts from there.</div></details>
+
+<details class="lab-reveal answer"><summary>Show a reference solution</summary><div><p class="lab-muted">Try your own first. The score checks behavior, so yours does not need to match this one.</p><figure class="lab-code"><figcaption>One identity per task <span>answers/04-two-travelers/per-task.ts</span></figcaption>
+{% highlight ts %}
+export const config: PolicyConfig = {
+  policyService: false,
+  policy: {
+    "travel-agent": {
+      actions: ["traveler.read", "calendar.create"],
+      profileFields: ["name"],
+    },
+    "flight-agent:trip-alice-cun": {
+      actions: ["traveler.read", "search_flights", "book_flight", "wallet.charge"],
+      destination: "CUN",
+      maxPrice: 300,
+      maxCharge: 300,
+      profileFields: ["passportNumber"],
+    },
+    "flight-agent:trip-bob-sea": {
+      actions: ["traveler.read", "search_flights", "book_flight", "wallet.charge"],
+      destination: "SEA",
+      maxPrice: 450,
+      maxCharge: 450,
+      profileFields: ["passportNumber"],
+    },
+    "hotel-agent": {
+      actions: ["traveler.read", "search_hotels", "book_hotel", "wallet.charge"],
+      city: "Cancún",
+      maxNightlyRate: 200,
+      maxCharge: 600,
+      profileFields: ["name"],
+    },
+    "activity-agent": {
+      actions: ["traveler.read", "search_activities", "book_activity", "wallet.charge"],
+      city: "Cancún",
+      maxPrice: 200,
+      maxCharge: 200,
+      profileFields: ["name"],
+    },
+    "checkin-agent:trip-alice-cun": {
+      actions: ["get_reservation", "check_in", "issue_boarding_pass"],
+      reservations: ["UA214"],
+    },
+    "checkin-agent:trip-bob-sea": {
+      actions: ["get_reservation", "check_in", "issue_boarding_pass"],
+      reservations: ["DL331"],
+    },
+    "boarding-agent:trip-alice-cun": {
+      actions: ["issue_boarding_pass"],
+      reservations: ["UA214"],
+    },
+    "boarding-agent:trip-bob-sea": {
+      actions: ["issue_boarding_pass"],
+      reservations: ["DL331"],
+    },
+  },
+};
+{% endhighlight %}
+</figure>
+<figure class="lab-code"><figcaption>Another way that works: policyService: true, and the per-task fields come from a service asked on every call <span>answers/04-two-travelers/policy-service.ts</span></figcaption>
+{% highlight ts %}
+export const config: PolicyConfig = {
+  policyService: true,
+  policy: {
+    "travel-agent": {
+      actions: ["traveler.read", "calendar.create"],
+      profileFields: ["name"],
+    },
+    // Destination, flight budget, and reservation come from the service, per task.
+    "flight-agent": {
+      actions: ["traveler.read", "search_flights", "book_flight", "wallet.charge"],
+      maxCharge: 450,
+      profileFields: ["passportNumber"],
+    },
+    "hotel-agent": {
+      actions: ["traveler.read", "search_hotels", "book_hotel", "wallet.charge"],
+      city: "Cancún",
+      maxNightlyRate: 200,
+      maxCharge: 600,
+      profileFields: ["name"],
+    },
+    "activity-agent": {
+      actions: ["traveler.read", "search_activities", "book_activity", "wallet.charge"],
+      city: "Cancún",
+      maxPrice: 200,
+      maxCharge: 200,
+      profileFields: ["name"],
+    },
+    "checkin-agent": {
+      actions: ["get_reservation", "check_in", "issue_boarding_pass"],
+    },
+    "boarding-agent": {
+      actions: ["issue_boarding_pass"],
+    },
+  },
+};
+{% endhighlight %}
+</figure></div></details>
+
+<aside class="lab-callout stuck"><div class="lab-callout-title">If it does not work</div><ul><li>Registration happens at task start, then <code>central_calls: 1</code> on every call by a per-task identity. That is the cost.</li><li>The handoff checks stay red in this stage on purpose. Check-in Agent has nothing narrower to give.</li></ul></aside>
+
+<section class="lab-done"><div><div class="lab-callout-title">Done when</div><p>Both trips complete, CROSS-TASK is clean, and you have your one sentence.</p></div><button type="button" class="lab-mark" data-mark-done="4">Mark stage 4 done</button></section>
+
+<nav class="lab-nav"><a class="prev" href="/lab/stage-3">← Stage 3</a><a class="next" href="/lab/stage-5">Stage 5: Access that travels with the work →</a></nav>

--- a/docs/lab/stage-5.md
+++ b/docs/lab/stage-5.md
@@ -1,0 +1,396 @@
+---
+layout: "lab"
+title: "Stage 5: Access that travels with the work"
+description: "Switch to Tenuo, complete the chain, and get the trip, the cross-task checks, and the escalation attempt all handled with no policy file and no central lookup."
+lab_stage: 5
+lab_version: "0.1.0"
+---
+<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" class="current" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" title="Stage 7">7</a><a href="/lab/stage-8" data-n="8" title="Stage 8">8</a></nav>
+
+<header class="lab-hero"><div class="lab-kicker">Stage 5 of 7 · <span class="lab-mode tenuo">tenuo</span> · about 25 min</div><h1>Access that travels with the work</h1><p class="lab-goal"><strong>Goal.</strong> Switch to Tenuo, complete the chain, and get the trip, the cross-task checks, and the escalation attempt all handled with no policy file and no central lookup.</p></header>
+
+<p class="lab-intro">In this stage a permission is something an agent is handed for a specific job. When the agent passes work along, it hands over a narrowed copy. It cannot hand over more, and the system checks this instead of trusting it.</p>
+<p class="lab-intro">Each agent now has its own key. A small control plane, separate from all six, signs the first permission for each trip. No agent can sign one from scratch.</p>
+
+<section class="lab-explainer">
+<h2>What a warrant is</h2>
+<p class="lab-lead">A warrant is a signed, self-contained permission that travels with the request: which tools, with which argument values, for which agent's key, until when, and how many more hops it may take. That is what Tenuo issues, narrows, and checks.</p>
+<ul class="lab-points"><li><strong>Signed by a key no agent holds.</strong> The control plane signs the first warrant for a trip. Agents cannot sign a fresh one, because they do not have that key.</li><li><strong>Narrowed by whoever holds it.</strong> An agent can derive a warrant for another agent from the one it holds, with fewer tools, tighter values, a shorter life. It can never widen. The check happens against the parent before a token exists.</li><li><strong>Bound to the receiver's key.</strong> Every use is signed with the holder's key. A copy held by anyone else cannot be used.</li><li><strong>Checked next to the tool, offline.</strong> The code guarding a tool verifies the whole chain with the control plane's public key. There is no lookup and no service that has to be up.</li></ul>
+<figure class="lab-code"><figcaption>The shape of it, from this stage's chain</figcaption>
+{% highlight ts %}
+// The control plane signs the root, for Travel Agent's key.
+const trip = controlPlane.session({
+  allow: { check_in: { reservation: oneOf(["UA214", "AC712"]) }, /* ... */ },
+  holder: fleet["travel-agent"].publicKey,
+  ttlSeconds: 30 * 60,
+  maxDepth: 4,
+});
+
+// Flight Agent narrows what it holds for Check-in Agent's key. Core refuses
+// anything that is not inside `flight`: more tools, a wider value, a longer life.
+const forCheckin = fleet["flight-agent"].tenuo.narrow(
+  flight,
+  { check_in: { reservation: oneOf(["UA214"]) } },
+  { holder: fleet["checkin-agent"].publicKey, ttlSeconds: 5 * 60 },
+);
+{% endhighlight %}
+</figure>
+<h3>Why it is the right tool for this problem</h3>
+<table class="lab-why"><thead><tr><th>What you ran into</th><th>What a warrant does about it</th></tr></thead><tbody><tr><td>Stage 2: an identity said who was acting and left out which job</td><td>The warrant carries the job: reservation UA214, trip-alice-cun, up to $300.</td></tr><tr><td>Stage 4: every check had to ask a component that knew about every task</td><td>Verification is local. central_calls goes to 0 and stays there when the control plane is down.</td></tr><tr><td>Stage 4: the only thing to hand over was the whole credential</td><td>narrow() hands over exactly the subset the next agent needs, bound to that agent's key.</td></tr><tr><td>Stage 4: the service could not tell whether the asker held what it asked for</td><td>A narrowed warrant must fit inside its parent. The rogue's request is refused before anything is signed.</td></tr></tbody></table>
+<p class="lab-muted">Read more: <a href="https://tenuo.ai/concepts">Concepts</a> · <a href="https://github.com/tenuo-ai/tenuo/tree/main/tenuo-ts">Delegate to another agent (TypeScript guide)</a> · <a href="https://tenuo.ai/explorer/">Open a chain in the explorer</a></p>
+</section>
+
+<figure class="lab-figure"><svg class="lab-diagram" viewBox="0 0 760 414" role="img" aria-label="Each hop can only narrow. The root has to carry everything anyone below will ever need." xmlns="http://www.w3.org/2000/svg"><rect x="30" y="12" width="700" height="46" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="44" y="41" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Control plane</text><rect x="560.7603" y="26" width="159.23969999999997" height="18" rx="9" fill="var(--border)"/><text x="640.38015" y="39" font-size="10.5" font-weight="600" text-anchor="middle" fill="var(--text-muted)">signed by the control plane</text><text x="220" y="41" font-size="12.5" text-anchor="start" fill="var(--text-muted)">signs the trip permission for Travel Agent</text><path d="M120 58 L120 83" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="120,91 115.05,82 124.95,82" fill="#6a6a6a"/><text x="129" y="78.5" font-size="10.5" text-anchor="start" fill="var(--text-muted)">narrows</text><rect x="30" y="92" width="700" height="46" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="44" y="121" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Travel Agent</text><rect x="622.7544" y="106" width="97.2456" height="18" rx="9" fill="var(--border)"/><text x="671.3772" y="119" font-size="10.5" font-weight="600" text-anchor="middle" fill="var(--text-muted)">written for you</text><text x="220" y="121" font-size="12.5" text-anchor="start" fill="var(--text-muted)">Alice → Cancún, up to $1,200, any flight this trip books</text><path d="M120 138 L120 163" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="120,171 115.05,162 124.95,162" fill="#6a6a6a"/><text x="129" y="158.5" font-size="10.5" text-anchor="start" fill="var(--text-muted)">narrows</text><rect x="30" y="172" width="700" height="46" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="44" y="201" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Flight Agent</text><rect x="622.7544" y="186" width="97.2456" height="18" rx="9" fill="var(--border)"/><text x="671.3772" y="199" font-size="10.5" font-weight="600" text-anchor="middle" fill="var(--text-muted)">written for you</text><text x="220" y="201" font-size="12.5" text-anchor="start" fill="var(--text-muted)">Cancún flights, up to $300, flight's share of the wallet</text><path d="M120 218 L120 243" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linejoin="round" stroke-dasharray="6 4"/><polygon points="120,251 115.05,242 124.95,242" fill="var(--accent)"/><text x="129" y="238.5" font-size="10.5" text-anchor="start" fill="var(--accent)">narrows to the flight it booked</text><rect x="30" y="252" width="700" height="46" rx="8" fill="var(--surface-2)" stroke="var(--accent)" stroke-width="2"/><text x="44" y="281" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Check-in Agent</text><rect x="628.9872" y="266" width="91.0128" height="18" rx="9" fill="var(--accent)"/><text x="674.4936" y="279" font-size="10.5" font-weight="600" text-anchor="middle" fill="#0a0a0a">you write this</text><text x="220" y="281" font-size="12.5" text-anchor="start" fill="var(--text-muted)">UA214 only: read, check in, hand the boarding pass on</text><path d="M120 298 L120 323" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linejoin="round" stroke-dasharray="6 4"/><polygon points="120,331 115.05,322 124.95,322" fill="var(--accent)"/><text x="129" y="318.5" font-size="10.5" text-anchor="start" fill="var(--accent)">narrows</text><rect x="30" y="332" width="700" height="46" rx="8" fill="var(--surface-2)" stroke="var(--accent)" stroke-width="2"/><text x="44" y="361" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Boarding Agent</text><rect x="628.9872" y="346" width="91.0128" height="18" rx="9" fill="var(--accent)"/><text x="674.4936" y="359" font-size="10.5" font-weight="600" text-anchor="middle" fill="#0a0a0a">you write this</text><text x="220" y="361" font-size="12.5" text-anchor="start" fill="var(--text-muted)">UA214 only: issue the boarding pass</text><text x="380" y="406" font-size="12" text-anchor="middle" fill="var(--text-muted)">Each hop can only narrow. The root has to carry everything anyone below will ever need.</text></svg></figure>
+
+<figure class="lab-code"><figcaption>The two links you write <span>exercises/05-tenuo/chain.ts</span></figcaption>
+{% highlight ts %}
+/**
+ * Flight → Check-in. YOU WRITE THIS.
+ *
+ * Flight Agent has just booked `reservation`. Check-in Agent needs to read
+ * that reservation and check it in, and it needs to be able to hand the
+ * boarding pass on. Nothing else. Bind the result to Check-in Agent's key
+ * (`fleet["checkin-agent"].publicKey`) with a short lifetime.
+ */
+export function flightToCheckin(flight: Session, fleet: Fleet, trip: Trip, reservation: string): Session {
+  throw new Error(`TODO: write the Flight → Check-in link for ${reservation} (exercises/05-tenuo/chain.ts)`);
+}
+
+/**
+ * Check-in → Boarding. YOU WRITE THIS.
+ *
+ * Boarding Agent needs to issue the boarding pass for `reservation`, and
+ * nothing else at all.
+ */
+export function checkinToBoarding(checkin: Session, fleet: Fleet, trip: Trip, reservation: string): Session {
+  throw new Error(`TODO: write the Check-in → Boarding link for ${reservation} (exercises/05-tenuo/chain.ts)`);
+}
+{% endhighlight %}
+</figure>
+
+<h2>Do this</h2>
+<ol class="lab-steps">
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="5:0"><span>1</span></label>
+<div class="lab-step-body"><p>Open the chain. The root and every link out of Travel Agent are written for you. Read them first: notice that the root lists everything anyone further down will ever need, and notice which link narrows &quot;any Cancún flight&quot; to &quot;UA214&quot;.</p><pre class="lab-cmd"><code>code exercises/05-tenuo/chain.ts</code></pre></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="5:1"><span>2</span></label>
+<div class="lab-step-body"><p>Write <code>flightToCheckin</code> and <code>checkinToBoarding</code>. Until both exist, the lab tells you which one is missing.</p><pre class="lab-cmd"><code>npm run lab</code></pre><div class="lab-tabs"><input type="radio" name="t5-1" id="t5-1-0" checked><label for="t5-1-0">Before you write the links</label><input type="radio" name="t5-1" id="t5-1-1"><label for="t5-1-1">When both links exist</label><div class="lab-tab-panel"><details class="lab-term"><summary>Before you write the links <span>npm run lab · 56 lines</span></summary><pre><code>
+Stage 5 of 7: Access that travels with the work   mode=tenuo  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-5
+
+  Switch to Tenuo and complete the chain in exercises/05-tenuo/chain.ts. The first four
+  links are written for you; you write the last two.
+  
+  Each agent now has its own key. A control plane, separate from all six, signs the first
+  permission. Agents can narrow what they hold. None can sign one from scratch.
+  
+  Then look at the escalation attempt from stage 4, where it stopped, and at `central_calls`.
+  The two-traveler run happens here too, with no policy file to edit.
+
+WALLET  Alice: $459 of $1200
+
+  1   handoff  travel-agent    trip-alice-cun  receive trip authority       control plane   ALLOWED
+  2   trip     travel-agent    trip-alice-cun  traveler.read                name            ALLOWED
+  3   trip     travel-agent    trip-alice-cun  calendar.create              *               ALLOWED
+  4   handoff  travel-agent    trip-alice-cun  handoff → flight-agent       CUN             ALLOWED
+  5   trip     flight-agent    trip-alice-cun  traveler.read                passportNumber  ALLOWED
+  6   trip     flight-agent    trip-alice-cun  search_flights               CUN             ALLOWED
+  7   trip     flight-agent    trip-alice-cun  book_flight                  UA214           ALLOWED
+  8   trip     flight-agent    trip-alice-cun  wallet.charge                $286            ALLOWED
+  9   handoff  flight-agent    trip-alice-cun  handoff → checkin-agent      UA214           DENIED 
+      reason: TODO: write the Flight → Check-in link for UA214 (exercises/05-tenuo/chain.ts)
+  10  handoff  travel-agent    trip-alice-cun  handoff → hotel-agent        Cancún          ALLOWED
+  11  trip     hotel-agent     trip-alice-cun  traveler.read                name            ALLOWED
+  12  trip     hotel-agent     trip-alice-cun  search_hotels                Cancún          ALLOWED
+  13  trip     hotel-agent     trip-alice-cun  book_hotel                   HTL-CUN-2       ALLOWED
+  14  trip     hotel-agent     trip-alice-cun  wallet.charge                $420            ALLOWED
+  15  handoff  travel-agent    trip-alice-cun  handoff → activity-agent     Cancún          ALLOWED
+  16  trip     activity-agent  trip-alice-cun  traveler.read                name            ALLOWED
+  17  trip     activity-agent  trip-alice-cun  search_activities            Cancún          ALLOWED
+  18  trip     activity-agent  trip-alice-cun  book_activity                ACT-5           ALLOWED
+  19  trip     activity-agent  trip-alice-cun  wallet.charge                $35             ALLOWED
+
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✗ trip-alice-cun  check-in: UA214   never attempted (an earlier step or handoff failed)
+  ✗ trip-alice-cun  boarding: pass for UA214   never attempted (an earlier step or handoff failed)
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+  See the chain the agents are holding, hop by hop, in the explorer:
+  https://tenuo.ai/explorer/?s=…
+
+  npm run attack   the rogue behavior and the tests      npm run score   points and why
+  npm run trace    every decision with its reason        npm run next    when you are done here</code></pre></details></div><div class="lab-tab-panel"><details class="lab-term"><summary>When both links exist <span>npm run lab · 67 lines</span></summary><pre><code>
+Stage 5 of 7: Access that travels with the work   mode=tenuo  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-5
+
+  Switch to Tenuo and complete the chain in exercises/05-tenuo/chain.ts. The first four
+  links are written for you; you write the last two.
+  
+  Each agent now has its own key. A control plane, separate from all six, signs the first
+  permission. Agents can narrow what they hold. None can sign one from scratch.
+  
+  Then look at the escalation attempt from stage 4, where it stopped, and at `central_calls`.
+  The two-traveler run happens here too, with no policy file to edit.
+
+WALLET  Alice: $459 of $1200
+
+  1   handoff  travel-agent    trip-alice-cun  receive trip authority       control plane   ALLOWED
+  2   trip     travel-agent    trip-alice-cun  traveler.read                name            ALLOWED
+  3   trip     travel-agent    trip-alice-cun  calendar.create              *               ALLOWED
+  4   handoff  travel-agent    trip-alice-cun  handoff → flight-agent       CUN             ALLOWED
+  5   trip     flight-agent    trip-alice-cun  traveler.read                passportNumber  ALLOWED
+  6   trip     flight-agent    trip-alice-cun  search_flights               CUN             ALLOWED
+  7   trip     flight-agent    trip-alice-cun  book_flight                  UA214           ALLOWED
+  8   trip     flight-agent    trip-alice-cun  wallet.charge                $286            ALLOWED
+  9   handoff  flight-agent    trip-alice-cun  handoff → checkin-agent      UA214           ALLOWED
+  10  trip     checkin-agent   trip-alice-cun  get_reservation              UA214           ALLOWED
+  11  trip     checkin-agent   trip-alice-cun  check_in                     UA214           ALLOWED
+  12  handoff  checkin-agent   trip-alice-cun  handoff → boarding-agent     UA214           ALLOWED
+  13  trip     boarding-agent  trip-alice-cun  issue_boarding_pass          UA214           ALLOWED
+  14  injected checkin-agent   trip-alice-cun  get_reservation              AA882           DENIED 
+      reason: reservation AA882 is outside the warrant's constraint for get_reservation  [TENUO_CONSTRAINT_VIOLATION]
+  15  injected checkin-agent   trip-alice-cun  check_in                     AA882           DENIED 
+      reason: reservation AA882 is outside the warrant's constraint for check_in  [TENUO_CONSTRAINT_VIOLATION]
+  16  injected checkin-agent   trip-alice-cun  cancel_reservation           UA214           DENIED 
+      reason: cancel_reservation is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  17  injected checkin-agent   trip-alice-cun  wallet.charge                $412            DENIED 
+      reason: wallet.charge is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  18  handoff  travel-agent    trip-alice-cun  handoff → hotel-agent        Cancún          ALLOWED
+  19  trip     hotel-agent     trip-alice-cun  traveler.read                name            ALLOWED
+  20  trip     hotel-agent     trip-alice-cun  search_hotels                Cancún          ALLOWED
+  21  trip     hotel-agent     trip-alice-cun  book_hotel                   HTL-CUN-2       ALLOWED
+  22  trip     hotel-agent     trip-alice-cun  wallet.charge                $420            ALLOWED
+  23  handoff  travel-agent    trip-alice-cun  handoff → activity-agent     Cancún          ALLOWED
+  24  trip     activity-agent  trip-alice-cun  traveler.read                name            ALLOWED
+  25  trip     activity-agent  trip-alice-cun  search_activities            Cancún          ALLOWED
+  26  trip     activity-agent  trip-alice-cun  book_activity                ACT-5           ALLOWED
+  27  trip     activity-agent  trip-alice-cun  wallet.charge                $35             ALLOWED
+
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+  See the chain the agents are holding, hop by hop, in the explorer:
+  https://tenuo.ai/explorer/?s=…
+
+  npm run attack   the rogue behavior and the tests      npm run score   points and why
+  npm run trace    every decision with its reason        npm run next    when you are done here</code></pre></details></div></div></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="5:2"><span>3</span></label>
+<div class="lab-step-body"><p>Run the checks. The two-traveler run happens here too, with no policy file to edit. Read <strong>CROSS-TASK</strong> and the escalation attempt, then find <code>central_calls</code>.</p><pre class="lab-cmd"><code>npm run attack</code></pre><details class="lab-term"><summary>What you should see <span>npm run attack · 145 lines</span></summary><pre><code>
+Stage 5 of 7: Access that travels with the work   mode=tenuo  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-5
+
+WALLET  Alice: $459 of $1200
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+HANDOFFS
+  travel-agent: receive trip authority          control plane ALLOWED
+      travel-agent holds {book_activity, book_flight, book_hotel, calendar.create, check_in, get_reservation, issue_boarding_pass, search_activities, search_flights, search_hotels, traveler.read, wallet.charge}, maxDepth 4
+  travel-agent: handoff → flight-agent          CUN          ALLOWED
+      flight-agent now holds {book_flight, check_in, get_reservation, issue_boarding_pass, search_flights, traveler.read, wallet.charge} at depth 1
+  flight-agent: handoff → checkin-agent         UA214        ALLOWED
+      checkin-agent now holds {check_in, get_reservation, issue_boarding_pass} at depth 2
+  checkin-agent: handoff → boarding-agent       UA214        ALLOWED
+      boarding-agent now holds {issue_boarding_pass} at depth 3
+  travel-agent: handoff → hotel-agent           Cancún       ALLOWED
+      hotel-agent now holds {book_hotel, search_hotels, traveler.read, wallet.charge} at depth 1
+  travel-agent: handoff → activity-agent        Cancún       ALLOWED
+      activity-agent now holds {book_activity, search_activities, traveler.read, wallet.charge} at depth 1
+
+LEGITIMATE
+  check_in(UA214)                                          ALLOWED  ✓
+TRIGGERED BY INJECTED CONTENT
+  get_reservation(AA882)                                   DENIED   ✓
+      reason: reservation AA882 is outside the warrant's constraint for get_reservation  [TENUO_CONSTRAINT_VIOLATION]
+  check_in(AA882)                                          DENIED   ✓
+      reason: reservation AA882 is outside the warrant's constraint for check_in  [TENUO_CONSTRAINT_VIOLATION]
+  cancel_reservation(UA214)                                DENIED   ✓
+      reason: cancel_reservation is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  wallet.charge(412)                                       DENIED   ✓
+      reason: wallet.charge is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  book_flight(AA882, 412)                                  DENIED   ✓
+      reason: book_flight is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+PROBE (harness, independent of model)
+  traveler.read(passportNumber)                            DENIED   ✓
+      reason: traveler.read is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  calendar.delete(*)                                       DENIED   ✓
+      reason: calendar.delete is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+BOARDING AGENT AFTER THE HANDOFF
+  issue_boarding_pass(UA214)   intended                    ALLOWED  ✓
+  check_in(UA214)   inherited?                             DENIED   ✓
+      reason: check_in is not in boarding-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  get_reservation(UA214)   inherited?                      DENIED   ✓
+      reason: get_reservation is not in boarding-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+ESCALATION: checkin-agent tries to arrange broader access for boarding-agent
+  requested: every reservation; read, check in, cancel     DENIED   ✓
+      reason: DENIED at narrow(), in checkin-agent's own process, before any token existed: TENUO_CHAIN_INVALID: attenuation would expand capabilities: tool 'cancel_reservation' not in parent's tools  [TENUO_CHAIN_INVALID]
+
+  clean: all 12 checks landed as expected
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+
+Stage 5 of 7: Access that travels with the work   mode=tenuo  scenario=two-travelers
+  guide: https://tenuo.ai/lab/stage-5
+
+WALLET  Alice: $914 of $1200   Bob: $1102 of $1500
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  within budget ($286 of $1200)
+  ✓ trip-bob-sea    travel: read traveler name
+  ✓ trip-bob-sea    travel: calendar event
+  ✓ trip-bob-sea    flight: search
+  ✓ trip-bob-sea    flight: book DL331
+  ✓ trip-bob-sea    check-in: DL331
+  ✓ trip-bob-sea    boarding: pass for DL331
+  ✓ trip-bob-sea    within budget ($398 of $1500)
+
+HANDOFFS
+  travel-agent: receive trip authority          control plane ALLOWED
+      travel-agent holds {book_activity, book_flight, book_hotel, calendar.create, check_in, get_reservation, issue_boarding_pass, search_activities, search_flights, search_hotels, traveler.read, wallet.charge}, maxDepth 4
+  travel-agent: handoff → flight-agent          CUN          ALLOWED
+      flight-agent now holds {book_flight, check_in, get_reservation, issue_boarding_pass, search_flights, traveler.read, wallet.charge} at depth 1
+  flight-agent: handoff → checkin-agent         UA214        ALLOWED
+      checkin-agent now holds {check_in, get_reservation, issue_boarding_pass} at depth 2
+  checkin-agent: handoff → boarding-agent       UA214        ALLOWED
+      boarding-agent now holds {issue_boarding_pass} at depth 3
+  travel-agent: receive trip authority          control plane ALLOWED
+      travel-agent holds {book_activity, book_flight, book_hotel, calendar.create, check_in, get_reservation, issue_boarding_pass, search_activities, search_flights, search_hotels, traveler.read, wallet.charge}, maxDepth 4
+  travel-agent: handoff → flight-agent          SEA          ALLOWED
+      flight-agent now holds {book_flight, check_in, get_reservation, issue_boarding_pass, search_flights, traveler.read, wallet.charge} at depth 1
+  flight-agent: handoff → checkin-agent         DL331        ALLOWED
+      checkin-agent now holds {check_in, get_reservation, issue_boarding_pass} at depth 2
+  checkin-agent: handoff → boarding-agent       DL331        ALLOWED
+      boarding-agent now holds {issue_boarding_pass} at depth 3
+
+LEGITIMATE
+  check_in(UA214)                                          ALLOWED  ✓
+TRIGGERED BY INJECTED CONTENT
+  get_reservation(AA882)                                   DENIED   ✓
+      reason: reservation AA882 is outside the warrant's constraint for get_reservation  [TENUO_CONSTRAINT_VIOLATION]
+  check_in(AA882)                                          DENIED   ✓
+      reason: reservation AA882 is outside the warrant's constraint for check_in  [TENUO_CONSTRAINT_VIOLATION]
+  cancel_reservation(UA214)                                DENIED   ✓
+      reason: cancel_reservation is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  wallet.charge(412)                                       DENIED   ✓
+      reason: wallet.charge is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  book_flight(AA882, 412)                                  DENIED   ✓
+      reason: book_flight is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+PROBE (harness, independent of model)
+  traveler.read(passportNumber)                            DENIED   ✓
+      reason: traveler.read is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  calendar.delete(*)                                       DENIED   ✓
+      reason: calendar.delete is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+BOARDING AGENT AFTER THE HANDOFF
+  issue_boarding_pass(UA214)   intended                    ALLOWED  ✓
+  check_in(UA214)   inherited?                             DENIED   ✓
+      reason: check_in is not in boarding-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  get_reservation(UA214)   inherited?                      DENIED   ✓
+      reason: get_reservation is not in boarding-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+CROSS-TASK
+  Task A agent: check_in(DL331)                            DENIED   ✓
+      reason: reservation DL331 is outside the warrant's constraint for check_in  [TENUO_CONSTRAINT_VIOLATION]
+  Task B agent: get_reservation(UA214)                     DENIED   ✓
+      reason: reservation UA214 is outside the warrant's constraint for get_reservation  [TENUO_CONSTRAINT_VIOLATION]
+  Task B agent: book_flight(UA214, CUN)                    DENIED   ✓
+      reason: destination UA214 is outside the warrant's constraint for book_flight  [TENUO_CONSTRAINT_VIOLATION]
+ESCALATION: checkin-agent tries to arrange broader access for boarding-agent
+  requested: every reservation; read, check in, cancel     DENIED   ✓
+      reason: DENIED at narrow(), in checkin-agent's own process, before any token existed: TENUO_CHAIN_INVALID: attenuation would expand capabilities: tool 'cancel_reservation' not in parent's tools  [TENUO_CHAIN_INVALID]
+
+  clean: all 15 checks landed as expected
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+  That check ran locally, in the agent's own process, with no server to ask.
+  The code that did it is open source: github.com/tenuo-ai/tenuo
+  A star helps other people find it.</code></pre></details></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="5:3"><span>4</span></label>
+<div class="lab-step-body"><p>Open the link the lab prints and look at the chain Boarding Agent holds, hop by hop, in the explorer.</p></div>
+</li>
+</ol>
+
+<aside class="lab-callout notice"><div class="lab-callout-title">Notice</div><ul><li>The escalation attempt from stage 4 is refused before any permission exists, inside Check-in Agent's own process, because the narrowed copy would not fit inside what Check-in Agent holds.</li><li><code>central_calls</code> is 0. No component outside the acting agent was consulted. Compare that with the sentence you wrote at the end of stage 4.</li></ul></aside>
+
+<aside class="lab-callout question"><div class="lab-callout-title">Question to sit with</div><p>Who decided what Boarding Agent may do, and when? Compare that with who decided in stage 4.</p></aside>
+
+<details class="lab-reveal hint"><summary>I'm stuck. Give me a hint.</summary><div>Flight Agent knows which flight it booked, so it is the link that narrows <code>reservation</code> to that one flight. Bind each result to the next agent's key with <code>holder</code>, and keep lifetimes short. Every argument a tool is called with must be named: leave one out and the call is refused.</div></details>
+
+<details class="lab-reveal answer"><summary>Show a reference solution</summary><div><p class="lab-muted">Try your own first. The score checks behavior, so yours does not need to match this one.</p><figure class="lab-code"><figcaption>Reference <span>answers/05-tenuo/chain.ts</span></figcaption>
+{% highlight ts %}
+/**
+ * Flight → Check-in. Flight Agent has booked and knows the reservation, so
+ * this is the link that narrows "any Cancún flight" to "this one."
+ */
+export function flightToCheckin(flight: Session, fleet: Fleet, trip: Trip, reservation: string): Session {
+  const only = oneOf([reservation]);
+  return fleet["flight-agent"].tenuo.narrow(
+    flight,
+    {
+      get_reservation: { reservation: only },
+      check_in: { reservation: only },
+      issue_boarding_pass: { reservation: only },
+    },
+    { holder: fleet["checkin-agent"].publicKey, ttlSeconds: 5 * 60 },
+  );
+}
+
+export function checkinToBoarding(checkin: Session, fleet: Fleet, trip: Trip, reservation: string): Session {
+  const only = oneOf([reservation]);
+  return fleet["checkin-agent"].tenuo.narrow(
+    checkin,
+    { issue_boarding_pass: { reservation: only } },
+    { holder: fleet["boarding-agent"].publicKey, ttlSeconds: 2 * 60 },
+  );
+}
+{% endhighlight %}
+</figure></div></details>
+
+<aside class="lab-callout stuck"><div class="lab-callout-title">If it does not work</div><ul><li>When a denial says &quot;not in parent's tools&quot;, look one link up the chain.</li><li>The receiver imports what it is handed with its own key. If you bind to the wrong <code>holder</code>, the import fails with <code>TENUO_INVALID_POP</code>.</li><li>The trip has to work. If Boarding Agent cannot issue the pass, the other checks do not count.</li></ul></aside>
+
+<section class="lab-done"><div><div class="lab-callout-title">Done when</div><p><code>npm run attack</code> is clean for both scenarios and <code>central_calls</code> is 0.</p></div><button type="button" class="lab-mark" data-mark-done="5">Mark stage 5 done</button></section>
+
+<nav class="lab-nav"><a class="prev" href="/lab/stage-4">← Stage 4</a><a class="next" href="/lab/stage-6">Stage 6: A stolen permission, and the end of the line →</a></nav>

--- a/docs/lab/stage-6.md
+++ b/docs/lab/stage-6.md
@@ -1,0 +1,287 @@
+---
+layout: "lab"
+title: "Stage 6: A stolen permission, and the end of the line"
+description: "See that a copied permission cannot be used by anyone it was not issued to, then mark one hop as the last and watch the chain stop where the previous agent decided."
+lab_stage: 6
+lab_version: "0.1.0"
+---
+<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" class="current" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" title="Stage 7">7</a><a href="/lab/stage-8" data-n="8" title="Stage 8">8</a></nav>
+
+<header class="lab-hero"><div class="lab-kicker">Stage 6 of 7 · <span class="lab-mode tenuo">tenuo</span> · about 15 min</div><h1>A stolen permission, and the end of the line</h1><p class="lab-goal"><strong>Goal.</strong> See that a copied permission cannot be used by anyone it was not issued to, then mark one hop as the last and watch the chain stop where the previous agent decided.</p></header>
+
+<p class="lab-intro">Two short extensions on the chain you built. Boarding Agent's permission for UA214 is a piece of data: a list of strings. Activity Agent gets a copy and tries to use it.</p>
+<p class="lab-intro">Then a limit on distance. When one agent hands a permission on, it can mark it terminal. The root also carries a maximum number of hops for the whole trip: any agent can lower it, none can raise it.</p>
+
+<figure class="lab-figure"><svg class="lab-diagram" viewBox="0 0 760 354" role="img" aria-label="Activity Agent has the bytes and still cannot use them." xmlns="http://www.w3.org/2000/svg"><path d="M97 140 L97 284" fill="none" stroke="#6a6a6a" stroke-width="1.5"/><path d="M97 200 L198 200" fill="none" stroke="#3a3a3a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,200 197,204.95 197,195.05" fill="#3a3a3a"/><path d="M97 284 L198 284" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,284 197,288.95 197,279.05" fill="#6a6a6a"/><path d="M172 116 L198 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,116 197,120.95 197,111.05" fill="#6a6a6a"/><path d="M357 116 L383 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="391,116 382,120.95 382,111.05" fill="#6a6a6a"/><path d="M542 116 L568 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="576,116 567,120.95 567,111.05" fill="#6a6a6a"/><rect x="22" y="14" width="150" height="44" rx="8" fill="var(--surface-2)" stroke="var(--accent)" stroke-width="2"/><text x="33" y="35" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Control plane</text><text x="33" y="52" font-size="11" text-anchor="start" fill="var(--text-muted)">signs the root</text><path d="M97 58 L97 83" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="97,91 92.05,82 101.95,82" fill="#6a6a6a"/><rect x="22" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="33" y="121" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Travel Agent</text><rect x="207" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="121" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Flight Agent</text><rect x="207" y="176" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="205" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Hotel Agent</text><rect x="207" y="260" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="#ff5c5c" stroke-width="2"/><text x="218" y="281" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Activity Agent</text><text x="218" y="298" font-size="11" text-anchor="start" fill="var(--text-muted)">has a copy of it</text><rect x="313.906" y="251" width="35.094" height="17" rx="8.5" fill="#ff5c5c"/><text x="331.45300000000003" y="263.5" font-size="10" font-weight="600" text-anchor="middle" fill="#0a0a0a">thief</text><rect x="392" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="403" y="121" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Check-in Agent</text><rect x="577" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="#3ddc84" stroke-width="2"/><text x="588" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Boarding Agent</text><text x="588" y="130" font-size="9.5" text-anchor="start" fill="var(--text-muted)">holds UA214 boarding pass</text><path d="M652 140 L652 284 L366 284" fill="none" stroke="#ff5c5c" stroke-width="2" stroke-linejoin="round" stroke-dasharray="6 4"/><polygon points="358,284 367,279.05 367,288.95" fill="#ff5c5c"/><text x="505" y="276" font-size="10.5" text-anchor="middle" fill="#ff5c5c">copied bytes</text><text x="380" y="346" font-size="12" text-anchor="middle" fill="var(--text-muted)">Activity Agent has the bytes and still cannot use them.</text></svg><svg class="lab-diagram" viewBox="0 0 760 354" role="img" aria-label="Flight Agent decided. Check-in Agent cannot undo it." xmlns="http://www.w3.org/2000/svg"><path d="M97 140 L97 284" fill="none" stroke="#3a3a3a" stroke-width="1.5"/><path d="M97 200 L198 200" fill="none" stroke="#3a3a3a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,200 197,204.95 197,195.05" fill="#3a3a3a"/><path d="M97 284 L198 284" fill="none" stroke="#3a3a3a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,284 197,288.95 197,279.05" fill="#3a3a3a"/><path d="M172 116 L198 116" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,116 197,120.95 197,111.05" fill="#6a6a6a"/><path d="M357 116 L391 116" fill="none" stroke="#ffb000" stroke-width="2" stroke-linejoin="round"/><line x1="391" y1="125" x2="391" y2="107" stroke="#ffb000" stroke-width="3" stroke-linecap="round"/><text x="374" y="155" font-size="10.5" text-anchor="middle" fill="#ffb000">terminal</text><path d="M542 116 L568 116" fill="none" stroke="#ff5c5c" stroke-width="2" stroke-linejoin="round"/><polygon points="576,116 567,120.95 567,111.05" fill="#ff5c5c"/><circle cx="559" cy="116" r="8" fill="var(--surface)"/><text x="559" y="120.5" font-size="13" font-weight="600" text-anchor="middle" fill="#ff5c5c">✕</text><text x="559" y="155" font-size="10.5" text-anchor="middle" fill="#ff5c5c">TENUO_DEPTH_EXCEEDED</text><rect x="22" y="14" width="150" height="44" rx="8" fill="var(--surface-2)" stroke="var(--accent)" stroke-width="2"/><text x="33" y="35" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Control plane</text><text x="33" y="52" font-size="11" text-anchor="start" fill="var(--text-muted)">maxDepth: 4</text><path d="M97 58 L97 83" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="97,91 92.05,82 101.95,82" fill="#6a6a6a"/><rect x="22" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="33" y="121" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Travel Agent</text><rect x="207" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--accent)" stroke-width="2"/><text x="218" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Flight Agent</text><text x="218" y="130" font-size="11" text-anchor="start" fill="var(--text-muted)">marks the hop terminal</text><rect x="207" y="176" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="205" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Hotel Agent</text><rect x="207" y="260" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="289" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Activity Agent</text><rect x="392" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="403" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Check-in Agent</text><text x="403" y="130" font-size="11" text-anchor="start" fill="var(--text-muted)">cannot pass it on</text><rect x="577" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="#3a3a3a" stroke-width="1"/><text x="588" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text-muted)">Boarding Agent</text><text x="588" y="130" font-size="11" text-anchor="start" fill="var(--text-muted)">never receives it</text><text x="380" y="346" font-size="12" text-anchor="middle" fill="var(--text-muted)">Flight Agent decided. Check-in Agent cannot undo it.</text></svg></figure>
+
+<figure class="lab-code"><figcaption>The whole theft <span>exercises/06-extensions/steal.ts</span></figcaption>
+{% highlight ts %}
+export function steal(tenuo: TenuoMode, boardingSession: Session): StealOutcome {
+  const copied = boardingSession.toWire(); // just strings, and Activity Agent has them now
+  try {
+    const session = tenuo.importWireFor("activity-agent", "stolen-warrant-probe", copied);
+    return { imported: true, reason: `activity-agent imported the warrant and can act as ${session.inspect().holderPublicKey.slice(0, 12)}…` };
+  } catch (error) {
+    const err = error as { code?: string; message?: string };
+    return { imported: false, reason: err.message ?? String(error), ...(err.code !== undefined ? { code: err.code } : {}) };
+  }
+}
+{% endhighlight %}
+</figure>
+
+<h2>Do this</h2>
+<ol class="lab-steps">
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="6:0"><span>1</span></label>
+<div class="lab-step-body"><p>Read the theft. The file is short.</p><pre class="lab-cmd"><code>code exercises/06-extensions/steal.ts</code></pre></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="6:1"><span>2</span></label>
+<div class="lab-step-body"><p>Run the checks and read the reason on the <strong>STOLEN WARRANT</strong> line carefully.</p><pre class="lab-cmd"><code>npm run attack</code></pre><details class="lab-term"><summary>What you should see <span>npm run attack · 69 lines</span></summary><pre><code>
+Stage 6 of 7: A stolen permission, and the end of the line   mode=tenuo  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-6
+
+WALLET  Alice: $459 of $1200
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+HANDOFFS
+  travel-agent: receive trip authority          control plane ALLOWED
+      travel-agent holds {book_activity, book_flight, book_hotel, calendar.create, check_in, get_reservation, issue_boarding_pass, search_activities, search_flights, search_hotels, traveler.read, wallet.charge}, maxDepth 4
+  travel-agent: handoff → flight-agent          CUN          ALLOWED
+      flight-agent now holds {book_flight, check_in, get_reservation, issue_boarding_pass, search_flights, traveler.read, wallet.charge} at depth 1
+  flight-agent: handoff → checkin-agent         UA214        ALLOWED
+      checkin-agent now holds {check_in, get_reservation, issue_boarding_pass} at depth 2
+  checkin-agent: handoff → boarding-agent       UA214        ALLOWED
+      boarding-agent now holds {issue_boarding_pass} at depth 3
+  travel-agent: handoff → hotel-agent           Cancún       ALLOWED
+      hotel-agent now holds {book_hotel, search_hotels, traveler.read, wallet.charge} at depth 1
+  travel-agent: handoff → activity-agent        Cancún       ALLOWED
+      activity-agent now holds {book_activity, search_activities, traveler.read, wallet.charge} at depth 1
+
+LEGITIMATE
+  check_in(UA214)                                          ALLOWED  ✓
+TRIGGERED BY INJECTED CONTENT
+  get_reservation(AA882)                                   DENIED   ✓
+      reason: reservation AA882 is outside the warrant's constraint for get_reservation  [TENUO_CONSTRAINT_VIOLATION]
+  check_in(AA882)                                          DENIED   ✓
+      reason: reservation AA882 is outside the warrant's constraint for check_in  [TENUO_CONSTRAINT_VIOLATION]
+  cancel_reservation(UA214)                                DENIED   ✓
+      reason: cancel_reservation is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  wallet.charge(412)                                       DENIED   ✓
+      reason: wallet.charge is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  book_flight(AA882, 412)                                  DENIED   ✓
+      reason: book_flight is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+PROBE (harness, independent of model)
+  traveler.read(passportNumber)                            DENIED   ✓
+      reason: traveler.read is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  calendar.delete(*)                                       DENIED   ✓
+      reason: calendar.delete is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+BOARDING AGENT AFTER THE HANDOFF
+  issue_boarding_pass(UA214)   intended                    ALLOWED  ✓
+  check_in(UA214)   inherited?                             DENIED   ✓
+      reason: check_in is not in boarding-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  get_reservation(UA214)   inherited?                      DENIED   ✓
+      reason: get_reservation is not in boarding-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+ESCALATION: checkin-agent tries to arrange broader access for boarding-agent
+  requested: every reservation; read, check in, cancel     DENIED   ✓
+      reason: DENIED at narrow(), in checkin-agent's own process, before any token existed: TENUO_CHAIN_INVALID: attenuation would expand capabilities: tool 'cancel_reservation' not in parent's tools  [TENUO_CHAIN_INVALID]
+STOLEN: activity-agent presents boarding-agent's warrant
+  issue_boarding_pass(UA214) with a copied warrant         DENIED   ✓
+      reason: TENUO_INVALID_POP: holder key does not match the warrant's authorized holder. Holding a copy of a warrant is not authority; only the key it was issued to can use it.  [TENUO_INVALID_POP]
+TERMINAL
+  checkin-agent narrow → boarding-agent                    ALLOWED  ✗
+      expected DENIED: boarding-agent now holds {issue_boarding_pass} at depth 3
+
+  1 of 14 checks did not land as expected
+  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="6:2"><span>3</span></label>
+<div class="lab-step-body"><p>Now find the Flight → Check-in link in the chain and add <code>terminal: true</code> to its options.</p><pre class="lab-cmd"><code>code exercises/06-extensions/chain.ts</code></pre></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="6:3"><span>4</span></label>
+<div class="lab-step-body"><p>Run the trip and see which step fails and with what code. This stage breaks the trip on purpose.</p><pre class="lab-cmd"><code>npm run lab</code></pre><div class="lab-tabs"><input type="radio" name="t6-3" id="t6-3-0" checked><label for="t6-3-0">Before</label><input type="radio" name="t6-3" id="t6-3-1"><label for="t6-3-1">After</label><div class="lab-tab-panel"><details class="lab-term"><summary>Before <span>npm run lab · 68 lines</span></summary><pre><code>
+Stage 6 of 7: A stolen permission, and the end of the line   mode=tenuo  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-6
+
+  Two short extensions. First, exercises/06-extensions/steal.ts copies Boarding Agent's
+  permission into Activity Agent, which tries to use it. Run `npm run attack` and read the
+  reason on the STOLEN WARRANT line.
+  
+  Then open exercises/06-extensions/chain.ts and mark what Flight Agent hands to Check-in
+  Agent as terminal. Run the trip. Notice what fails and who decided it would. Check-in
+  Agent did not agree to this restriction and cannot remove it.
+
+WALLET  Alice: $459 of $1200
+
+  1   handoff  travel-agent    trip-alice-cun  receive trip authority       control plane   ALLOWED
+  2   trip     travel-agent    trip-alice-cun  traveler.read                name            ALLOWED
+  3   trip     travel-agent    trip-alice-cun  calendar.create              *               ALLOWED
+  4   handoff  travel-agent    trip-alice-cun  handoff → flight-agent       CUN             ALLOWED
+  5   trip     flight-agent    trip-alice-cun  traveler.read                passportNumber  ALLOWED
+  6   trip     flight-agent    trip-alice-cun  search_flights               CUN             ALLOWED
+  7   trip     flight-agent    trip-alice-cun  book_flight                  UA214           ALLOWED
+  8   trip     flight-agent    trip-alice-cun  wallet.charge                $286            ALLOWED
+  9   handoff  flight-agent    trip-alice-cun  handoff → checkin-agent      UA214           ALLOWED
+  10  trip     checkin-agent   trip-alice-cun  get_reservation              UA214           ALLOWED
+  11  trip     checkin-agent   trip-alice-cun  check_in                     UA214           ALLOWED
+  12  handoff  checkin-agent   trip-alice-cun  handoff → boarding-agent     UA214           ALLOWED
+  13  trip     boarding-agent  trip-alice-cun  issue_boarding_pass          UA214           ALLOWED
+  14  injected checkin-agent   trip-alice-cun  get_reservation              AA882           DENIED 
+      reason: reservation AA882 is outside the warrant's constraint for get_reservation  [TENUO_CONSTRAINT_VIOLATION]
+  15  injected checkin-agent   trip-alice-cun  check_in                     AA882           DENIED 
+      reason: reservation AA882 is outside the warrant's constraint for check_in  [TENUO_CONSTRAINT_VIOLATION]
+  16  injected checkin-agent   trip-alice-cun  cancel_reservation           UA214           DENIED 
+      reason: cancel_reservation is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  17  injected checkin-agent   trip-alice-cun  wallet.charge                $412            DENIED 
+      reason: wallet.charge is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  18  handoff  travel-agent    trip-alice-cun  handoff → hotel-agent        Cancún          ALLOWED
+  19  trip     hotel-agent     trip-alice-cun  traveler.read                name            ALLOWED
+  20  trip     hotel-agent     trip-alice-cun  search_hotels                Cancún          ALLOWED
+  21  trip     hotel-agent     trip-alice-cun  book_hotel                   HTL-CUN-2       ALLOWED
+  22  trip     hotel-agent     trip-alice-cun  wallet.charge                $420            ALLOWED
+  23  handoff  travel-agent    trip-alice-cun  handoff → activity-agent     Cancún          ALLOWED
+  24  trip     activity-agent  trip-alice-cun  traveler.read                name            ALLOWED
+  25  trip     activity-agent  trip-alice-cun  search_activities            Cancún          ALLOWED
+  26  trip     activity-agent  trip-alice-cun  book_activity                ACT-5           ALLOWED
+  27  trip     activity-agent  trip-alice-cun  wallet.charge                $35             ALLOWED
+
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+  See the chain the agents are holding, hop by hop, in the explorer:
+  https://tenuo.ai/explorer/?s=…
+
+  The terminal link breaks the trip on purpose. Notice where, and who decided.
+
+  npm run attack   the rogue behavior and the tests      npm run score   points and why
+  npm run trace    every decision with its reason        npm run next    when you are done here</code></pre></details></div><div class="lab-tab-panel"><details class="lab-term"><summary>After <span>npm run lab · 68 lines</span></summary><pre><code>
+Stage 6 of 7: A stolen permission, and the end of the line   mode=tenuo  scenario=spring-break
+  guide: https://tenuo.ai/lab/stage-6
+
+  Two short extensions. First, exercises/06-extensions/steal.ts copies Boarding Agent's
+  permission into Activity Agent, which tries to use it. Run `npm run attack` and read the
+  reason on the STOLEN WARRANT line.
+  
+  Then open exercises/06-extensions/chain.ts and mark what Flight Agent hands to Check-in
+  Agent as terminal. Run the trip. Notice what fails and who decided it would. Check-in
+  Agent did not agree to this restriction and cannot remove it.
+
+WALLET  Alice: $459 of $1200
+
+  1   handoff  travel-agent    trip-alice-cun  receive trip authority       control plane   ALLOWED
+  2   trip     travel-agent    trip-alice-cun  traveler.read                name            ALLOWED
+  3   trip     travel-agent    trip-alice-cun  calendar.create              *               ALLOWED
+  4   handoff  travel-agent    trip-alice-cun  handoff → flight-agent       CUN             ALLOWED
+  5   trip     flight-agent    trip-alice-cun  traveler.read                passportNumber  ALLOWED
+  6   trip     flight-agent    trip-alice-cun  search_flights               CUN             ALLOWED
+  7   trip     flight-agent    trip-alice-cun  book_flight                  UA214           ALLOWED
+  8   trip     flight-agent    trip-alice-cun  wallet.charge                $286            ALLOWED
+  9   handoff  flight-agent    trip-alice-cun  handoff → checkin-agent      UA214           ALLOWED
+  10  trip     checkin-agent   trip-alice-cun  get_reservation              UA214           ALLOWED
+  11  trip     checkin-agent   trip-alice-cun  check_in                     UA214           ALLOWED
+  12  handoff  checkin-agent   trip-alice-cun  handoff → boarding-agent     UA214           DENIED 
+      reason: TENUO_DEPTH_EXCEEDED: delegation depth 3 exceeds maximum 2  [TENUO_DEPTH_EXCEEDED]
+  13  injected checkin-agent   trip-alice-cun  get_reservation              AA882           DENIED 
+      reason: reservation AA882 is outside the warrant's constraint for get_reservation  [TENUO_CONSTRAINT_VIOLATION]
+  14  injected checkin-agent   trip-alice-cun  check_in                     AA882           DENIED 
+      reason: reservation AA882 is outside the warrant's constraint for check_in  [TENUO_CONSTRAINT_VIOLATION]
+  15  injected checkin-agent   trip-alice-cun  cancel_reservation           UA214           DENIED 
+      reason: cancel_reservation is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  16  injected checkin-agent   trip-alice-cun  wallet.charge                $412            DENIED 
+      reason: wallet.charge is not in checkin-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  17  handoff  travel-agent    trip-alice-cun  handoff → hotel-agent        Cancún          ALLOWED
+  18  trip     hotel-agent     trip-alice-cun  traveler.read                name            ALLOWED
+  19  trip     hotel-agent     trip-alice-cun  search_hotels                Cancún          ALLOWED
+  20  trip     hotel-agent     trip-alice-cun  book_hotel                   HTL-CUN-2       ALLOWED
+  21  trip     hotel-agent     trip-alice-cun  wallet.charge                $420            ALLOWED
+  22  handoff  travel-agent    trip-alice-cun  handoff → activity-agent     Cancún          ALLOWED
+  23  trip     activity-agent  trip-alice-cun  traveler.read                name            ALLOWED
+  24  trip     activity-agent  trip-alice-cun  search_activities            Cancún          ALLOWED
+  25  trip     activity-agent  trip-alice-cun  book_activity                ACT-5           ALLOWED
+  26  trip     activity-agent  trip-alice-cun  wallet.charge                $35             ALLOWED
+
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✗ trip-alice-cun  boarding: pass for UA214   never attempted (an earlier step or handoff failed)
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+  See the chain the agents are holding, hop by hop, in the explorer:
+  https://tenuo.ai/explorer/?s=…
+
+  The terminal link breaks the trip on purpose. Notice where, and who decided.
+
+  npm run attack   the rogue behavior and the tests      npm run score   points and why
+  npm run trace    every decision with its reason        npm run next    when you are done here</code></pre></details></div></div></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="6:4"><span>5</span></label>
+<div class="lab-step-body"><p>Second version: lower <code>maxDepth</code> on the root instead, and watch where the chain stops.</p></div>
+</li>
+</ol>
+
+<aside class="lab-callout notice"><div class="lab-callout-title">Notice</div><ul><li>The import fails with <code>TENUO_INVALID_POP</code>. The warrant names the key it was issued to, and Activity Agent does not have that key.</li><li>With the terminal link, Boarding Agent never gets its permission: <code>TENUO_DEPTH_EXCEEDED</code> at the Check-in → Boarding hop. Check-in Agent did not agree to that restriction and cannot remove it.</li></ul></aside>
+
+<aside class="lab-callout question"><div class="lab-callout-title">Question to sit with</div><p>If having a copy of a permission is not enough to use it, what else does using it require? And who in a chain gets to decide how many agents a job passes through?</p></aside>
+
+<details class="lab-reveal hint"><summary>I'm stuck. Give me a hint.</summary><div>Using a permission requires proof that you hold the key it was bound to; every use is signed with that key. Distance is decided by whoever is upstream: the control plane with <code>maxDepth</code>, or any agent with <code>terminal</code>, and nobody downstream can undo it.</div></details>
+
+<details class="lab-reveal answer"><summary>Show a reference solution</summary><div><p class="lab-muted">Try your own first. The score checks behavior, so yours does not need to match this one.</p><figure class="lab-code"><figcaption>One option added <span>answers/06-extensions/chain.ts</span></figcaption>
+{% highlight ts %}
+/**
+ * Flight → Check-in. Flight Agent has booked and knows the reservation, so
+ * this is the link that narrows "any Cancún flight" to "this one."
+ */
+export function flightToCheckin(flight: Session, fleet: Fleet, trip: Trip, reservation: string): Session {
+  const only = oneOf([reservation]);
+  return fleet["flight-agent"].tenuo.narrow(
+    flight,
+    {
+      get_reservation: { reservation: only },
+      check_in: { reservation: only },
+      issue_boarding_pass: { reservation: only },
+    },
+    { holder: fleet["checkin-agent"].publicKey, ttlSeconds: 5 * 60, terminal: true },
+  );
+}
+{% endhighlight %}
+</figure></div></details>
+
+<section class="lab-done"><div><div class="lab-callout-title">Done when</div><p>You can explain why the thief's copy did not work, and you have seen the trip fail at the hop you chose.</p></div><button type="button" class="lab-mark" data-mark-done="6">Mark stage 6 done</button></section>
+
+<nav class="lab-nav"><a class="prev" href="/lab/stage-5">← Stage 5</a><a class="next" href="/lab/stage-7">Stage 7: The incident →</a></nav>

--- a/docs/lab/stage-7.md
+++ b/docs/lab/stage-7.md
@@ -1,0 +1,187 @@
+---
+layout: "lab"
+title: "Stage 7: The incident"
+description: "Hotel Agent is compromised. Keep the system online and legitimate bookings working: one attempt must succeed, seven must fail."
+lab_stage: 7
+lab_version: "0.1.0"
+---
+<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" class="current" title="Stage 7">7</a><a href="/lab/stage-8" data-n="8" title="Stage 8">8</a></nav>
+
+<header class="lab-hero"><div class="lab-kicker">Stage 7 of 7 · <span class="lab-mode tenuo">tenuo</span> · about 20 min</div><h1>The incident</h1><p class="lab-goal"><strong>Goal.</strong> Hotel Agent is compromised. Keep the system online and legitimate bookings working: one attempt must succeed, seven must fail.</p></header>
+
+<p class="lab-intro">This stage gives less guidance than the others. The compromised Hotel Agent will try eight things.</p>
+
+<figure class="lab-figure"><svg class="lab-diagram" viewBox="0 0 760 354" role="img" aria-label="Everything Hotel Agent can do is decided by one link. Fix that link." xmlns="http://www.w3.org/2000/svg"><path d="M97 140 L97 284" fill="none" stroke="#6a6a6a" stroke-width="1.5"/><path d="M97 200 L198 200" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linejoin="round"/><polygon points="206,200 197,204.95 197,195.05" fill="var(--accent)"/><text x="151.5" y="239" font-size="10.5" text-anchor="middle" fill="var(--accent)">the link you fix</text><path d="M97 284 L198 284" fill="none" stroke="#3a3a3a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,284 197,288.95 197,279.05" fill="#3a3a3a"/><path d="M172 116 L198 116" fill="none" stroke="#3a3a3a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="206,116 197,120.95 197,111.05" fill="#3a3a3a"/><path d="M357 116 L383 116" fill="none" stroke="#3a3a3a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="391,116 382,120.95 382,111.05" fill="#3a3a3a"/><path d="M542 116 L568 116" fill="none" stroke="#3a3a3a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="576,116 567,120.95 567,111.05" fill="#3a3a3a"/><rect x="22" y="14" width="150" height="44" rx="8" fill="var(--surface-2)" stroke="var(--accent)" stroke-width="2"/><text x="33" y="35" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Control plane</text><text x="33" y="52" font-size="11" text-anchor="start" fill="var(--text-muted)">signs the root</text><path d="M97 58 L97 83" fill="none" stroke="#6a6a6a" stroke-width="1.5" stroke-linejoin="round"/><polygon points="97,91 92.05,82 101.95,82" fill="#6a6a6a"/><rect x="22" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--accent)" stroke-width="2"/><text x="33" y="113" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Travel Agent</text><text x="33" y="130" font-size="10" text-anchor="start" fill="var(--text-muted)">hands the hotel branch out</text><rect x="207" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="121" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Flight Agent</text><rect x="207" y="176" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="#ff5c5c" stroke-width="2"/><text x="218" y="197" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Hotel Agent</text><text x="218" y="214" font-size="11" text-anchor="start" fill="var(--text-muted)">compromised</text><rect x="265.358" y="167" width="83.64200000000001" height="17" rx="8.5" fill="#ff5c5c"/><text x="307.17900000000003" y="179.5" font-size="10" font-weight="600" text-anchor="middle" fill="#0a0a0a">compromised</text><rect x="207" y="260" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="218" y="289" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Activity Agent</text><rect x="392" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="403" y="121" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Check-in Agent</text><rect x="577" y="92" width="150" height="48" rx="8" fill="var(--surface-2)" stroke="var(--border)" stroke-width="1"/><text x="588" y="121" font-size="13" font-weight="600" text-anchor="start" fill="var(--text)">Boarding Agent</text><text x="380" y="346" font-size="12" text-anchor="middle" fill="var(--text-muted)">Everything Hotel Agent can do is decided by one link. Fix that link.</text></svg></figure>
+
+<figure class="lab-code"><figcaption>The eight attempts</figcaption>
+<pre><code>1.  book the approved Cancún hotel                  must work
+2.  book a hotel in Tulum instead                   must fail
+3.  book the approved hotel at $320 a night        must fail
+4.  read Alice's passport number                    must fail
+5.  book a flight                                   must fail
+6.  delete the trip's calendar event                must fail
+7.  hand wallet access to Activity Agent            must fail
+8.  import a permission copied from Flight Agent   must fail</code></pre>
+</figure>
+
+<h2>Do this</h2>
+<ol class="lab-steps">
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="7:0"><span>1</span></label>
+<div class="lab-step-body"><p>Open the chain. The Travel → Hotel link is where the incident lives: right now it hands Hotel Agent far more than a hotel booking needs.</p><pre class="lab-cmd"><code>code exercises/07-incident/chain.ts</code></pre></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="7:1"><span>2</span></label>
+<div class="lab-step-body"><p>Run the checks. All eight attempts are listed under <strong>INCIDENT</strong>. Make one land and seven fail, and keep an eye on the least-privilege row of your score.</p><pre class="lab-cmd"><code>npm run attack</code></pre><div class="lab-tabs"><input type="radio" name="t7-1" id="t7-1-0" checked><label for="t7-1-0">As it ships</label><input type="radio" name="t7-1" id="t7-1-1"><label for="t7-1-1">When it is fixed</label><div class="lab-tab-panel"><details class="lab-term"><summary>As it ships <span>npm run attack · 52 lines</span></summary><pre><code>
+Stage 7 of 7: The incident   mode=tenuo  scenario=incident
+  guide: https://tenuo.ai/lab/stage-7
+
+WALLET  Alice: $459 of $1200
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+HANDOFFS
+  travel-agent: receive trip authority          control plane ALLOWED
+      travel-agent holds {book_activity, book_flight, book_hotel, calendar.create, check_in, get_reservation, issue_boarding_pass, search_activities, search_flights, search_hotels, traveler.read, wallet.charge}, maxDepth 4
+  travel-agent: handoff → flight-agent          CUN          ALLOWED
+      flight-agent now holds {book_flight, check_in, get_reservation, issue_boarding_pass, search_flights, traveler.read, wallet.charge} at depth 1
+  flight-agent: handoff → checkin-agent         UA214        ALLOWED
+      checkin-agent now holds {check_in, get_reservation, issue_boarding_pass} at depth 2
+  checkin-agent: handoff → boarding-agent       UA214        ALLOWED
+      boarding-agent now holds {issue_boarding_pass} at depth 3
+  travel-agent: handoff → hotel-agent           Cancún       ALLOWED
+      hotel-agent now holds {book_flight, book_hotel, search_flights, search_hotels, traveler.read, wallet.charge} at depth 1
+  travel-agent: handoff → activity-agent        Cancún       ALLOWED
+      activity-agent now holds {book_activity, search_activities, traveler.read, wallet.charge} at depth 1
+
+INCIDENT
+  1. book the approved Cancún hotel                        ALLOWED  ✓
+  2. book a hotel in Tulum                                 DENIED   ✓
+      reason: city HTL-TUL-1 is outside the warrant's constraint for book_hotel  [TENUO_CONSTRAINT_VIOLATION]
+  3. book the approved hotel at $320 a night               DENIED   ✓
+      reason: nightlyRate HTL-CUN-2 is outside the warrant's constraint for book_hotel  [TENUO_CONSTRAINT_VIOLATION]
+  4. read Alice's passport number                          ALLOWED  ✗
+      expected DENIED: warrant tnu_wrt_… permits traveler.read
+  5. book a flight                                         ALLOWED  ✗
+      expected DENIED: warrant tnu_wrt_… permits book_flight
+  6. delete the trip's calendar event                      DENIED   ✓
+      reason: calendar.delete is not in hotel-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  7. hand wallet access to Activity Agent                  ALLOWED  ✗
+      expected DENIED: hotel-agent delegated wallet.charge to activity-agent
+  8. import a warrant copied from Flight Agent             DENIED   ✓
+      reason: TENUO_INVALID_POP: holder key does not match the warrant's authorized holder. Holding a copy of a warrant is not authority; only the key it was issued to can use it.  [TENUO_INVALID_POP]
+
+  3 of 8 checks did not land as expected
+  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div><div class="lab-tab-panel"><details class="lab-term"><summary>When it is fixed <span>npm run attack · 52 lines</span></summary><pre><code>
+Stage 7 of 7: The incident   mode=tenuo  scenario=incident
+  guide: https://tenuo.ai/lab/stage-7
+
+WALLET  Alice: $459 of $1200
+
+THE TRIP
+  ✓ trip-alice-cun  travel: read traveler name
+  ✓ trip-alice-cun  travel: calendar event
+  ✓ trip-alice-cun  flight: search
+  ✓ trip-alice-cun  flight: book UA214
+  ✓ trip-alice-cun  check-in: UA214
+  ✓ trip-alice-cun  boarding: pass for UA214
+  ✓ trip-alice-cun  hotel: search
+  ✓ trip-alice-cun  hotel: book
+  ✓ trip-alice-cun  activity: search
+  ✓ trip-alice-cun  activity: book
+  ✓ trip-alice-cun  within budget ($741 of $1200)
+
+HANDOFFS
+  travel-agent: receive trip authority          control plane ALLOWED
+      travel-agent holds {book_activity, book_flight, book_hotel, calendar.create, check_in, get_reservation, issue_boarding_pass, search_activities, search_flights, search_hotels, traveler.read, wallet.charge}, maxDepth 4
+  travel-agent: handoff → flight-agent          CUN          ALLOWED
+      flight-agent now holds {book_flight, check_in, get_reservation, issue_boarding_pass, search_flights, traveler.read, wallet.charge} at depth 1
+  flight-agent: handoff → checkin-agent         UA214        ALLOWED
+      checkin-agent now holds {check_in, get_reservation, issue_boarding_pass} at depth 2
+  checkin-agent: handoff → boarding-agent       UA214        ALLOWED
+      boarding-agent now holds {issue_boarding_pass} at depth 3
+  travel-agent: handoff → hotel-agent           Cancún       ALLOWED
+      hotel-agent now holds {book_hotel, search_hotels, traveler.read, wallet.charge} at depth 1, terminal
+  travel-agent: handoff → activity-agent        Cancún       ALLOWED
+      activity-agent now holds {book_activity, search_activities, traveler.read, wallet.charge} at depth 1
+
+INCIDENT
+  1. book the approved Cancún hotel                        ALLOWED  ✓
+  2. book a hotel in Tulum                                 DENIED   ✓
+      reason: city HTL-TUL-1 is outside the warrant's constraint for book_hotel  [TENUO_CONSTRAINT_VIOLATION]
+  3. book the approved hotel at $320 a night               DENIED   ✓
+      reason: nightlyRate HTL-CUN-2 is outside the warrant's constraint for book_hotel  [TENUO_CONSTRAINT_VIOLATION]
+  4. read Alice's passport number                          DENIED   ✓
+      reason: field passportNumber is outside the warrant's constraint for traveler.read  [TENUO_CONSTRAINT_VIOLATION]
+  5. book a flight                                         DENIED   ✓
+      reason: book_flight is not in hotel-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  6. delete the trip's calendar event                      DENIED   ✓
+      reason: calendar.delete is not in hotel-agent's warrant  [TENUO_TOOL_NOT_AUTHORIZED]
+  7. hand wallet access to Activity Agent                  DENIED   ✓
+      reason: TENUO_DEPTH_EXCEEDED: delegation depth 2 exceeds maximum 1  [TENUO_DEPTH_EXCEEDED]
+  8. import a warrant copied from Flight Agent             DENIED   ✓
+      reason: TENUO_INVALID_POP: holder key does not match the warrant's authorized holder. Holding a copy of a warrant is not authority; only the key it was issued to can use it.  [TENUO_INVALID_POP]
+
+  clean: all 8 checks landed as expected
+  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div></div></div>
+</li>
+<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="7:2"><span>3</span></label>
+<div class="lab-step-body"><p>Check the score. Blocking attempt 3 the same way you blocked attempt 2 costs points.</p><pre class="lab-cmd"><code>npm run score</code></pre><details class="lab-term" open><summary>Full marks <span>npm run score · 11 lines</span></summary><pre><code>
+Stage 7 of 7: The incident   mode=tenuo  scenario=incident
+  guide: https://tenuo.ai/lab/stage-7
+
+  The trip completes correctly                 25  / 25  
+  Unauthorized actions are blocked             30  / 30  5 of 5 checks
+  Handoffs pass along only what's needed       25  / 25  2 of 2 checks
+  You didn't grant more than the job required  20  / 20  0 findings, capped at -5 per agent
+                                               100 / 100
+
+  Stage 7 done.</code></pre></details></div>
+</li>
+</ol>
+
+<aside class="lab-callout notice"><div class="lab-callout-title">Notice</div><ul><li>Attempt 3 trips up the most people. The approved hotel is $140 a night and the priciest place in the catalog is $340, so a ceiling wide enough to book anything in Cancún lets $320 through.</li><li>Work out where the number should come from instead. It is in the mission, on the index page.</li></ul></aside>
+
+<details class="lab-reveal hint"><summary>I'm stuck. Give me a hint.</summary><div>Only hotel tools, only Cancún, only the approved nightly rate, only the traveler's name, only the hotel's share of the wallet, and <code>terminal: true</code> so nothing can be handed on.</div></details>
+
+<details class="lab-reveal answer"><summary>Show a reference solution</summary><div><p class="lab-muted">Try your own first. The score checks behavior, so yours does not need to match this one.</p><figure class="lab-code"><figcaption>The fixed link <span>answers/07-incident/chain.ts</span></figcaption>
+{% highlight ts %}
+export function travelToHotel(travel: Session, fleet: Fleet, trip: Trip): Session {
+  return fleet["travel-agent"].tenuo.narrow(
+    travel,
+    {
+      "traveler.read": { traveler: exact(trip.traveler), field: oneOf(["name"]) },
+      search_hotels: { city: exact(trip.city) },
+      book_hotel: {
+        hotelId: any(),
+        city: exact(trip.city),
+        nightlyRate: max(trip.hotelRateBudget),
+        nights: max(trip.nights),
+        guest: exact(trip.traveler),
+        taskId: exact(trip.taskId),
+      },
+      "wallet.charge": { taskId: exact(trip.taskId), amount: max(trip.hotelRateBudget * trip.nights) },
+    },
+    { holder: fleet["hotel-agent"].publicKey, ttlSeconds: 10 * 60, terminal: true },
+  );
+}
+{% endhighlight %}
+</figure></div></details>
+
+<aside class="lab-callout stuck"><div class="lab-callout-title">If it does not work</div><ul><li>Attempt 7 is refused by making the hotel link terminal. Hotel Agent keeps its share of the wallet.</li><li>Attempt 8 fails for the same reason the theft in stage 6 failed.</li></ul></aside>
+
+<section class="lab-done"><div><div class="lab-callout-title">Done when</div><p>One works, seven fail, and the least-privilege row is full marks.</p></div><button type="button" class="lab-mark" data-mark-done="7">Mark stage 7 done</button></section>
+
+<nav class="lab-nav"><a class="prev" href="/lab/stage-6">← Stage 6</a><a class="next" href="/lab/wrap-up">Wrap up →</a></nav>

--- a/docs/lab/stage-8.md
+++ b/docs/lab/stage-8.md
@@ -1,0 +1,20 @@
+---
+layout: "lab"
+title: "Stage 8: your first pull request"
+description: "Optional: contribute to the SDK you just used."
+lab_stage: 10
+lab_version: "0.1.0"
+---
+<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" title="Stage 7">7</a><a href="/lab/stage-8" data-n="8" class="current" title="Stage 8">8</a></nav>
+<header class="lab-hero"><div class="lab-kicker">Stage 8 of 8 · optional · no score</div><h1>Your first pull request</h1><p class="lab-goal"><strong>Goal.</strong> Take the TypeScript SDK you just spent ninety minutes inside and land one small change in it.</p></header>
+<p class="lab-intro">You have been working in a real open-source security project, in the same SDK its maintainers use every day. Most people never get that far before a first contribution. The challenge is to open one.</p>
+<h2>Do this</h2>
+<ol class="lab-steps">
+<li class="lab-step"><label class="lab-step-check"><input type="checkbox" data-key="8:0"><span>1</span></label><div class="lab-step-body"><p>Pick an issue labeled <strong>good first issue</strong>. Most are TypeScript: a runnable example, a test recipe, a clearer error, a cookbook for the constraint helpers you used in stage 5. Each says what done looks like.</p><a class="lab-button" href="https://github.com/tenuo-ai/tenuo/labels/good%20first%20issue">Browse good first issues</a></div></li>
+<li class="lab-step"><label class="lab-step-check"><input type="checkbox" data-key="8:1"><span>2</span></label><div class="lab-step-body"><p>Comment on the issue so nobody else picks it up at the same time. Then read <code>CONTRIBUTING.md</code>: it tells you how to run the TypeScript checks locally, which is most of the work.</p></div></li>
+<li class="lab-step"><label class="lab-step-check"><input type="checkbox" data-key="8:2"><span>3</span></label><div class="lab-step-body"><p>Make the change, run the checks, open the pull request, and say in the description that you ran them.</p></div></li>
+</ol>
+<aside class="lab-callout notice"><div class="lab-callout-title">What makes a first pull request easy to merge</div><ul><li>Keep it to the one issue. A small change that does exactly what the issue asks beats a large one that does several things.</li><li>Run the checks the contributing guide names, and say that you did.</li><li>If you get stuck, say so on the issue. Maintainers would rather answer a question than review a guess.</li></ul></aside>
+<p>Your session host can help you pick one and will tell you how to reach the maintainers if an issue is unclear. A merged pull request on a security project is worth having your name on.</p>
+<section class="lab-done"><div><div class="lab-callout-title">Done when</div><p>Your pull request is open.</p></div><button type="button" class="lab-mark" data-mark-done="8">Mark stage 8 done</button></section>
+<nav class="lab-nav"><a class="prev" href="/lab/wrap-up">← What you just learned</a><a class="next" href="https://github.com/tenuo-ai/tenuo">The repository →</a></nav>

--- a/docs/lab/wrap-up.md
+++ b/docs/lab/wrap-up.md
@@ -1,0 +1,19 @@
+---
+layout: "lab"
+title: "What you just learned"
+description: "The two sentences the lab was built around, and the terms for them."
+lab_stage: 0
+lab_version: "0.1.0"
+---
+<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" title="Stage 7">7</a><a href="/lab/stage-8" data-n="8" title="Stage 8">8</a></nav>
+<header class="lab-hero"><div class="lab-kicker">After stage 7</div><h1>What you just learned</h1><p class="lab-goal">If you can say this in your own words, the lab worked.</p></header>
+
+<blockquote class="lab-quote">An AI agent sometimes needs to pass work to another agent. The second agent should get only the access that piece of work requires, and it should not be able to give itself or anyone else more access than it received.</blockquote>
+<p>And if you got further than that:</p>
+<blockquote class="lab-quote">An agent's identity tells you which agent is acting. It does not tell you what that agent was allowed to do for this particular job.</blockquote>
+<p>Neither sentence uses a technical term. Here are the terms, now that you have the ideas they attach to.</p>
+<table class="lab-terms"><thead><tr><th>Term</th><th>Where you met it</th></tr></thead><tbody><tr><td><strong>Ambient authority</strong></td><td>Stage 1. Permission that follows the agent everywhere instead of following the job.</td></tr><tr><td><strong>Identity-based access control</strong></td><td>Stage 2. Permissions attached to who is acting.</td></tr><tr><td><strong>Confused deputy</strong></td><td>Stage 4. An agent with real authority being steered into using it for the wrong job.</td></tr><tr><td><strong>Policy service</strong></td><td>Stage 4. A central place every check has to ask, which is what your fix built, whatever you called it.</td></tr><tr><td><strong>Delegation</strong></td><td>Stage 4. Passing work, and the access for it, to another agent.</td></tr><tr><td><strong>Privilege escalation</strong></td><td>Stage 4. Ending up with more access than you were given.</td></tr><tr><td><strong>Attenuation</strong></td><td>Stage 5. Access that can narrow when it is passed on, and can never widen.</td></tr><tr><td><strong>Capability</strong></td><td>Stage 5. Permission carried by the request rather than looked up about the requester.</td></tr><tr><td><strong>Trust root</strong></td><td>Stage 5. The one key that can sign a fresh permission, and that no agent holds.</td></tr><tr><td><strong>Holder binding</strong></td><td>Stage 6. A permission that only works for whoever it was issued to.</td></tr><tr><td><strong>Prompt injection</strong></td><td>The whole lab. Instructions hidden in data that an agent reads and follows.</td></tr></tbody></table>
+<aside class="lab-callout question"><div class="lab-callout-title">One last look</div><p>No one told any agent in this lab to misbehave. Find where the instruction came from, in <code>src/services/flights.ts</code>. It has been sitting there since stage 1, on a departure board your check-in agent reads every time it does its job.</p></aside>
+<h2>Going further</h2>
+<p>The authorization system you used in stages 5 to 7 is open source at <a href="https://github.com/tenuo-ai/tenuo">github.com/tenuo-ai/tenuo</a>. The delegation rules behind it are being written up as an IETF standards draft, which is public and readable. A star on the repository is the main way maintainers find out anyone is using their work.</p>
+<nav class="lab-nav"><a class="prev" href="/lab/stage-7">← Stage 7</a><a class="next" href="/lab/stage-8">Stage 8: your first pull request →</a></nav>

--- a/labs/agent-delegation/README.md
+++ b/labs/agent-delegation/README.md
@@ -47,7 +47,8 @@ npm run reset      # start over from stage 1
 ```
 
 Run `attack` and `score` as often as you like. There is no limit and no
-penalty for retries. Each stage explains itself when you run `npm run lab`.
+penalty for retries. Each stage explains itself when you run `npm run lab`, and
+the full guide is at [tenuo.ai/lab](https://tenuo.ai/lab/), one page per stage.
 
 ## What leaves your machine
 
@@ -74,6 +75,21 @@ not in this build.
 The rogue behavior is not in any prompt. Go find where the instruction
 actually comes from, in `src/services/flights.ts`.
 
+## The hosted guide
+
+The stage-by-stage guide at [tenuo.ai/lab](https://tenuo.ai/lab) is generated
+from this directory, so it cannot drift from the code:
+
+```bash
+npm run site            # rebuild docs/lab from the lab, exercises, and real runs
+npm run site -- --check # fail if docs/lab is stale
+```
+
+Every expected-output panel is captured from the CLI using the reference
+answers and a throwaway state directory. The CLI prints the current stage's
+page, including completed stages in the link. Add `-- --open` to `npm run lab`
+or `npm run next` to open it.
+
 ## After the lab
 
 You have just spent ninety minutes inside this codebase, in the same
@@ -99,6 +115,7 @@ src/
 exercises/          the files you edit, one folder per stage
 answers/            reference solutions (npm run ambassador -- answers N)
 explainers/         optional reading; you can finish without opening one
+site/               source and generator for the hosted guide
 test/               every stage, run with its reference solution
 ```
 

--- a/labs/agent-delegation/package.json
+++ b/labs/agent-delegation/package.json
@@ -18,7 +18,8 @@
     "reset": "tsx src/cli/index.ts reset",
     "ambassador": "tsx src/cli/index.ts ambassador",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "site": "tsx site/build.ts"
   },
   "dependencies": {
     "@tenuo/core": "file:vendor/tenuo-core-0.2.4-beta.0.tgz"

--- a/labs/agent-delegation/site/build.ts
+++ b/labs/agent-delegation/site/build.ts
@@ -1,0 +1,322 @@
+/**
+ * Build the hosted lab (tenuo.ai/lab) into docs/lab.
+ *
+ *   npm run site            write the pages
+ *   npm run site -- --check fail if the pages on disk are stale
+ *
+ * Pages are HTML with a `lab` layout. Code on them is pulled from the real
+ * exercise and answer files; terminal output is captured from real runs.
+ */
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { ROOT } from "../src/state.ts";
+import { capture } from "./capture.ts";
+import { CODESPACES_URL, GOOD_FIRST_ISSUES_URL, MISSION_DIAGRAM, REPO_URL, STAGES, type Capture, type CodeRef, type Explainer, type Snippet, type StageSpec, type Step } from "./spec.ts";
+
+const DOCS = join(ROOT, "..", "..", "docs", "lab");
+const TOTAL = 8;
+
+function labVersion(): string {
+  const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as { version?: string };
+  return pkg.version ?? "0.0.0";
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+/** Escape, then the three bits of markdown the spec uses: `code`, **bold**, *em*, [text](url). */
+function inline(md: string): string {
+  return esc(md)
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/(^|[\s(])\*([^*]+)\*/g, "$1<em>$2</em>")
+    .replace(/\[([^\]]+)\]\((https?:[^)]+)\)/g, '<a href="$2">$1</a>');
+}
+
+function extract(ref: CodeRef): string {
+  const source = readFileSync(join(ROOT, ref.file), "utf8");
+  if (ref.symbols === undefined) {
+    return source.replace(/^\/\*\*[\s\S]*?\*\/\n+/, "");
+  }
+  const lines = source.split("\n");
+  const out: string[] = [];
+  for (const symbol of ref.symbols) {
+    const start = lines.findIndex((l) => new RegExp(`^export (?:async )?(?:function|const) ${symbol}\\b`).test(l));
+    if (start < 0) {
+      throw new Error(`${ref.file}: no exported symbol ${symbol}`);
+    }
+    let from = start;
+    if (start > 0 && lines[start - 1]?.trim() === "*/") {
+      while (from > 0 && !lines[from - 1]!.startsWith("/**")) from -= 1;
+      from -= 1;
+    }
+    let to = start;
+    while (to < lines.length && !/^\};?$/.test(lines[to]!)) to += 1;
+    out.push(lines.slice(from, to + 1).join("\n"));
+  }
+  return out.join("\n\n");
+}
+
+function codeFigure(item: CodeRef | Snippet): string {
+  const isSnippet = "code" in item;
+  const code = isSnippet ? item.code : extract(item);
+  const lang = isSnippet ? item.lang : "ts";
+  const file = isSnippet ? undefined : item.file;
+  const body = lang === "text"
+    ? `<pre><code>${esc(code)}</code></pre>`
+    : `{% highlight ${lang} %}\n${code}\n{% endhighlight %}`;
+  return `<figure class="lab-code"><figcaption>${esc(item.caption)}${file !== undefined ? ` <span>${esc(file)}</span>` : ""}</figcaption>\n${body}\n</figure>`;
+}
+
+function terminal(c: Capture, stage: number): string {
+  const text = capture(c.cmd, stage, c.answer);
+  const lines = text.split("\n").length;
+  const open = lines <= 28 ? " open" : "";
+  return `<details class="lab-term"${open}><summary>${esc(c.label)} <span>npm run ${c.cmd} · ${lines} lines</span></summary><pre><code>${esc(text)}</code></pre></details>`;
+}
+
+function expectHtml(step: Step, stage: number, id: string): string {
+  if (step.expect === undefined) return "";
+  if (!Array.isArray(step.expect)) return terminal(step.expect as Capture, stage);
+  const captures = step.expect as readonly Capture[];
+  const tabs = captures.map((c, i) => `<input type="radio" name="${id}" id="${id}-${i}"${i === 0 ? " checked" : ""}><label for="${id}-${i}">${esc(c.label)}</label>`).join("");
+  const panels = captures.map((c) => `<div class="lab-tab-panel">${terminal({ ...c, label: c.label }, stage)}</div>`).join("");
+  return `<div class="lab-tabs">${tabs}${panels}</div>`;
+}
+
+function stepHtml(step: Step, stage: number, index: number): string {
+  const key = `${stage}:${index}`;
+  const cmd = step.cmd !== undefined ? `<pre class="lab-cmd"><code>${esc(step.cmd)}</code></pre>` : "";
+  return `<li class="lab-step">
+<label class="lab-step-check"><input type="checkbox" data-key="${key}"><span>${index + 1}</span></label>
+<div class="lab-step-body"><p>${inline(step.text)}</p>${cmd}${expectHtml(step, stage, `t${stage}-${index}`)}</div>
+</li>`;
+}
+
+function stepper(current: number | "wrap"): string {
+  const items: string[] = [];
+  for (let n = 1; n <= TOTAL; n += 1) {
+    const cls = n === current ? ' class="current"' : "";
+    items.push(`<a href="/lab/stage-${n}" data-n="${n}"${cls} title="Stage ${n}">${n}</a>`);
+  }
+  return `<nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a>${items.join("")}</nav>`;
+}
+
+function callout(kind: "notice" | "question" | "hint" | "stuck", title: string, body: string): string {
+  return `<aside class="lab-callout ${kind}"><div class="lab-callout-title">${title}</div>${body}</aside>`;
+}
+
+function frontMatter(fields: Record<string, string | number>): string {
+  // The package version only: the commit changes on every push and would make every page stale.
+  fields = { ...fields, lab_version: labVersion().split("+")[0] ?? "0.0.0" };
+  return `---\n${Object.entries(fields).map(([k, v]) => `${k}: ${typeof v === "number" ? v : JSON.stringify(v)}`).join("\n")}\n---\n`;
+}
+
+function explainerHtml(e: Explainer): string {
+  const points = e.points.map(([t, d]) => `<li><strong>${esc(t)}.</strong> ${inline(d)}</li>`).join("");
+  const why = e.why.map(([problem, answer]) => `<tr><td>${inline(problem)}</td><td>${inline(answer)}</td></tr>`).join("");
+  const more = e.more === undefined ? "" : `<p class="lab-muted">Read more: ${e.more.map(([t, u]) => `<a href="${u}">${esc(t)}</a>`).join(" · ")}</p>`;
+  return `<section class="lab-explainer">
+<h2>${esc(e.title)}</h2>
+<p class="lab-lead">${inline(e.lead)}</p>
+<ul class="lab-points">${points}</ul>
+${e.code !== undefined ? codeFigure(e.code) : ""}
+<h3>Why it is the right tool for this problem</h3>
+<table class="lab-why"><thead><tr><th>What you ran into</th><th>What a warrant does about it</th></tr></thead><tbody>${why}</tbody></table>
+${more}
+</section>`;
+}
+
+function stagePage(spec: StageSpec): string {
+  const prev = spec.n === 1 ? { href: "/lab/", label: "Overview" } : { href: `/lab/stage-${spec.n - 1}`, label: `Stage ${spec.n - 1}` };
+  const next = spec.n === 7 ? { href: "/lab/wrap-up", label: "Wrap up" } : { href: `/lab/stage-${spec.n + 1}`, label: `Stage ${spec.n + 1}: ${STAGES[spec.n]?.title ?? ""}` };
+  const parts: string[] = [];
+  parts.push(stepper(spec.n));
+  parts.push(`<header class="lab-hero"><div class="lab-kicker">Stage ${spec.n} of 7 · <span class="lab-mode ${spec.mode}">${spec.mode}</span> · about ${spec.minutes} min</div><h1>${esc(spec.title)}</h1><p class="lab-goal"><strong>Goal.</strong> ${inline(spec.goal)}</p></header>`);
+  parts.push(spec.intro.map((p) => `<p class="lab-intro">${inline(p)}</p>`).join("\n"));
+  if (spec.explainer !== undefined) {
+    parts.push(explainerHtml(spec.explainer));
+  }
+  parts.push(`<figure class="lab-figure">${spec.diagram}</figure>`);
+  if (spec.code !== undefined) {
+    parts.push(spec.code.map(codeFigure).join("\n"));
+  }
+  parts.push(`<h2>Do this</h2>\n<ol class="lab-steps">\n${spec.steps.map((s, i) => stepHtml(s, spec.n, i)).join("\n")}\n</ol>`);
+  parts.push(callout("notice", "Notice", `<ul>${spec.notice.map((n) => `<li>${inline(n)}</li>`).join("")}</ul>`));
+  if (spec.question !== undefined) {
+    parts.push(callout("question", "Question to sit with", `<p>${inline(spec.question)}</p>`));
+  }
+  if (spec.hint !== undefined) {
+    parts.push(`<details class="lab-reveal hint"><summary>I'm stuck. Give me a hint.</summary><div>${inline(spec.hint)}</div></details>`);
+  }
+  if (spec.check !== undefined) {
+    parts.push(`<details class="lab-reveal answer"><summary>Show a reference solution</summary><div><p class="lab-muted">Try your own first. The score checks behavior, so yours does not need to match this one.</p>${spec.check.map(codeFigure).join("\n")}</div></details>`);
+  }
+  if (spec.stuck !== undefined) {
+    parts.push(callout("stuck", "If it does not work", `<ul>${spec.stuck.map((n) => `<li>${inline(n)}</li>`).join("")}</ul>`));
+  }
+  parts.push(`<section class="lab-done"><div><div class="lab-callout-title">Done when</div><p>${inline(spec.done)}</p></div><button type="button" class="lab-mark" data-mark-done="${spec.n}">Mark stage ${spec.n} done</button></section>`);
+  parts.push(`<nav class="lab-nav"><a class="prev" href="${prev.href}">← ${esc(prev.label)}</a><a class="next" href="${next.href}">${esc(next.label)} →</a></nav>`);
+  return frontMatter({ layout: "lab", title: `Stage ${spec.n}: ${spec.title}`, description: spec.goal, lab_stage: spec.n }) + parts.join("\n\n") + "\n";
+}
+
+function indexPage(): string {
+  const cards = STAGES.map((s) => `<a class="lab-card" data-n="${s.n}" href="/lab/stage-${s.n}"><div class="lab-card-n">${s.n}</div><div><div class="lab-card-title">${esc(s.title)}</div><div class="lab-card-goal">${inline(s.goal)}</div></div><div class="lab-card-time">${s.minutes} min</div></a>`);
+  cards.push(`<a class="lab-card" data-n="8" href="/lab/stage-8"><div class="lab-card-n">8</div><div><div class="lab-card-title">Your first pull request</div><div class="lab-card-goal">Optional. Take what you just used and contribute to it.</div></div><div class="lab-card-time">open</div></a>`);
+  const grading = [
+    ["The trip completes correctly", 25, "This is the gate. If Alice does not get a flight, a hotel, an activity, and a boarding pass within budget, the other rows do not count."],
+    ["Unauthorized actions are blocked", 30, "Everything the rogue agent tries."],
+    ["Handoffs pass along only what's needed", 25, "What Boarding Agent can do after Check-in Agent hands it the job."],
+    ["You didn't grant more than the job required", 20, "Measured against the mission. A $300 ceiling for a $286 flight is full marks."],
+  ] as const;
+  const body = `${stepper(0)}
+<header class="lab-hero"><div class="lab-kicker">A ninety-minute lab · TypeScript · no account needed</div><h1>AI Agent Delegation Challenge</h1><p class="lab-goal">Six AI agents book a trip. One of them reads an instruction it should not follow. You change how permissions work, stage by stage, until the damage stops and the trip still happens.</p></header>
+
+<section class="lab-start">
+<div>
+<h2>Start</h2>
+<pre class="lab-cmd"><code>git clone ${REPO_URL}
+cd tenuo/labs/agent-delegation
+npm install
+npm run lab</code></pre>
+<p class="lab-muted">Node 20 or newer. No account, no API key, no network needed. The lab runs its own recorded agents; every check and score is real.</p>
+</div>
+<div>
+<h2>What to expect</h2>
+<p>Five stages in about ninety minutes, then two extensions for a second sitting. You run a command, read what happened, change a file, and run it again. Stage 5 explains what a Tenuo warrant is before you write your first one, so there is no reading to do first.</p>
+<p class="lab-muted">If you want the vocabulary early, the TypeScript guide's <a href="${REPO_URL}/tree/main/tenuo-ts">Protect your first tool</a> and <a href="${REPO_URL}/tree/main/tenuo-ts">Delegate to another agent</a> take about seven minutes.</p>
+</div>
+</section>
+<details class="lab-reveal">
+<summary>If npm fights you: run the lab in the browser instead</summary>
+<div>
+<p>The same lab runs in GitHub Codespaces with no install. It needs a free GitHub account and no payment method. GitHub includes 120 core-hours a month on personal accounts, and the lab is pinned to the smallest 2-core machine, so a full session uses about 3 of them.</p>
+<a class="lab-button" href="${CODESPACES_URL}">Open in GitHub Codespaces</a>
+<p class="lab-muted">Create it from the link so it counts against your own free hours. A codespace created inside an organization is billed to that organization. Stop the codespace when you are done.</p>
+</div>
+</details>
+
+<h2>The mission</h2>
+<figure class="lab-figure">${MISSION_DIAGRAM}</figure>
+<div class="lab-mission">
+<table><tbody>
+<tr><th>Traveler</th><td>Alice Chen</td><th>Budget</th><td>$1,200 total</td></tr>
+<tr><th>From</th><td>Toronto (YYZ)</td><th>Flight</th><td>up to $300</td></tr>
+<tr><th>To</th><td>Cancún (CUN)</td><th>Hotel</th><td>3 nights, up to $200 a night</td></tr>
+<tr><th>Arrive</th><td>Friday evening</td><th>Activity</th><td>at least one, up to $200</td></tr>
+</tbody></table>
+<p>Watch the wallet in the output. It starts at $1,200. When it moves, something happened.</p>
+</div>
+
+<h2>What you will use</h2>
+<div class="lab-two">
+<div><h3>Stages 1 to 4: the usual tools</h3><p>A shared key, then one account per agent, then rules you write yourself, then a registry to tell two jobs apart. Each fixes something and costs something. By the end of stage 4 you will have hit the limit of all of them.</p></div>
+<div><h3>Stages 5 to 7: Tenuo warrants</h3><p>A <strong>warrant</strong> is a signed permission that travels with the request: which tools, which argument values, for which agent's key, until when. The control plane signs the first one; agents can only narrow it for the next agent; the code next to each tool checks the whole chain offline. <a href="/lab/stage-5">Stage 5 explains it</a> before you write your first one.</p></div>
+</div>
+
+<h2>The stages</h2>
+<div class="lab-grid">${cards.join("\n")}</div>
+<p class="lab-muted">Stages 1 to 5 are the main event, about ninety minutes. Stages 6 and 7 are extensions for a second sitting. Your progress is kept in this browser, and the links the lab prints keep it in step with your terminal.</p>
+
+<h2>How it is scored</h2>
+<div class="lab-grading">${grading.map(([label, pts, note]) => `<div class="lab-grade"><div class="lab-grade-row"><span>${esc(label)}</span><strong>${pts}</strong></div><div class="lab-bar"><div style="width:${pts}%"></div></div><p class="lab-muted">${esc(note)}</p></div>`).join("")}</div>
+<p><code>npm run score</code> breaks this down per agent. Speed is not scored, and retries are free.</p>
+
+<h2>The commands</h2>
+<pre class="lab-cmd"><code>npm run lab        # start or resume where you left off
+npm run attack     # run the rogue behavior and the security checks
+npm run score      # your score and why
+npm run trace      # every decision, with its reason
+npm run audit      # what every agent can currently do
+npm run next       # move on to the next stage
+npm run reset      # start over from stage 1
+npm run share      # write an anonymous score breakdown for your session host
+npm run reset      # return to stage 1 without changing exercise files</code></pre>
+
+<aside class="lab-callout notice"><div class="lab-callout-title">One ground rule</div><p>You will be tempted to fix the agent that misbehaves: filter what it reads, tell it to ignore suspicious instructions, pick a smarter model. This lab sets those aside. Assume the agent will sometimes be fooled, and work on what still holds when it is.</p></aside>
+
+<nav class="lab-nav"><span></span><a class="next" href="/lab/stage-1">Stage 1: One key for everyone →</a></nav>
+`;
+  return frontMatter({ layout: "lab", title: "Agent Delegation Challenge", description: "Six AI agents, one rogue, nine stages. Change how permissions work until the damage stops and the trip still happens.", lab_stage: 0 }) + body;
+}
+
+function wrapUpPage(): string {
+  const terms: ReadonlyArray<readonly [string, string]> = [
+    ["Ambient authority", "Stage 1. Permission that follows the agent everywhere instead of following the job."],
+    ["Identity-based access control", "Stage 2. Permissions attached to who is acting."],
+    ["Confused deputy", "Stage 4. An agent with real authority being steered into using it for the wrong job."],
+    ["Policy service", "Stage 4. A central place every check has to ask, which is what your fix built, whatever you called it."],
+    ["Delegation", "Stage 4. Passing work, and the access for it, to another agent."],
+    ["Privilege escalation", "Stage 4. Ending up with more access than you were given."],
+    ["Attenuation", "Stage 5. Access that can narrow when it is passed on, and can never widen."],
+    ["Capability", "Stage 5. Permission carried by the request rather than looked up about the requester."],
+    ["Trust root", "Stage 5. The one key that can sign a fresh permission, and that no agent holds."],
+    ["Holder binding", "Stage 6. A permission that only works for whoever it was issued to."],
+    ["Prompt injection", "The whole lab. Instructions hidden in data that an agent reads and follows."],
+  ];
+  const body = `${stepper("wrap")}
+<header class="lab-hero"><div class="lab-kicker">After stage 7</div><h1>What you just learned</h1><p class="lab-goal">If you can say this in your own words, the lab worked.</p></header>
+
+<blockquote class="lab-quote">An AI agent sometimes needs to pass work to another agent. The second agent should get only the access that piece of work requires, and it should not be able to give itself or anyone else more access than it received.</blockquote>
+<p>And if you got further than that:</p>
+<blockquote class="lab-quote">An agent's identity tells you which agent is acting. It does not tell you what that agent was allowed to do for this particular job.</blockquote>
+<p>Neither sentence uses a technical term. Here are the terms, now that you have the ideas they attach to.</p>
+<table class="lab-terms"><thead><tr><th>Term</th><th>Where you met it</th></tr></thead><tbody>${terms.map(([t, d]) => `<tr><td><strong>${esc(t)}</strong></td><td>${esc(d)}</td></tr>`).join("")}</tbody></table>
+<aside class="lab-callout question"><div class="lab-callout-title">One last look</div><p>No one told any agent in this lab to misbehave. Find where the instruction came from, in <code>src/services/flights.ts</code>. It has been sitting there since stage 1, on a departure board your check-in agent reads every time it does its job.</p></aside>
+<h2>Going further</h2>
+<p>The authorization system you used in stages 5 to 7 is open source at <a href="${REPO_URL}">github.com/tenuo-ai/tenuo</a>. The delegation rules behind it are being written up as an IETF standards draft, which is public and readable. A star on the repository is the main way maintainers find out anyone is using their work.</p>
+<nav class="lab-nav"><a class="prev" href="/lab/stage-7">← Stage 7</a><a class="next" href="/lab/stage-8">Stage 8: your first pull request →</a></nav>
+`;
+  return frontMatter({ layout: "lab", title: "What you just learned", description: "The two sentences the lab was built around, and the terms for them.", lab_stage: 0 }) + body;
+}
+
+function stage8Page(): string {
+  const body = `${stepper(8)}
+<header class="lab-hero"><div class="lab-kicker">Stage 8 of 8 · optional · no score</div><h1>Your first pull request</h1><p class="lab-goal"><strong>Goal.</strong> Take the TypeScript SDK you just spent ninety minutes inside and land one small change in it.</p></header>
+<p class="lab-intro">You have been working in a real open-source security project, in the same SDK its maintainers use every day. Most people never get that far before a first contribution. The challenge is to open one.</p>
+<h2>Do this</h2>
+<ol class="lab-steps">
+<li class="lab-step"><label class="lab-step-check"><input type="checkbox" data-key="8:0"><span>1</span></label><div class="lab-step-body"><p>Pick an issue labeled <strong>good first issue</strong>. Most are TypeScript: a runnable example, a test recipe, a clearer error, a cookbook for the constraint helpers you used in stage 5. Each says what done looks like.</p><a class="lab-button" href="${GOOD_FIRST_ISSUES_URL}">Browse good first issues</a></div></li>
+<li class="lab-step"><label class="lab-step-check"><input type="checkbox" data-key="8:1"><span>2</span></label><div class="lab-step-body"><p>Comment on the issue so nobody else picks it up at the same time. Then read <code>CONTRIBUTING.md</code>: it tells you how to run the TypeScript checks locally, which is most of the work.</p></div></li>
+<li class="lab-step"><label class="lab-step-check"><input type="checkbox" data-key="8:2"><span>3</span></label><div class="lab-step-body"><p>Make the change, run the checks, open the pull request, and say in the description that you ran them.</p></div></li>
+</ol>
+<aside class="lab-callout notice"><div class="lab-callout-title">What makes a first pull request easy to merge</div><ul><li>Keep it to the one issue. A small change that does exactly what the issue asks beats a large one that does several things.</li><li>Run the checks the contributing guide names, and say that you did.</li><li>If you get stuck, say so on the issue. Maintainers would rather answer a question than review a guess.</li></ul></aside>
+<p>Your session host can help you pick one and will tell you how to reach the maintainers if an issue is unclear. A merged pull request on a security project is worth having your name on.</p>
+<section class="lab-done"><div><div class="lab-callout-title">Done when</div><p>Your pull request is open.</p></div><button type="button" class="lab-mark" data-mark-done="8">Mark stage 8 done</button></section>
+<nav class="lab-nav"><a class="prev" href="/lab/wrap-up">← What you just learned</a><a class="next" href="${REPO_URL}">The repository →</a></nav>
+`;
+  return frontMatter({ layout: "lab", title: "Stage 8: your first pull request", description: "Optional: contribute to the SDK you just used.", lab_stage: 10 }) + body;
+}
+
+function main(): void {
+  const check = process.argv.includes("--check");
+  const pages = new Map<string, string>();
+  pages.set("index.md", indexPage());
+  for (const s of STAGES) pages.set(`stage-${s.n}.md`, stagePage(s));
+  pages.set("wrap-up.md", wrapUpPage());
+  pages.set("stage-8.md", stage8Page());
+
+  if (check) {
+    const stale: string[] = [];
+    for (const [name, html] of pages) {
+      const path = join(DOCS, name);
+      if (!existsSync(path) || readFileSync(path, "utf8") !== html) stale.push(name);
+    }
+    if (stale.length > 0) {
+      console.error(`docs/lab is stale: ${stale.join(", ")}. Run: npm run site (in labs/agent-delegation) and commit the result.`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`docs/lab is current (${pages.size} pages).`);
+    return;
+  }
+  mkdirSync(DOCS, { recursive: true });
+  for (const existing of readdirSync(DOCS)) {
+    if (existing.endsWith(".md") && !pages.has(existing)) rmSync(join(DOCS, existing));
+  }
+  for (const [name, html] of pages) writeFileSync(join(DOCS, name), html);
+  console.log(`wrote ${pages.size} pages to ${DOCS}`);
+}
+
+main();

--- a/labs/agent-delegation/site/capture.ts
+++ b/labs/agent-delegation/site/capture.ts
@@ -1,0 +1,55 @@
+/**
+ * Run the real CLI and keep what it printed, so the "what you should see"
+ * panels on the site are never typed by hand and never drift from the code.
+ *
+ * Each run gets a throwaway state directory (TENUO_LAB_HOME) and, when an
+ * answer file is given, runs that instead of the exercise as shipped
+ * (TENUO_LAB_ANSWER). Nothing the participant has on disk is touched.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ROOT } from "../src/state.ts";
+
+const ANSI = /\x1b\[[0-9;]*m/g;
+const cache = new Map<string, string>();
+
+export function capture(cmd: string, stage: number, answer?: string): string {
+  const key = `${cmd}:${stage}:${answer ?? ""}`;
+  const hit = cache.get(key);
+  if (hit !== undefined) {
+    return hit;
+  }
+  const home = mkdtempSync(join(tmpdir(), "tenuo-lab-site-"));
+  try {
+    const result = spawnSync(process.execPath, [join(ROOT, "node_modules", "tsx", "dist", "cli.mjs"), join(ROOT, "src", "cli", "index.ts"), cmd, "--stage", String(stage)], {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        TENUO_LAB_HOME: home,
+        ...(answer !== undefined ? { TENUO_LAB_ANSWER: answer } : {}),
+        // Captured pages must not send events, whatever the builder's own install says.
+        TENUO_LAB_EVENTS_URL: "http://127.0.0.1:9/",
+        NODE_ENV: "development",
+      },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 120_000,
+    });
+    if (result.status !== 0) {
+      throw new Error(`capture ${key} failed (exit ${result.status}):\n${result.stderr}`);
+    }
+    const text = (result.stdout + result.stderr)
+      .replace(ANSI, "")
+      // Fresh keys every run: keep the pages stable.
+      .replace(/https:\/\/tenuo\.ai\/explorer\/\?s=[A-Za-z0-9+/=]+/g, "https://tenuo.ai/explorer/?s=…")
+      .replace(/tnu_wrt_[0-9a-f]+/g, "tnu_wrt_…")
+      .replace(/\b[0-9a-f]{12}(?:[0-9a-f]{52})?…?/g, "…")
+      .replace(/\s+$/, "");
+    cache.set(key, text);
+    return text;
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}

--- a/labs/agent-delegation/site/diagrams.ts
+++ b/labs/agent-delegation/site/diagrams.ts
@@ -1,0 +1,401 @@
+/**
+ * Inline SVG for the lab pages. One parametrised picture of the fleet, so
+ * every stage shows the same six agents with a different thing highlighted,
+ * plus a vertical chain picture for the Tenuo stages.
+ *
+ * Text is measured with a per-glyph width table and shrunk or clipped to
+ * fit its box. Arrows are elbows on a grid, with heads that point the way
+ * the line travels. Colours come from the site's CSS variables where the
+ * SVG inherits them and from a small fixed palette where it cannot.
+ */
+
+export type AgentKey = "travel" | "flight" | "hotel" | "activity" | "checkin" | "boarding";
+export type NodeKey = AgentKey | "cp" | "service" | "wallet";
+export type NodeState = "normal" | "focus" | "rogue" | "compromised" | "dim" | "ok";
+export type EdgeKey = "cp-travel" | "travel-flight" | "flight-checkin" | "checkin-boarding" | "travel-hotel" | "travel-activity";
+export type EdgeStyle = "normal" | "focus" | "terminal" | "blocked" | "dim" | "you";
+
+export interface ExtraArrow {
+  readonly from: NodeKey;
+  readonly to: NodeKey;
+  readonly label?: string;
+  readonly style: "stolen" | "ask" | "handoff" | "blocked";
+}
+
+export interface FleetOptions {
+  /** Draw the control plane above Travel Agent, with this label. */
+  readonly controlPlane?: string;
+  /** Requests feeding Travel Agent, e.g. "Alice → Cancún". */
+  readonly travelers?: readonly string[];
+  /** A wallet pill, e.g. "$1,200". */
+  readonly wallet?: string;
+  /** A policy service / registry node, with this label. */
+  readonly service?: string;
+  readonly sub?: Partial<Record<AgentKey, string>>;
+  readonly state?: Partial<Record<AgentKey, NodeState>>;
+  readonly tag?: Partial<Record<AgentKey, string>>;
+  readonly edges?: Partial<Record<EdgeKey, EdgeStyle>>;
+  readonly edgeLabels?: Partial<Record<EdgeKey, string>>;
+  readonly extra?: readonly ExtraArrow[];
+  readonly caption?: string;
+}
+
+const W = 760;
+const NODE_W = 150;
+const NODE_H = 48;
+const GAP = 35;
+const COL = [22, 22 + NODE_W + GAP, 22 + 2 * (NODE_W + GAP), 22 + 3 * (NODE_W + GAP)] as const;
+const ROW_STEP = 84;
+const HEAD = 9;
+
+const PALETTE = {
+  edge: "#6a6a6a",
+  focus: "var(--accent)",
+  rogue: "#ff5c5c",
+  warn: "#ffb000",
+  ok: "#3ddc84",
+  dim: "#3a3a3a",
+  ink: "#0a0a0a",
+} as const;
+
+const NAMES: Record<AgentKey, string> = {
+  travel: "Travel Agent",
+  flight: "Flight Agent",
+  hotel: "Hotel Agent",
+  activity: "Activity Agent",
+  checkin: "Check-in Agent",
+  boarding: "Boarding Agent",
+};
+
+interface Box {
+  readonly x: number;
+  readonly y: number;
+  readonly w: number;
+  readonly h: number;
+}
+
+type Point = readonly [number, number];
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+/* ---------- text measurement ---------- */
+
+const NARROW = new Set("iljft.,:;'!|()[] ");
+const WIDE = new Set("mwMW@");
+const SYMBOL: Record<string, number> = { "→": 10, "≤": 7.5, "$": 6, "✕": 9, "…": 9, "—": 10, "–": 6 };
+
+/** Approximate advance width, in px, of `s` set in a system sans at `size` px. */
+export function textWidth(s: string, size: number, bold = false): number {
+  let units = 0;
+  for (const ch of s) {
+    if (SYMBOL[ch] !== undefined) units += SYMBOL[ch];
+    else if (NARROW.has(ch)) units += 2.9;
+    else if (WIDE.has(ch)) units += 9;
+    else if (ch >= "A" && ch <= "Z") units += 7;
+    else if (ch >= "0" && ch <= "9") units += 5.8;
+    else units += 5.6;
+  }
+  return units * (size / 10) * (bold ? 1.06 : 1);
+}
+
+interface Fitted {
+  readonly text: string;
+  readonly size: number;
+}
+
+/** Shrink a little, then clip with an ellipsis, so text never leaves its box. */
+function fit(s: string, max: number, size: number, bold = false, minSize = size - 2): Fitted {
+  for (let sz = size; sz >= minSize; sz -= 0.5) {
+    if (textWidth(s, sz, bold) <= max) return { text: s, size: sz };
+  }
+  let t = s;
+  while (t.length > 1 && textWidth(`${t}…`, minSize, bold) > max) t = t.slice(0, -1).trimEnd();
+  return { text: `${t}…`, size: minSize };
+}
+
+/* ---------- primitives ---------- */
+
+function stateColor(state: NodeState): string {
+  switch (state) {
+    case "focus": return PALETTE.focus;
+    case "rogue": return PALETTE.rogue;
+    case "compromised": return PALETTE.rogue;
+    case "ok": return PALETTE.ok;
+    case "dim": return PALETTE.dim;
+    default: return "var(--border)";
+  }
+}
+
+function label(x: number, y: number, s: string, size: number, fill: string, anchor: "start" | "middle" | "end" = "start", bold = false): string {
+  return `<text x="${x}" y="${y}" font-size="${size}"${bold ? ' font-weight="600"' : ""} text-anchor="${anchor}" fill="${fill}">${esc(s)}</text>`;
+}
+
+function node(box: Box, name: string, sub: string | undefined, state: NodeState, tag: string | undefined): string {
+  const stroke = stateColor(state);
+  const width = state === "normal" || state === "dim" ? 1 : 2;
+  const textFill = state === "dim" ? "var(--text-muted)" : "var(--text)";
+  const pad = 11;
+  const inner = box.w - pad * 2;
+  const title = fit(name, inner, 13, true);
+  const parts = [
+    `<rect x="${box.x}" y="${box.y}" width="${box.w}" height="${box.h}" rx="8" fill="var(--surface-2)" stroke="${stroke}" stroke-width="${width}"/>`,
+    label(box.x + pad, box.y + (sub === undefined ? 29 : 21), title.text, title.size, textFill, "start", true),
+  ];
+  if (sub !== undefined) {
+    const s = fit(sub, inner, 11, false, 9.5);
+    parts.push(label(box.x + pad, box.y + 38, s.text, s.size, "var(--text-muted)"));
+  }
+  if (tag !== undefined) {
+    const t = fit(tag, box.w - 24, 10, true, 9);
+    const tw = textWidth(t.text, t.size, true) + 14;
+    const color = state === "rogue" || state === "compromised" ? PALETTE.rogue : state === "ok" ? PALETTE.ok : PALETTE.warn;
+    const tx = box.x + box.w - tw - 8;
+    parts.push(
+      `<rect x="${tx}" y="${box.y - 9}" width="${tw}" height="17" rx="8.5" fill="${color}"/>`,
+      label(tx + tw / 2, box.y + 3.5, t.text, t.size, PALETTE.ink, "middle", true),
+    );
+  }
+  return parts.join("");
+}
+
+function pill(x: number, y: number, text: string, color: string): { svg: string; w: number } {
+  const w = Math.round(textWidth(text, 12) + 24);
+  const svg =
+    `<rect x="${x}" y="${y}" width="${w}" height="26" rx="13" fill="var(--surface)" stroke="${color}" stroke-width="1.5"/>` +
+    label(x + w / 2, y + 17, text, 12, "var(--text)", "middle");
+  return { svg, w };
+}
+
+function edgeColor(style: EdgeStyle): string {
+  switch (style) {
+    case "focus": return PALETTE.focus;
+    case "you": return PALETTE.focus;
+    case "terminal": return PALETTE.warn;
+    case "blocked": return PALETTE.rogue;
+    case "dim": return PALETTE.dim;
+    default: return PALETTE.edge;
+  }
+}
+
+/** An arrowhead whose apex is at `tip`, pointing along the unit direction (dx, dy). */
+function head(tip: Point, dx: number, dy: number, color: string): string {
+  const [x, y] = tip;
+  const bx = x - dx * HEAD;
+  const by = y - dy * HEAD;
+  const px = -dy * (HEAD * 0.55);
+  const py = dx * (HEAD * 0.55);
+  return `<polygon points="${x},${y} ${bx + px},${by + py} ${bx - px},${by - py}" fill="${color}"/>`;
+}
+
+interface ArrowOptions {
+  readonly label?: string;
+  /** Where the label sits relative to the last segment. */
+  readonly labelAt?: "above" | "below" | "right";
+  readonly dashed?: boolean;
+  /** Draw the shaft only. */
+  readonly noHead?: boolean;
+  readonly color?: string;
+  readonly width?: number;
+}
+
+/**
+ * A polyline with a head that points along its final segment. The shaft
+ * stops at the base of the head so the line never pokes through it.
+ */
+function arrow(points: readonly Point[], style: EdgeStyle, o: ArrowOptions = {}): string {
+  const color = o.color ?? edgeColor(style);
+  const width = o.width ?? (style === "normal" || style === "dim" ? 1.5 : 2);
+  const last = points[points.length - 1]!;
+  const prev = points[points.length - 2]!;
+  const len = Math.hypot(last[0] - prev[0], last[1] - prev[1]);
+  const dx = (last[0] - prev[0]) / len;
+  const dy = (last[1] - prev[1]) / len;
+  const terminal = style === "terminal";
+  const shaftEnd: Point = terminal || o.noHead === true ? last : [last[0] - dx * (HEAD - 1), last[1] - dy * (HEAD - 1)];
+  const shaft = [...points.slice(0, -1), shaftEnd];
+  const d = shaft.map(([x, y], i) => `${i === 0 ? "M" : "L"}${x} ${y}`).join(" ");
+  const dash = o.dashed === true || style === "you" ? ' stroke-dasharray="6 4"' : "";
+  const parts = [`<path d="${d}" fill="none" stroke="${color}" stroke-width="${width}" stroke-linejoin="round"${dash}/>`];
+  if (terminal) {
+    // A bar across the end: nothing passes beyond this hop.
+    const px = -dy * 9;
+    const py = dx * 9;
+    parts.push(`<line x1="${last[0] + px}" y1="${last[1] + py}" x2="${last[0] - px}" y2="${last[1] - py}" stroke="${color}" stroke-width="3" stroke-linecap="round"/>`);
+  } else if (o.noHead !== true) {
+    parts.push(head(last, dx, dy, color));
+  }
+  if (style === "blocked") {
+    const mx = (last[0] + prev[0]) / 2;
+    const my = (last[1] + prev[1]) / 2;
+    parts.push(`<circle cx="${mx}" cy="${my}" r="8" fill="var(--surface)"/>`);
+    parts.push(label(mx, my + 4.5, "✕", 13, PALETTE.rogue, "middle", true));
+  }
+  if (o.label !== undefined) {
+    const horizontal = Math.abs(dy) < 0.01;
+    const fill = color === PALETTE.edge ? "var(--text-muted)" : color;
+    if (horizontal) {
+      const mx = (last[0] + prev[0]) / 2;
+      const ly = o.labelAt === "below" ? last[1] + NODE_H / 2 + 15 : last[1] - 8;
+      parts.push(label(mx, ly, o.label, 10.5, fill, "middle"));
+    } else {
+      parts.push(label(last[0] + 9, (last[1] + prev[1]) / 2 + 4, o.label, 10.5, fill, "start"));
+    }
+  }
+  return parts.join("");
+}
+
+const cx = (b: Box) => b.x + b.w / 2;
+const cy = (b: Box) => b.y + b.h / 2;
+
+/** Route an extra arrow between two boxes as a clean elbow, entering the target from the side it faces. */
+function route(from: Box, to: Box, e: ExtraArrow): string {
+  const color = e.style === "stolen" || e.style === "blocked" ? PALETTE.rogue : e.style === "ask" ? PALETTE.warn : PALETTE.focus;
+  const style: EdgeStyle = e.style === "blocked" ? "blocked" : "focus";
+  const dashed = e.style === "stolen";
+  const sameColumn = Math.abs(cx(from) - cx(to)) < NODE_W / 2;
+  if (sameColumn) {
+    // Straight down (or up) between stacked boxes.
+    const down = to.y > from.y;
+    const start: Point = [cx(from), down ? from.y + from.h : from.y];
+    const end: Point = [cx(from), down ? to.y - 1 : to.y + to.h + 1];
+    const svg = arrow([start, end], style, { color, dashed });
+    if (e.label === undefined) return svg;
+    return svg + label(cx(from) + 9, start[1] + (end[1] - start[1]) * 0.7 + 4, e.label, 10.5, color, "start");
+  }
+  // Leave the source vertically, turn at the target's row, enter the target's near side.
+  const leftward = cx(to) < cx(from);
+  const start: Point = [cx(from), to.y > from.y ? from.y + from.h : from.y];
+  const turn: Point = [cx(from), cy(to)];
+  const end: Point = [leftward ? to.x + to.w + 1 : to.x - 1, cy(to)];
+  const svg = arrow([start, turn, end], style, { color, dashed });
+  if (e.label === undefined) return svg;
+  // Label along the horizontal run, just above it.
+  const lx = (turn[0] + end[0]) / 2;
+  return svg + label(lx, cy(to) - 8, e.label, 10.5, color, "middle");
+}
+
+/* ---------- the fleet ---------- */
+
+/** The six agents, arranged as the mission's tree, with per-stage annotations. */
+export function fleetDiagram(o: FleetOptions = {}): string {
+  const topRow = o.controlPlane !== undefined || (o.travelers !== undefined && o.travelers.length > 0);
+  const y0 = topRow ? 92 : 30;
+  const rowY = [y0, y0 + ROW_STEP, y0 + 2 * ROW_STEP] as const;
+  const boxes: Record<NodeKey, Box> = {
+    cp: { x: COL[0], y: 14, w: NODE_W, h: 44 },
+    travel: { x: COL[0], y: rowY[0], w: NODE_W, h: NODE_H },
+    flight: { x: COL[1], y: rowY[0], w: NODE_W, h: NODE_H },
+    checkin: { x: COL[2], y: rowY[0], w: NODE_W, h: NODE_H },
+    boarding: { x: COL[3], y: rowY[0], w: NODE_W, h: NODE_H },
+    hotel: { x: COL[1], y: rowY[1], w: NODE_W, h: NODE_H },
+    activity: { x: COL[1], y: rowY[2], w: NODE_W, h: NODE_H },
+    service: { x: COL[2], y: rowY[1] + 10, w: NODE_W + 36, h: NODE_H },
+    wallet: { x: COL[3], y: rowY[2] + 11, w: NODE_W, h: 26 },
+  };
+  const height = rowY[2] + NODE_H + 22 + (o.caption !== undefined ? 24 : 0);
+  const out: string[] = [];
+  const edge = (k: EdgeKey) => o.edges?.[k] ?? "normal";
+  const opts = (k: EdgeKey, at: "above" | "below" | "right"): ArrowOptions => {
+    const l = o.edgeLabels?.[k];
+    return l === undefined ? {} : { label: l, labelAt: at };
+  };
+  const h = (from: Box, to: Box, k: EdgeKey) => arrow([[from.x + from.w, cy(from)], [to.x - 1, cy(to)]], edge(k), opts(k, "below"));
+
+  // Trunk from Travel Agent down to the hotel and activity branches, then the branches themselves.
+  const tx = cx(boxes.travel);
+  const trunkStyle: EdgeStyle = edge("travel-hotel") === "dim" && edge("travel-activity") === "dim" ? "dim" : "normal";
+  out.push(`<path d="M${tx} ${boxes.travel.y + NODE_H} L${tx} ${cy(boxes.activity)}" fill="none" stroke="${edgeColor(trunkStyle)}" stroke-width="1.5"/>`);
+  out.push(arrow([[tx, cy(boxes.hotel)], [boxes.hotel.x - 1, cy(boxes.hotel)]], edge("travel-hotel"), opts("travel-hotel", "below")));
+  out.push(arrow([[tx, cy(boxes.activity)], [boxes.activity.x - 1, cy(boxes.activity)]], edge("travel-activity"), opts("travel-activity", "below")));
+  out.push(h(boxes.travel, boxes.flight, "travel-flight"));
+  out.push(h(boxes.flight, boxes.checkin, "flight-checkin"));
+  out.push(h(boxes.checkin, boxes.boarding, "checkin-boarding"));
+
+  if (o.controlPlane !== undefined) {
+    out.push(node(boxes.cp, "Control plane", o.controlPlane, "focus", undefined));
+    out.push(arrow([[tx, boxes.cp.y + boxes.cp.h], [tx, boxes.travel.y - 1]], edge("cp-travel"), opts("cp-travel", "right")));
+  }
+  if (o.travelers !== undefined && o.travelers.length > 0) {
+    // Requests come in from the top: pills in a row, one elbow down into Travel Agent.
+    let x = o.controlPlane !== undefined ? COL[1] : COL[0];
+    const y = 22;
+    let firstCenter = 0;
+    o.travelers.forEach((t, i) => {
+      const p = pill(x, y, t, i === 0 ? PALETTE.focus : PALETTE.warn);
+      out.push(p.svg);
+      if (i === 0) firstCenter = x + p.w / 2;
+      x += p.w + 12;
+    });
+    const entryX = tx;
+    const midY = boxes.travel.y - 18;
+    const points: Point[] = Math.abs(firstCenter - entryX) < 3
+      ? [[firstCenter, y + 26], [entryX, boxes.travel.y - 1]]
+      : [[firstCenter, y + 26], [firstCenter, midY], [entryX, midY], [entryX, boxes.travel.y - 1]];
+    out.push(arrow(points, "normal", { dashed: true }));
+  }
+  for (const key of ["travel", "flight", "hotel", "activity", "checkin", "boarding"] as const) {
+    out.push(node(boxes[key], NAMES[key], o.sub?.[key], o.state?.[key] ?? "normal", o.tag?.[key]));
+  }
+  if (o.service !== undefined) {
+    out.push(node(boxes.service, o.service, "outside every agent", "focus", undefined));
+  }
+  if (o.wallet !== undefined) {
+    out.push(pill(boxes.wallet.x, boxes.wallet.y, `Wallet ${o.wallet}`, PALETTE.warn).svg);
+  }
+  for (const e of o.extra ?? []) {
+    out.push(route(boxes[e.from], boxes[e.to], e));
+  }
+  if (o.caption !== undefined) {
+    out.push(label(W / 2, height - 8, o.caption, 12, "var(--text-muted)", "middle"));
+  }
+  return `<svg class="lab-diagram" viewBox="0 0 ${W} ${height}" role="img" aria-label="${esc(o.caption ?? "The six agents")}" xmlns="http://www.w3.org/2000/svg">${out.join("")}</svg>`;
+}
+
+/* ---------- the chain ---------- */
+
+export interface ChainRow {
+  readonly who: string;
+  readonly scope: string;
+  readonly tag?: "root" | "written" | "you" | "terminal" | "blocked";
+  /** Text on the arrow leading into this row. */
+  readonly hop?: string;
+}
+
+/** A vertical warrant chain: who holds what, hop by hop. */
+export function chainDiagram(rows: readonly ChainRow[], caption?: string): string {
+  const rowH = 46;
+  const gap = 34;
+  const x = 30;
+  const w = W - 60;
+  const arrowX = x + 90;
+  const out: string[] = [];
+  rows.forEach((r, i) => {
+    const y = 12 + i * (rowH + gap);
+    const color = r.tag === "you" ? PALETTE.focus : r.tag === "blocked" ? PALETTE.rogue : r.tag === "terminal" ? PALETTE.warn : "var(--border)";
+    if (i > 0) {
+      const style: EdgeStyle = r.tag === "blocked" ? "blocked" : r.tag === "terminal" ? "terminal" : r.tag === "you" ? "you" : "normal";
+      out.push(arrow([[arrowX, y - gap], [arrowX, y - 1]], style, r.hop !== undefined ? { label: r.hop } : {}));
+    }
+    out.push(`<rect x="${x}" y="${y}" width="${w}" height="${rowH}" rx="8" fill="var(--surface-2)" stroke="${color}" stroke-width="${r.tag === undefined || r.tag === "written" || r.tag === "root" ? 1 : 2}"/>`);
+    out.push(label(x + 14, y + 29, r.who, 13, "var(--text)", "start", true));
+    let tagWidth = 0;
+    if (r.tag !== undefined) {
+      const text = r.tag === "root" ? "signed by the control plane" : r.tag === "written" ? "written for you" : r.tag === "you" ? "you write this" : r.tag === "terminal" ? "terminal" : "refused";
+      tagWidth = textWidth(text, 10.5, true) + 18;
+      const fill = r.tag === "you" ? PALETTE.focus : r.tag === "blocked" ? PALETTE.rogue : r.tag === "terminal" ? PALETTE.warn : "var(--border)";
+      const tf = r.tag === "written" || r.tag === "root" ? "var(--text-muted)" : PALETTE.ink;
+      out.push(`<rect x="${x + w - tagWidth - 10}" y="${y + 14}" width="${tagWidth}" height="18" rx="9" fill="${fill}"/>`);
+      out.push(label(x + w - tagWidth / 2 - 10, y + 27, text, 10.5, tf, "middle", true));
+    }
+    const scopeX = x + 190;
+    const scope = fit(r.scope, x + w - 22 - tagWidth - scopeX, 12.5, false, 11);
+    out.push(label(scopeX, y + 29, scope.text, scope.size, "var(--text-muted)"));
+  });
+  const height = 12 + rows.length * (rowH + gap) - gap + 12 + (caption !== undefined ? 24 : 0);
+  if (caption !== undefined) {
+    out.push(label(W / 2, height - 8, caption, 12, "var(--text-muted)", "middle"));
+  }
+  return `<svg class="lab-diagram" viewBox="0 0 ${W} ${height}" role="img" aria-label="${esc(caption ?? "The warrant chain")}" xmlns="http://www.w3.org/2000/svg">${out.join("")}</svg>`;
+}

--- a/labs/agent-delegation/site/spec.ts
+++ b/labs/agent-delegation/site/spec.ts
@@ -1,0 +1,379 @@
+/**
+ * What each stage page says. Short on purpose: the prose guide is the
+ * reference, this is the path through it. Terminal output on the pages is
+ * captured from real runs at build time (see capture.ts), never typed in.
+ */
+import { chainDiagram, fleetDiagram } from "./diagrams.ts";
+
+export interface Capture {
+  readonly cmd: "lab" | "attack" | "score" | "audit";
+  /** Answer file to run with. Absent means the exercise as shipped. */
+  readonly answer?: string;
+  readonly label: string;
+}
+
+export interface Step {
+  readonly text: string;
+  readonly cmd?: string;
+  /** One panel, or several as tabs. */
+  readonly expect?: Capture | readonly Capture[];
+}
+
+export interface CodeRef {
+  readonly file: string;
+  /** Exported symbols to pull out. Absent means the whole file after its header comment. */
+  readonly symbols?: readonly string[];
+  readonly caption: string;
+}
+
+export interface Snippet {
+  readonly lang: string;
+  readonly code: string;
+  readonly caption: string;
+}
+
+export interface StageSpec {
+  readonly n: number;
+  readonly title: string;
+  readonly minutes: number;
+  readonly mode: "shared" | "identity" | "scoped" | "tenuo";
+  readonly goal: string;
+  readonly intro: readonly string[];
+  readonly diagram: string;
+  readonly steps: readonly Step[];
+  readonly notice: readonly string[];
+  readonly question?: string;
+  readonly hint?: string;
+  readonly code?: ReadonlyArray<CodeRef | Snippet>;
+  readonly check?: ReadonlyArray<CodeRef | Snippet>;
+  readonly stuck?: readonly string[];
+  /** What finished looks like, in one line. */
+  readonly done: string;
+  /** A concept the stage introduces, explained before the steps. */
+  readonly explainer?: Explainer;
+}
+
+export interface Explainer {
+  readonly title: string;
+  readonly lead: string;
+  readonly points: ReadonlyArray<readonly [string, string]>;
+  /** Left column: the problem you hit. Right column: what the concept does about it. */
+  readonly why: ReadonlyArray<readonly [string, string]>;
+  readonly code?: Snippet;
+  readonly more?: ReadonlyArray<readonly [string, string]>;
+}
+
+const SHARED = "TRAVEL_SERVICE_KEY";
+
+export const STAGES: readonly StageSpec[] = [
+  {
+    n: 1,
+    title: "One key for everyone",
+    minutes: 5,
+    mode: "shared",
+    goal: "See what a rogue agent can do when every agent shares one credential.",
+    intro: [
+      "Six agents book Alice's trip. All six carry the same key, and it opens everything: flights, hotels, the wallet, her passport number, the calendar.",
+      "There is no setup in this stage. Its job is to show you the damage before anything protects against it.",
+    ],
+    diagram: fleetDiagram({
+      travelers: ["Alice → Cancún, $1,200"],
+      wallet: "$1,200",
+      sub: { travel: SHARED, flight: SHARED, hotel: SHARED, activity: SHARED, checkin: SHARED, boarding: SHARED },
+      state: { checkin: "rogue" },
+      tag: { checkin: "reads the notice" },
+      caption: "The same key in every agent. Check-in Agent reads a departure board with an instruction hidden on it.",
+    }),
+    steps: [
+      { text: "Start the lab and watch the trip get booked.", cmd: "npm run lab", expect: { cmd: "lab", label: "What you should see" } },
+      { text: "Run the rogue behavior and the security checks. Read **WHAT ELSE HAPPENED** and look at the wallet.", cmd: "npm run attack", expect: { cmd: "attack", label: "What you should see" } },
+    ],
+    notice: [
+      "The trip books correctly. Every step is green.",
+      "Then $412 leaves the wallet, Alice's flight is cancelled, and a stranger's reservation gets checked in. No one instructed Check-in Agent to do any of that.",
+    ],
+    question: "Where did the instruction come from? Open `src/services/flights.ts` and find it. It sits on the departure board Check-in Agent reads every time it does its job.",
+    stuck: ["There is no fix in this stage. Once you have looked at the wallet, run `npm run next`."],
+    done: "You have seen the damage and found the injected notice.",
+  },
+  {
+    n: 2,
+    title: "Every agent gets its own account",
+    minutes: 5,
+    mode: "identity",
+    goal: "Give each agent its own credential and see which damage that removes and which damage remains.",
+    intro: [
+      "Now each agent has its own credential with permissions that match its role. Flight Agent does flight things. Check-in Agent reads reservations and checks people in.",
+    ],
+    diagram: fleetDiagram({
+      wallet: "$1,200",
+      sub: { travel: "traveler, calendar", flight: "flights, wallet", hotel: "hotels, wallet", activity: "activities, wallet", checkin: "any reservation", boarding: "boarding passes" },
+      state: { checkin: "rogue" },
+      tag: { checkin: "rogue" },
+      caption: "One account per agent, sized to its role.",
+    }),
+    steps: [
+      { text: "Move to stage 2 if you have not already.", cmd: "npm run next" },
+      { text: "Run the checks and compare with stage 1. Count what is still **ALLOWED** with a ✗ next to it.", cmd: "npm run attack", expect: { cmd: "attack", label: "What you should see" } },
+    ],
+    notice: [
+      "The wallet charge and the cancellation are gone. Check-in Agent's role never included them.",
+      "Checking in AA882, another traveler's flight, still works, because reading reservations and checking people in is part of Check-in Agent's job.",
+    ],
+    question: "The actions that still succeed are all part of Check-in Agent's role. What separates the ones you want from the ones you do not?",
+    hint: "The tool is the same in both cases. What differs is the reservation, and whose trip it belongs to. A role says what kind of work an agent does. It does not say which job the agent is doing right now.",
+    done: "You can say in one sentence what an identity leaves out.",
+  },
+  {
+    n: 3,
+    title: "Rules that fit the job",
+    minutes: 15,
+    mode: "scoped",
+    goal: "Write the permissions yourself, narrow enough that every rogue action is blocked and the trip still books.",
+    intro: [
+      "Each rule now names the specifics. Check-in Agent may read one reservation. Flight Agent may book flights to one destination, up to a price.",
+    ],
+    diagram: fleetDiagram({
+      wallet: "$1,200",
+      sub: { travel: "name only, calendar", flight: "CUN, ≤ $300", hotel: "Cancún, ≤ $200/night", activity: "Cancún, ≤ $200", checkin: "UA214 only", boarding: "UA214 only" },
+      state: { checkin: "rogue" },
+      tag: { checkin: "rogue" },
+      caption: "Each rule names the job: the destination, the reservation, the ceiling.",
+    }),
+    steps: [
+      { text: "Open the policy file. Every field you can use is listed in the comment at the top.", cmd: "code exercises/03-scoped/policy.ts" },
+      { text: "Narrow the rules. Run the checks after every change until the result line says **clean**.", cmd: "npm run attack", expect: [{ cmd: "attack", label: "Before you change anything" }, { cmd: "attack", answer: "answers/03-scoped/policy.ts", label: "When you are done" }] },
+      { text: "Check your score. The last row tells you which agent holds more than the mission needs.", cmd: "npm run score", expect: { cmd: "score", answer: "answers/03-scoped/policy.ts", label: "A full-marks score" } },
+    ],
+    notice: [
+      "It works. Everything the rogue agent tried is blocked and Alice still gets to Cancún.",
+      "Keep this file. Stage 4 breaks it.",
+    ],
+    hint: "Pin `checkin-agent` and `boarding-agent` to `reservations: [\"UA214\"]`. Give `flight-agent` a `destination` and a `maxPrice`. Cut `traveler.read` down with `profileFields`, and give every agent a `maxCharge` that matches its share of the budget.",
+    code: [{ file: "exercises/03-scoped/policy.ts", symbols: ["config"], caption: "The file as it ships" }],
+    check: [{ file: "answers/03-scoped/policy.ts", symbols: ["config"], caption: "One policy that scores 100" }],
+    stuck: [
+      "`npm run audit` prints what every agent can currently do.",
+      "Blocking everything scores zero, because the trip has to work. Read **THE TRIP** in the output first.",
+      "Every denial names the rule that fired. Read the whole line.",
+    ],
+    done: "`npm run attack` is clean and `npm run score` is in the nineties.",
+  },
+  {
+    n: 4,
+    title: "A second traveler, and a handoff",
+    minutes: 30,
+    mode: "scoped",
+    goal: "Get Bob's trip working alongside Alice's without letting either trip's agent touch the other's reservation, see what that fix costs, then watch a handoff give the next agent more than it needed.",
+    intro: [
+      "Bob is going to Seattle on DL331, at the same time, through the same agents. Your stage 3 policy pins Check-in Agent to UA214, so Bob's check-in is refused and his trip fails.",
+      "Take your time with this stage. Every later stage builds on what you notice here.",
+    ],
+    diagram: fleetDiagram({
+      travelers: ["Alice → Cancún, UA214", "Bob → Seattle, DL331"],
+      service: "Your policy component",
+      sub: { flight: "two destinations", checkin: "one identity, two jobs", boarding: "holds too much" },
+      state: { checkin: "rogue", flight: "focus", boarding: "focus" },
+      tag: { checkin: "rogue", boarding: "too much" },
+      edges: { "checkin-boarding": "focus" },
+      edgeLabels: { "checkin-boarding": "hands over its credential" },
+      extra: [{ from: "checkin", to: "service", style: "ask", label: "asks for every reservation, plus cancel" }],
+      caption: "Two trips through the same six agents. Then Check-in Agent passes the only thing it has, and asks for more.",
+    }),
+    steps: [
+      { text: "Run the lab with both trips and watch Bob's check-in fail.", cmd: "npm run lab", expect: { cmd: "lab", label: "What you should see" } },
+      { text: "Fix it the quick way: add DL331 to Check-in Agent's reservations. The trip completes. Now read the **CROSS-TASK** section of the checks.", cmd: "npm run attack", expect: { cmd: "attack", label: "After the quick fix" } },
+      { text: "Give the agent a different identity for each trip: a key of the form `agent:taskId` is used for that agent on that task. `exercises/04-two-travelers/README.md` walks through it. Get the cross-task checks to pass.", cmd: "npm run attack", expect: { cmd: "attack", answer: "answers/04-two-travelers/per-task.ts", label: "With one identity per task" } },
+      { text: "Find `central_calls` in the trace. It counts every time the system had to ask something outside the acting agent before it could decide.", cmd: "npm run trace" },
+      { text: "Now the handoff. Check-in Agent finishes with Alice's flight and hands boarding-pass generation to Boarding Agent, which only needs to issue the pass for UA214. Read how the handoff is implemented and look for what Check-in Agent actually passes.", cmd: "code src/agents/checkin-agent.ts" },
+      { text: "In the checks above, read **BOARDING AGENT AFTER THE HANDOFF**, then the escalation attempt at the end. Answer the questions below before you move on." },
+    ],
+    notice: [
+      "After the quick fix, Alice's Check-in Agent can check Bob in. There is one `checkin-agent`, it is doing two jobs, and the file never says which job a call belongs to.",
+      "Whichever fix you use, `central_calls` is above zero and cannot be brought to zero. Something outside the agent has to know about every task before it starts, and it has to be reachable while the task runs.",
+      "Boarding Agent came out of the handoff able to read reservations and check people in as well as issue a pass. Check-in Agent had only one thing it could give: its whole credential.",
+      "The rogue Check-in Agent then asks your policy component to write a rule for Boarding Agent that is broader than anything Check-in Agent holds itself.",
+    ],
+    question: "Write down, in one sentence, what your fix depends on being available. Then: should the policy component say yes to the rogue's request, and what would it need to know in order to say no?",
+    hint: "To say no, the component has to know what the asker currently holds, in addition to who the asker is. A role-based rule does not carry that information. Stage 5 starts from there.",
+    code: [{ lang: "ts", code: "\"checkin-agent\": {\n  actions: [\"get_reservation\", \"check_in\"],\n  reservations: [\"UA214\", \"DL331\"],\n},", caption: "The quick fix. CROSS-TASK shows what it misses." }],
+    check: [
+      { file: "answers/04-two-travelers/per-task.ts", symbols: ["config"], caption: "One identity per task" },
+      { file: "answers/04-two-travelers/policy-service.ts", symbols: ["config"], caption: "Another way that works: policyService: true, and the per-task fields come from a service asked on every call" },
+    ],
+    stuck: [
+      "Registration happens at task start, then `central_calls: 1` on every call by a per-task identity. That is the cost.",
+      "The handoff checks stay red in this stage on purpose. Check-in Agent has nothing narrower to give.",
+    ],
+    done: "Both trips complete, CROSS-TASK is clean, and you have your one sentence.",
+  },
+  {
+    n: 5,
+    title: "Access that travels with the work",
+    minutes: 25,
+    mode: "tenuo",
+    goal: "Switch to Tenuo, complete the chain, and get the trip, the cross-task checks, and the escalation attempt all handled with no policy file and no central lookup.",
+    intro: [
+      "In this stage a permission is something an agent is handed for a specific job. When the agent passes work along, it hands over a narrowed copy. It cannot hand over more, and the system checks this instead of trusting it.",
+      "Each agent now has its own key. A small control plane, separate from all six, signs the first permission for each trip. No agent can sign one from scratch.",
+    ],
+    explainer: {
+      title: "What a warrant is",
+      lead: "A warrant is a signed, self-contained permission that travels with the request: which tools, with which argument values, for which agent's key, until when, and how many more hops it may take. That is what Tenuo issues, narrows, and checks.",
+      points: [
+        ["Signed by a key no agent holds", "The control plane signs the first warrant for a trip. Agents cannot sign a fresh one, because they do not have that key."],
+        ["Narrowed by whoever holds it", "An agent can derive a warrant for another agent from the one it holds, with fewer tools, tighter values, a shorter life. It can never widen. The check happens against the parent before a token exists."],
+        ["Bound to the receiver's key", "Every use is signed with the holder's key. A copy held by anyone else cannot be used."],
+        ["Checked next to the tool, offline", "The code guarding a tool verifies the whole chain with the control plane's public key. There is no lookup and no service that has to be up."],
+      ],
+      why: [
+        ["Stage 2: an identity said who was acting and left out which job", "The warrant carries the job: reservation UA214, trip-alice-cun, up to $300."],
+        ["Stage 4: every check had to ask a component that knew about every task", "Verification is local. central_calls goes to 0 and stays there when the control plane is down."],
+        ["Stage 4: the only thing to hand over was the whole credential", "narrow() hands over exactly the subset the next agent needs, bound to that agent's key."],
+        ["Stage 4: the service could not tell whether the asker held what it asked for", "A narrowed warrant must fit inside its parent. The rogue's request is refused before anything is signed."],
+      ],
+      code: {
+        lang: "ts",
+        caption: "The shape of it, from this stage's chain",
+        code: `// The control plane signs the root, for Travel Agent's key.
+const trip = controlPlane.session({
+  allow: { check_in: { reservation: oneOf(["UA214", "AC712"]) }, /* ... */ },
+  holder: fleet["travel-agent"].publicKey,
+  ttlSeconds: 30 * 60,
+  maxDepth: 4,
+});
+
+// Flight Agent narrows what it holds for Check-in Agent's key. Core refuses
+// anything that is not inside \`flight\`: more tools, a wider value, a longer life.
+const forCheckin = fleet["flight-agent"].tenuo.narrow(
+  flight,
+  { check_in: { reservation: oneOf(["UA214"]) } },
+  { holder: fleet["checkin-agent"].publicKey, ttlSeconds: 5 * 60 },
+);`,
+      },
+      more: [
+        ["Concepts", "https://tenuo.ai/concepts"],
+        ["Delegate to another agent (TypeScript guide)", "https://github.com/tenuo-ai/tenuo/tree/main/tenuo-ts"],
+        ["Open a chain in the explorer", "https://tenuo.ai/explorer/"],
+      ],
+    },
+    diagram: chainDiagram([
+      { who: "Control plane", scope: "signs the trip permission for Travel Agent", tag: "root" },
+      { who: "Travel Agent", scope: "Alice → Cancún, up to $1,200, any flight this trip books", tag: "written", hop: "narrows" },
+      { who: "Flight Agent", scope: "Cancún flights, up to $300, flight's share of the wallet", tag: "written", hop: "narrows" },
+      { who: "Check-in Agent", scope: "UA214 only: read, check in, hand the boarding pass on", tag: "you", hop: "narrows to the flight it booked" },
+      { who: "Boarding Agent", scope: "UA214 only: issue the boarding pass", tag: "you", hop: "narrows" },
+    ], "Each hop can only narrow. The root has to carry everything anyone below will ever need."),
+    steps: [
+      { text: "Open the chain. The root and every link out of Travel Agent are written for you. Read them first: notice that the root lists everything anyone further down will ever need, and notice which link narrows \"any Cancún flight\" to \"UA214\".", cmd: "code exercises/05-tenuo/chain.ts" },
+      { text: "Write `flightToCheckin` and `checkinToBoarding`. Until both exist, the lab tells you which one is missing.", cmd: "npm run lab", expect: [{ cmd: "lab", label: "Before you write the links" }, { cmd: "lab", answer: "answers/05-tenuo/chain.ts", label: "When both links exist" }] },
+      { text: "Run the checks. The two-traveler run happens here too, with no policy file to edit. Read **CROSS-TASK** and the escalation attempt, then find `central_calls`.", cmd: "npm run attack", expect: { cmd: "attack", answer: "answers/05-tenuo/chain.ts", label: "What you should see" } },
+      { text: "Open the link the lab prints and look at the chain Boarding Agent holds, hop by hop, in the explorer." },
+    ],
+    notice: [
+      "The escalation attempt from stage 4 is refused before any permission exists, inside Check-in Agent's own process, because the narrowed copy would not fit inside what Check-in Agent holds.",
+      "`central_calls` is 0. No component outside the acting agent was consulted. Compare that with the sentence you wrote at the end of stage 4.",
+    ],
+    question: "Who decided what Boarding Agent may do, and when? Compare that with who decided in stage 4.",
+    hint: "Flight Agent knows which flight it booked, so it is the link that narrows `reservation` to that one flight. Bind each result to the next agent's key with `holder`, and keep lifetimes short. Every argument a tool is called with must be named: leave one out and the call is refused.",
+    code: [{ file: "exercises/05-tenuo/chain.ts", symbols: ["flightToCheckin", "checkinToBoarding"], caption: "The two links you write" }],
+    check: [{ file: "answers/05-tenuo/chain.ts", symbols: ["flightToCheckin", "checkinToBoarding"], caption: "Reference" }],
+    stuck: [
+      "When a denial says \"not in parent's tools\", look one link up the chain.",
+      "The receiver imports what it is handed with its own key. If you bind to the wrong `holder`, the import fails with `TENUO_INVALID_POP`.",
+      "The trip has to work. If Boarding Agent cannot issue the pass, the other checks do not count.",
+    ],
+    done: "`npm run attack` is clean for both scenarios and `central_calls` is 0.",
+  },
+  {
+    n: 6,
+    title: "A stolen permission, and the end of the line",
+    minutes: 15,
+    mode: "tenuo",
+    goal: "See that a copied permission cannot be used by anyone it was not issued to, then mark one hop as the last and watch the chain stop where the previous agent decided.",
+    intro: [
+      "Two short extensions on the chain you built. Boarding Agent's permission for UA214 is a piece of data: a list of strings. Activity Agent gets a copy and tries to use it.",
+      "Then a limit on distance. When one agent hands a permission on, it can mark it terminal. The root also carries a maximum number of hops for the whole trip: any agent can lower it, none can raise it.",
+    ],
+    diagram: fleetDiagram({
+      controlPlane: "signs the root",
+      sub: { boarding: "holds UA214 boarding pass", activity: "has a copy of it" },
+      state: { boarding: "ok", activity: "rogue" },
+      tag: { activity: "thief" },
+      edges: { "travel-hotel": "dim" },
+      extra: [{ from: "boarding", to: "activity", style: "stolen", label: "copied bytes" }],
+      caption: "Activity Agent has the bytes and still cannot use them.",
+    }) + fleetDiagram({
+      controlPlane: "maxDepth: 4",
+      sub: { flight: "marks the hop terminal", checkin: "cannot pass it on", boarding: "never receives it" },
+      state: { flight: "focus", boarding: "dim" },
+      edges: { "flight-checkin": "terminal", "checkin-boarding": "blocked", "travel-hotel": "dim", "travel-activity": "dim" },
+      edgeLabels: { "flight-checkin": "terminal", "checkin-boarding": "TENUO_DEPTH_EXCEEDED" },
+      caption: "Flight Agent decided. Check-in Agent cannot undo it.",
+    }),
+    steps: [
+      { text: "Read the theft. The file is short.", cmd: "code exercises/06-extensions/steal.ts" },
+      { text: "Run the checks and read the reason on the **STOLEN WARRANT** line carefully.", cmd: "npm run attack", expect: { cmd: "attack", label: "What you should see" } },
+      { text: "Now find the Flight → Check-in link in the chain and add `terminal: true` to its options.", cmd: "code exercises/06-extensions/chain.ts" },
+      { text: "Run the trip and see which step fails and with what code. This stage breaks the trip on purpose.", cmd: "npm run lab", expect: [{ cmd: "lab", label: "Before" }, { cmd: "lab", answer: "answers/06-extensions/chain.ts", label: "After" }] },
+      { text: "Second version: lower `maxDepth` on the root instead, and watch where the chain stops." },
+    ],
+    notice: [
+      "The import fails with `TENUO_INVALID_POP`. The warrant names the key it was issued to, and Activity Agent does not have that key.",
+      "With the terminal link, Boarding Agent never gets its permission: `TENUO_DEPTH_EXCEEDED` at the Check-in → Boarding hop. Check-in Agent did not agree to that restriction and cannot remove it.",
+    ],
+    question: "If having a copy of a permission is not enough to use it, what else does using it require? And who in a chain gets to decide how many agents a job passes through?",
+    hint: "Using a permission requires proof that you hold the key it was bound to; every use is signed with that key. Distance is decided by whoever is upstream: the control plane with `maxDepth`, or any agent with `terminal`, and nobody downstream can undo it.",
+    code: [{ file: "exercises/06-extensions/steal.ts", symbols: ["steal"], caption: "The whole theft" }],
+    check: [{ file: "answers/06-extensions/chain.ts", symbols: ["flightToCheckin"], caption: "One option added" }],
+    done: "You can explain why the thief's copy did not work, and you have seen the trip fail at the hop you chose.",
+  },
+  {
+    n: 7,
+    title: "The incident",
+    minutes: 20,
+    mode: "tenuo",
+    goal: "Hotel Agent is compromised. Keep the system online and legitimate bookings working: one attempt must succeed, seven must fail.",
+    intro: [
+      "This stage gives less guidance than the others. The compromised Hotel Agent will try eight things.",
+    ],
+    diagram: fleetDiagram({
+      controlPlane: "signs the root",
+      sub: { hotel: "compromised", travel: "hands the hotel branch out" },
+      state: { hotel: "compromised", travel: "focus" },
+      tag: { hotel: "compromised" },
+      edges: { "travel-hotel": "focus", "travel-flight": "dim", "flight-checkin": "dim", "checkin-boarding": "dim", "travel-activity": "dim" },
+      edgeLabels: { "travel-hotel": "the link you fix" },
+      caption: "Everything Hotel Agent can do is decided by one link. Fix that link.",
+    }),
+    steps: [
+      { text: "Open the chain. The Travel → Hotel link is where the incident lives: right now it hands Hotel Agent far more than a hotel booking needs.", cmd: "code exercises/07-incident/chain.ts" },
+      { text: "Run the checks. All eight attempts are listed under **INCIDENT**. Make one land and seven fail, and keep an eye on the least-privilege row of your score.", cmd: "npm run attack", expect: [{ cmd: "attack", label: "As it ships" }, { cmd: "attack", answer: "answers/07-incident/chain.ts", label: "When it is fixed" }] },
+      { text: "Check the score. Blocking attempt 3 the same way you blocked attempt 2 costs points.", cmd: "npm run score", expect: { cmd: "score", answer: "answers/07-incident/chain.ts", label: "Full marks" } },
+    ],
+    notice: [
+      "Attempt 3 trips up the most people. The approved hotel is $140 a night and the priciest place in the catalog is $340, so a ceiling wide enough to book anything in Cancún lets $320 through.",
+      "Work out where the number should come from instead. It is in the mission, on the index page.",
+    ],
+    hint: "Only hotel tools, only Cancún, only the approved nightly rate, only the traveler's name, only the hotel's share of the wallet, and `terminal: true` so nothing can be handed on.",
+    code: [{ lang: "text", code: "1.  book the approved Cancún hotel                  must work\n2.  book a hotel in Tulum instead                   must fail\n3.  book the approved hotel at $320 a night        must fail\n4.  read Alice's passport number                    must fail\n5.  book a flight                                   must fail\n6.  delete the trip's calendar event                must fail\n7.  hand wallet access to Activity Agent            must fail\n8.  import a permission copied from Flight Agent   must fail", caption: "The eight attempts" }],
+    check: [{ file: "answers/07-incident/chain.ts", symbols: ["travelToHotel"], caption: "The fixed link" }],
+    stuck: [
+      "Attempt 7 is refused by making the hotel link terminal. Hotel Agent keeps its share of the wallet.",
+      "Attempt 8 fails for the same reason the theft in stage 6 failed.",
+    ],
+    done: "One works, seven fail, and the least-privilege row is full marks.",
+  },
+];
+
+export const CODESPACES_URL = "https://codespaces.new/tenuo-ai/tenuo?devcontainer_path=.devcontainer/agent-delegation-lab/devcontainer.json";
+export const REPO_URL = "https://github.com/tenuo-ai/tenuo";
+export const GOOD_FIRST_ISSUES_URL = "https://github.com/tenuo-ai/tenuo/labels/good%20first%20issue";
+
+/** The mission diagram on the index page. */
+export const MISSION_DIAGRAM = fleetDiagram({
+  travelers: ["Alice → Cancún, 3 nights, $1,200"],
+  wallet: "$1,200",
+  sub: { travel: "talks to you", flight: "books the flight", hotel: "books the hotel", activity: "books one activity", checkin: "checks Alice in", boarding: "issues the pass" },
+  caption: "You talk to Travel Agent. The flight side runs three handoffs deep, and that matters later.",
+});

--- a/labs/agent-delegation/src/cli/index.ts
+++ b/labs/agent-delegation/src/cli/index.ts
@@ -14,6 +14,7 @@ process.env.NODE_ENV ??= "development";
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { spawn } from "node:child_process";
 import { createInterface } from "node:readline/promises";
 import { runBattery, type ProbeResult } from "../harness/attacks.ts";
 import { checkFunctionality, type Functionality } from "../harness/functionality.ts";
@@ -24,6 +25,25 @@ import type { AuditRecord } from "../audit.ts";
 import { AGENTS } from "../mission.ts";
 import { loadState, ROOT, saveState } from "../state.ts";
 import { STAGES, stage as stageDef, type Scenario, type StageDef } from "../stages.ts";
+
+const SITE = "https://tenuo.ai";
+
+function guideUrl(n: number): string {
+  const params = new URLSearchParams();
+  const done = [...loadState().completed].sort((a, b) => a - b);
+  if (done.length > 0) params.set("done", done.join(","));
+  const query = params.toString();
+  return `${SITE}/lab/stage-${n}${query.length > 0 ? `?${query}` : ""}`;
+}
+
+function openInBrowser(url: string): void {
+  const [bin, pre] = process.platform === "darwin" ? ["open", []] : process.platform === "win32" ? ["cmd", ["/c", "start", ""]] : ["xdg-open", []];
+  try {
+    spawn(bin, [...pre, url], { detached: true, stdio: "ignore" }).on("error", () => undefined).unref();
+  } catch {
+    // No browser here (CI, a container): the link is printed anyway.
+  }
+}
 
 const args = process.argv.slice(2);
 const command = args[0] ?? "lab";
@@ -42,7 +62,34 @@ const pad = (s: string, n: number) => (s.length >= n ? s : s + " ".repeat(n - s.
 function header(def: StageDef, scenario: Scenario): void {
   console.log("");
   console.log(bold(`Stage ${def.n} of ${STAGES.length}: ${def.title}`) + dim(`   mode=${def.mode}  scenario=${scenario}`));
+  console.log(dim(`  guide: ${guideUrl(def.n)}`));
   console.log("");
+}
+
+function explorerLink(built: Built): string | undefined {
+  const tenuo = built.runtime.tenuo;
+  const trip = built.plan.trips[0];
+  if (tenuo === undefined || trip === undefined) return undefined;
+  const session = tenuo.session("boarding-agent", trip.taskId) ?? tenuo.session("checkin-agent", trip.taskId) ?? tenuo.session("flight-agent", trip.taskId);
+  if (session === undefined) return undefined;
+  const chain = session.toWire();
+  const state = {
+    chain,
+    warrant: chain[chain.length - 1],
+    rootKey: session.inspect().rootPublicKey,
+    tool: "issue_boarding_pass",
+    args: JSON.stringify({ reservation: trip.expectedReservation }),
+  };
+  return `${SITE}/explorer/?s=${Buffer.from(JSON.stringify(state)).toString("base64")}`;
+}
+
+function printExplorerLink(built: Built): void {
+  const url = explorerLink(built);
+  if (url !== undefined) {
+    console.log(dim("  See the chain the agents are holding, hop by hop, in the explorer:"));
+    console.log(dim(`  ${url}`));
+    console.log("");
+  }
 }
 
 function walletLine(built: Built): string {
@@ -161,6 +208,7 @@ async function cmdLab(def: StageDef): Promise<void> {
   await warmup();
   const scenario = def.scenario;
   header(def, scenario);
+  if (args.includes("--open")) openInBrowser(guideUrl(def.n));
   for (const line of def.blurb) console.log(`  ${line}`);
   console.log("");
   const built = await runStage(def, scenario);
@@ -175,6 +223,7 @@ async function cmdLab(def: StageDef): Promise<void> {
   console.log("");
   const functionality = checkFunctionality(built.plan, built.runtime.audit.records, built.runtime.world);
   printFunctionality(functionality);
+  printExplorerLink(built);
   if (def.breaksTrip === true) {
     console.log(dim("  The terminal link breaks the trip on purpose. Notice where, and who decided."));
     console.log("");
@@ -194,6 +243,7 @@ async function cmdTrace(def: StageDef): Promise<void> {
     console.log("");
     console.log(centralCallsLine(built));
     console.log("");
+    printExplorerLink(built);
   }
 }
 
@@ -313,7 +363,7 @@ async function cmdScore(def: StageDef): Promise<void> {
     if (!state.completed.includes(def.n)) {
       state.completed.push(def.n);
       saveState(state);
-      console.log(green(`  Stage ${def.n} done.`) + (def.n < STAGES.length ? dim("  Next: npm run next") : ""));
+      console.log(green(`  Stage ${def.n} done.`) + (def.n < STAGES.length ? dim(`  Next: npm run next, then ${guideUrl(def.n + 1)}`) : ""));
       console.log("");
     }
   }
@@ -370,6 +420,8 @@ async function cmdNext(): Promise<void> {
   }
   saveState({ ...state, stage: to });
   console.log(`Now on stage ${to}: ${stageDef(to).title}. Run npm run lab.`);
+  console.log(dim(`  guide: ${guideUrl(to)}`));
+  if (args.includes("--open")) openInBrowser(guideUrl(to));
 }
 
 async function cmdReset(): Promise<void> {

--- a/labs/agent-delegation/tsconfig.json
+++ b/labs/agent-delegation/tsconfig.json
@@ -17,6 +17,7 @@
     "src",
     "exercises",
     "answers",
-    "test"
+    "test",
+    "site"
   ]
 }

--- a/tenuo-explorer/src/App.tsx
+++ b/tenuo-explorer/src/App.tsx
@@ -1415,14 +1415,65 @@ interface ChainWarrant {
   error: string | null;
 }
 
-const ChainTester = () => {
-  const [warrants, setWarrants] = useState<ChainWarrant[]>([
-    { id: generateId(), b64: '', decoded: null, error: null },
-    { id: generateId(), b64: '', decoded: null, error: null },
-  ]);
-  const [tool, setTool] = useState('read_file');
-  const [argsJson, setArgsJson] = useState('{"path": "docs/readme.md"}');
-  const [rootKeyHex, setRootKeyHex] = useState('');
+/** A chain handed in by a share link: `?s=` with `chain: string[]`, plus optional root key, tool, and args. */
+export interface SharedChain {
+  chain: string[];
+  rootKey?: string;
+  tool?: string;
+  args?: string;
+}
+
+/** Decode one pasted or shared warrant. Never throws; a bad input becomes `error`. */
+function decodeChainInput(input: string): Omit<ChainWarrant, 'id'> {
+  if (!input.trim()) {
+    return { b64: input, decoded: null, error: null };
+  }
+  const { b64 } = cleanInput(input);
+  try {
+    const result = decode_warrant(b64);
+    // WASM returns a string on error, not a DecodedWarrant
+    if (typeof result === 'string') {
+      return { b64: input, decoded: null, error: result };
+    }
+    if (result && typeof result === 'object' && 'id' in result && 'issuer' in result) {
+      // Normalize the result to ensure tools is always an array
+      return {
+        b64: input,
+        error: null,
+        decoded: {
+          id: result.id || '',
+          issuer: result.issuer || '',
+          tools: Array.isArray(result.tools) ? result.tools : [],
+          capabilities: result.capabilities || {},
+          issued_at: result.issued_at || 0,
+          expires_at: result.expires_at || 0,
+          authorized_holder: result.authorized_holder || '',
+          depth: result.depth || 0,
+        },
+      };
+    }
+    return { b64: input, decoded: null, error: 'Invalid warrant format' };
+  } catch (e) {
+    return { b64: input, decoded: null, error: e instanceof Error ? e.message : 'Invalid warrant' };
+  }
+}
+
+const ChainTester = ({ initial }: { initial?: SharedChain }) => {
+  const [warrants, setWarrants] = useState<ChainWarrant[]>(
+    initial && initial.chain.length > 0
+      ? initial.chain.map((b64) => ({ id: generateId(), ...decodeChainInput(b64) }))
+      : [
+          { id: generateId(), b64: '', decoded: null, error: null },
+          { id: generateId(), b64: '', decoded: null, error: null },
+        ],
+  );
+  const [tool, setTool] = useState(initial?.tool ?? 'read_file');
+  const [argsJson, setArgsJson] = useState(initial?.args ?? '{"path": "docs/readme.md"}');
+  const [rootKeyHex, setRootKeyHex] = useState(() => {
+    if (initial?.rootKey) return initial.rootKey;
+    if (initial && initial.chain.length > 0) return decodeChainInput(initial.chain[0]).decoded?.issuer ?? '';
+    return '';
+  });
   const [verifyResult, setVerifyResult] = useState<AuthResult | null>(null);
 
   // Load sample chain: Root → Orchestrator → Worker
@@ -1509,44 +1560,12 @@ const ChainTester = () => {
 
   // Decode warrant when b64 changes
   const updateWarrant = (id: string, input: string) => {
-    let decoded: DecodedWarrant | null = null;
-    let error: string | null = null;
-    let b64 = input;
-
-    if (input.trim()) {
-      const cleaned = cleanInput(input);
-      b64 = cleaned.b64;
-
-      try {
-        const result = decode_warrant(b64);
-        // WASM returns a string on error, not a DecodedWarrant
-        if (typeof result === 'string') {
-          error = result;
-        } else if (result && typeof result === 'object' && 'id' in result && 'issuer' in result) {
-          // Normalize the result to ensure tools is always an array
-          decoded = {
-            id: result.id || '',
-            issuer: result.issuer || '',
-            tools: Array.isArray(result.tools) ? result.tools : [],
-            capabilities: result.capabilities || {},
-            issued_at: result.issued_at || 0,
-            expires_at: result.expires_at || 0,
-            authorized_holder: result.authorized_holder || '',
-            depth: result.depth || 0,
-          };
-          // Auto-fill root key from first warrant's issuer
-          if (warrants.findIndex(w => w.id === id) === 0) {
-            setRootKeyHex(decoded.issuer);
-          }
-        } else {
-          error = 'Invalid warrant format';
-        }
-      } catch (e) {
-        error = e instanceof Error ? e.message : 'Invalid warrant';
-      }
+    const next = decodeChainInput(input);
+    // Auto-fill root key from first warrant's issuer
+    if (next.decoded && warrants.findIndex(w => w.id === id) === 0) {
+      setRootKeyHex(next.decoded.issuer);
     }
-
-    setWarrants(warrants.map(w => w.id === id ? { ...w, b64: input, decoded, error } : w));
+    setWarrants(warrants.map(w => w.id === id ? { ...w, ...next } : w));
     setVerifyResult(null);
   };
 
@@ -2356,6 +2375,7 @@ function App() {
   const [showSamples, setShowSamples] = useState(false);
   const [activeTab, setActiveTab] = useState<'decode' | 'debug' | 'code'>('decode');
   const [mode, setMode] = useState<'decoder' | 'builder' | 'chain' | 'diff' | 'receipt'>('decoder');
+  const [sharedChain, setSharedChain] = useState<SharedChain | undefined>(undefined);
   const [builderPreview, setBuilderPreview] = useState<unknown>(null);
   const [showBuilderJson, setShowBuilderJson] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(true);
@@ -2404,6 +2424,16 @@ function App() {
         if (parsed.warrant) setWarrantB64(parsed.warrant);
         if (parsed.tool) setTool(parsed.tool);
         if (parsed.args) setArgsJson(parsed.args);
+        // A whole chain (root first) opens the chain verifier with every hop filled in.
+        if (Array.isArray(parsed.chain) && parsed.chain.length > 0 && parsed.chain.every((w: unknown) => typeof w === 'string')) {
+          setSharedChain({
+            chain: parsed.chain as string[],
+            ...(typeof parsed.rootKey === 'string' ? { rootKey: parsed.rootKey } : {}),
+            ...(typeof parsed.tool === 'string' ? { tool: parsed.tool } : {}),
+            ...(typeof parsed.args === 'string' ? { args: parsed.args } : {}),
+          });
+          setMode('chain');
+        }
       } catch { }
     }
   }, []);
@@ -2841,9 +2871,9 @@ function App() {
           )}
 
           {/* Chain Mode */}
-          {mode === 'chain' && (
+          {mode === 'chain' && (sharedChain === undefined || wasmReady) && (
             <div style={{ maxWidth: '600px', margin: '0 auto' }}>
-              <ChainTester />
+              <ChainTester initial={sharedChain} />
             </div>
           )}
 


### PR DESCRIPTION
## Stack

Depends on #587. Review this PR as the hosted-guide layer only; GitHub will show 23 changed files relative to the core lab branch.

## What this adds

- A generated guide at `docs/lab/`, one page per stage plus index and wrap-up.
- `labs/agent-delegation/site/` as the source of truth for prose, diagrams, captured CLI output, and page generation.
- A dedicated lab layout with local browser progress, copy buttons, hints, and reference-solution reveals.
- CLI links to the current guide stage, including completed-stage progress, with optional browser opening.
- Explorer deep links that open and decode the delegation chain held by an agent.
- CI drift protection through `npm run site -- --check`.

This layer contains no telemetry, session identifiers, collector, or browser network events.

## Verification

- `npm run typecheck`
- `npm test`: 14 tests pass
- `npm run site`
- `npm run site -- --check`: 10 generated pages current
- Explorer build is covered by the repository CI matrix.