### PR TITLE
lab: add opt-in progress telemetry and collector

### DIFF
--- a/docs/_layouts/lab.html
+++ b/docs/_layouts/lab.html
@@ -187,6 +187,36 @@ layout: default
       });
     });
 
+    // Progress events from the guide. Only when the CLI's link carried the anonymous session id,
+    // which it does only after the participant said yes in the terminal. Same id, same collector.
+    var EVENTS_URL = 'https://lab-events.tenuo.ai/v1/events';
+    var root = document.querySelector('.lab');
+    var sid = new URLSearchParams(location.search).get('sid');
+    if (sid && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sid)) {
+      try { localStorage.setItem('tenuo-lab-sid', sid); } catch (e) { /* fine */ }
+    } else {
+      sid = null;
+      try { sid = localStorage.getItem('tenuo-lab-sid'); } catch (e) { /* fine */ }
+    }
+    var sent = {};
+    function send(event) {
+      if (!sid || sent[event]) return;
+      sent[event] = true;
+      var body = JSON.stringify({
+        v: 1, session: sid, sentAt: new Date().toISOString(), event: event,
+        stage: Number(root.getAttribute('data-lab-stage')) || 0,
+        labVersion: root.getAttribute('data-lab-version') || undefined,
+        env: 'web', platform: 'web', node: 0
+      });
+      try {
+        // text/plain keeps this a simple request: no preflight, and a dead endpoint costs nothing.
+        fetch(EVENTS_URL, { method: 'POST', body: body, keepalive: true, headers: { 'content-type': 'text/plain' } }).catch(function () {});
+      } catch (e) { /* never the participant's problem */ }
+    }
+    send('page_view');
+    document.querySelectorAll('.lab-reveal.hint').forEach(function (d) { d.addEventListener('toggle', function () { if (d.open) send('hint_open'); }); });
+    document.querySelectorAll('.lab-reveal.answer').forEach(function (d) { d.addEventListener('toggle', function () { if (d.open) send('answer_open'); }); });
+
     var mark = document.querySelector('[data-mark-done]');
     if (mark) {
       var n = mark.getAttribute('data-mark-done');
@@ -200,6 +230,7 @@ layout: default
         save(p);
         render();
         paintStage(n);
+        if (p.stages[n]) send('mark_done');
       });
     }
 

--- a/docs/lab/index.md
+++ b/docs/lab/index.md
@@ -74,7 +74,8 @@ npm run audit      # what every agent can currently do
 npm run next       # move on to the next stage
 npm run reset      # start over from stage 1
 npm run share      # write an anonymous score breakdown for your session host
-npm run reset      # return to stage 1 without changing exercise files</code></pre>
+npm run telemetry  # see, turn on, or turn off anonymous progress events</code></pre>
+<p class="lab-muted">The first run asks once whether to share anonymous progress with the Tenuo team: stage numbers, scores, which checks did not land, the lab version, whether you run locally or in Codespaces, and which pages and hints you open here from the links the lab prints. Never your code or your name. If you say no, the lab sends nothing and these pages send nothing.</p>
 
 <aside class="lab-callout notice"><div class="lab-callout-title">One ground rule</div><p>You will be tempted to fix the agent that misbehaves: filter what it reads, tell it to ignore suspicious instructions, pick a smarter model. This lab sets those aside. Assume the agent will sometimes be fooled, and work on what still holds when it is.</p></aside>
 

--- a/docs/lab/stage-5.md
+++ b/docs/lab/stage-5.md
@@ -201,7 +201,7 @@ THE TRIP
 </li>
 <li class="lab-step">
 <label class="lab-step-check"><input type="checkbox" data-key="5:2"><span>3</span></label>
-<div class="lab-step-body"><p>Run the checks. The two-traveler run happens here too, with no policy file to edit. Read <strong>CROSS-TASK</strong> and the escalation attempt, then find <code>central_calls</code>.</p><pre class="lab-cmd"><code>npm run attack</code></pre><details class="lab-term"><summary>What you should see <span>npm run attack · 145 lines</span></summary><pre><code>
+<div class="lab-step-body"><p>Run the checks. The two-traveler run happens here too, with no policy file to edit. Read <strong>CROSS-TASK</strong> and the escalation attempt, then find <code>central_calls</code>.</p><pre class="lab-cmd"><code>npm run attack</code></pre><details class="lab-term"><summary>What you should see <span>npm run attack · 151 lines</span></summary><pre><code>
 Stage 5 of 7: Access that travels with the work   mode=tenuo  scenario=spring-break
   guide: https://tenuo.ai/lab/stage-5
 
@@ -264,6 +264,9 @@ ESCALATION: checkin-agent tries to arrange broader access for boarding-agent
 
   clean: all 12 checks landed as expected
   central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+  See the chain the agents are holding, hop by hop, in the explorer:
+  https://tenuo.ai/explorer/?s=…
 
 
 Stage 5 of 7: Access that travels with the work   mode=tenuo  scenario=two-travelers
@@ -342,6 +345,9 @@ ESCALATION: checkin-agent tries to arrange broader access for boarding-agent
 
   clean: all 15 checks landed as expected
   central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+  See the chain the agents are holding, hop by hop, in the explorer:
+  https://tenuo.ai/explorer/?s=…
 
   That check ran locally, in the agent's own process, with no server to ask.
   The code that did it is open source: github.com/tenuo-ai/tenuo

--- a/docs/lab/stage-6.md
+++ b/docs/lab/stage-6.md
@@ -37,7 +37,7 @@ export function steal(tenuo: TenuoMode, boardingSession: Session): StealOutcome 
 </li>
 <li class="lab-step">
 <label class="lab-step-check"><input type="checkbox" data-key="6:1"><span>2</span></label>
-<div class="lab-step-body"><p>Run the checks and read the reason on the <strong>STOLEN WARRANT</strong> line carefully.</p><pre class="lab-cmd"><code>npm run attack</code></pre><details class="lab-term"><summary>What you should see <span>npm run attack · 69 lines</span></summary><pre><code>
+<div class="lab-step-body"><p>Run the checks and read the reason on the <strong>STOLEN WARRANT</strong> line carefully.</p><pre class="lab-cmd"><code>npm run attack</code></pre><details class="lab-term"><summary>What you should see <span>npm run attack · 72 lines</span></summary><pre><code>
 Stage 6 of 7: A stolen permission, and the end of the line   mode=tenuo  scenario=spring-break
   guide: https://tenuo.ai/lab/stage-6
 
@@ -105,7 +105,10 @@ TERMINAL
       expected DENIED: boarding-agent now holds {issue_boarding_pass} at depth 3
 
   1 of 14 checks did not land as expected
-  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div>
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+  See the chain the agents are holding, hop by hop, in the explorer:
+  https://tenuo.ai/explorer/?s=…</code></pre></details></div>
 </li>
 <li class="lab-step">
 <label class="lab-step-check"><input type="checkbox" data-key="6:2"><span>3</span></label>

--- a/docs/lab/stage-7.md
+++ b/docs/lab/stage-7.md
@@ -32,7 +32,7 @@ lab_version: "0.1.0"
 </li>
 <li class="lab-step">
 <label class="lab-step-check"><input type="checkbox" data-key="7:1"><span>2</span></label>
-<div class="lab-step-body"><p>Run the checks. All eight attempts are listed under <strong>INCIDENT</strong>. Make one land and seven fail, and keep an eye on the least-privilege row of your score.</p><pre class="lab-cmd"><code>npm run attack</code></pre><div class="lab-tabs"><input type="radio" name="t7-1" id="t7-1-0" checked><label for="t7-1-0">As it ships</label><input type="radio" name="t7-1" id="t7-1-1"><label for="t7-1-1">When it is fixed</label><div class="lab-tab-panel"><details class="lab-term"><summary>As it ships <span>npm run attack · 52 lines</span></summary><pre><code>
+<div class="lab-step-body"><p>Run the checks. All eight attempts are listed under <strong>INCIDENT</strong>. Make one land and seven fail, and keep an eye on the least-privilege row of your score.</p><pre class="lab-cmd"><code>npm run attack</code></pre><div class="lab-tabs"><input type="radio" name="t7-1" id="t7-1-0" checked><label for="t7-1-0">As it ships</label><input type="radio" name="t7-1" id="t7-1-1"><label for="t7-1-1">When it is fixed</label><div class="lab-tab-panel"><details class="lab-term"><summary>As it ships <span>npm run attack · 55 lines</span></summary><pre><code>
 Stage 7 of 7: The incident   mode=tenuo  scenario=incident
   guide: https://tenuo.ai/lab/stage-7
 
@@ -83,7 +83,10 @@ INCIDENT
       reason: TENUO_INVALID_POP: holder key does not match the warrant's authorized holder. Holding a copy of a warrant is not authority; only the key it was issued to can use it.  [TENUO_INVALID_POP]
 
   3 of 8 checks did not land as expected
-  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div><div class="lab-tab-panel"><details class="lab-term"><summary>When it is fixed <span>npm run attack · 52 lines</span></summary><pre><code>
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+  See the chain the agents are holding, hop by hop, in the explorer:
+  https://tenuo.ai/explorer/?s=…</code></pre></details></div><div class="lab-tab-panel"><details class="lab-term"><summary>When it is fixed <span>npm run attack · 55 lines</span></summary><pre><code>
 Stage 7 of 7: The incident   mode=tenuo  scenario=incident
   guide: https://tenuo.ai/lab/stage-7
 
@@ -134,7 +137,10 @@ INCIDENT
       reason: TENUO_INVALID_POP: holder key does not match the warrant's authorized holder. Holding a copy of a warrant is not authority; only the key it was issued to can use it.  [TENUO_INVALID_POP]
 
   clean: all 8 checks landed as expected
-  central_calls during the trip: 0   (calls to a component outside the acting agent)</code></pre></details></div></div></div>
+  central_calls during the trip: 0   (calls to a component outside the acting agent)
+
+  See the chain the agents are holding, hop by hop, in the explorer:
+  https://tenuo.ai/explorer/?s=…</code></pre></details></div></div></div>
 </li>
 <li class="lab-step">
 <label class="lab-step-check"><input type="checkbox" data-key="7:2"><span>3</span></label>

--- a/labs/agent-delegation/README.md
+++ b/labs/agent-delegation/README.md
@@ -52,18 +52,28 @@ the full guide is at [tenuo.ai/lab](https://tenuo.ai/lab/), one page per stage.
 
 ## What leaves your machine
 
-Nothing. The lab runs locally and makes no network requests.
+Nothing, unless you say yes. The first `npm run lab` asks once whether to
+share anonymous progress with the Tenuo team: stage numbers, which command
+ran, whether the trip worked, the score, the names of checks that did not
+land, the time between runs, which stage 4 fix you used, the lab version,
+whether you run locally or in Codespaces, and, from the hosted guide, which
+pages and hints you open from the links the lab prints. Never your code, your
+files, your name, or anything about your machine beyond OS and Node version.
+`npm run telemetry`
+shows the current setting and endpoint; `npm run telemetry -- off` stops it.
+Everything is sent to a small open collector whose source is in
+`collector/`, so you can read exactly what it keeps.
 
 ## How it works
 
-Every tool call passes through one chokepoint (`src/auth/`). Stages 1 to 4
+Every tool call passes through one chokepoint (`src/auth/`). Stages 1 to 5
 use three classic approaches: one shared key, one identity per agent, and
 scoped rules you write yourself. Stage 6 switches to
 [Tenuo](https://github.com/tenuo-ai/tenuo): each agent gets its own key, a
 control plane signs the trip's authority, and every handoff narrows what the
 next agent holds. The signer stays outside the agent runtime, and each holder
 private key remains inside its agent boundary; chain code sees recipient public
-keys only. Stages 6 and 7 extend the chain and handle an incident.
+keys only. Stages 7 to 9 are extensions.
 
 The agents are scripted and deterministic. They follow the same tool-call
 intents a live model produced when this scenario was designed, including
@@ -81,14 +91,18 @@ The stage-by-stage guide at [tenuo.ai/lab](https://tenuo.ai/lab) is generated
 from this directory, so it cannot drift from the code:
 
 ```bash
-npm run site            # rebuild docs/lab from the lab, exercises, and real runs
-npm run site -- --check # fail if docs/lab is stale
+npm run site            # rebuild docs/lab from site/spec.ts, the exercise files, and real runs
+npm run site -- --check # what CI runs: fail if docs/lab is stale
 ```
 
-Every expected-output panel is captured from the CLI using the reference
-answers and a throwaway state directory. The CLI prints the current stage's
-page, including completed stages in the link. Add `-- --open` to `npm run lab`
-or `npm run next` to open it.
+Every "what you should see" panel on the site is the CLI's own output,
+captured by running the reference answers with a throwaway state directory.
+Code on the pages is pulled from `exercises/` and `answers/` by symbol name.
+Edit `site/spec.ts` to change what a stage page says, then rerun and commit.
+
+The CLI prints the page for the current stage on every run, with the stages
+this install has completed in the link, so the page's progress matches the
+terminal. `npm run lab -- --open` and `npm run next -- --open` open it.
 
 ## After the lab
 
@@ -115,7 +129,8 @@ src/
 exercises/          the files you edit, one folder per stage
 answers/            reference solutions (npm run ambassador -- answers N)
 explainers/         optional reading; you can finish without opening one
-site/               source and generator for the hosted guide
+collector/          the opt-in event collector, a Cloudflare Worker; logic tested here
+scripts/            guide-to-site.py turns the participant guide into docs/lab
 test/               every stage, run with its reference solution
 ```
 

--- a/labs/agent-delegation/collector/README.md
+++ b/labs/agent-delegation/collector/README.md
@@ -1,0 +1,31 @@
+# Lab event collector
+
+Receives the opt-in, anonymous progress events the lab CLI sends (see
+`src/telemetry.ts`). A Cloudflare Worker over D1; the logic is a pure
+function in `src/collector.ts` so it is tested with the rest of the lab.
+
+What arrives per event: a random per-install session id, an optional cohort
+code, the stage, the lab version, local or Codespaces, the command, whether
+the trip worked, the score, the labels of checks that did not land, the
+central-call count, the stage 4 fix, the over-granted agents, and the time
+since the previous event. The hosted guide sends page, hint, reference, and
+mark-done events under the same id when the CLI's link carried it. Nothing
+else is accepted; off-shape fields reject the event.
+
+## Deploy
+
+```bash
+cd labs/agent-delegation/collector
+npx wrangler d1 create lab-events            # paste the id into wrangler.toml
+npx wrangler d1 execute lab-events --file=schema.sql
+npx wrangler deploy
+```
+
+Then either route the Worker at the address in `DEFAULT_EVENTS_URL` or set
+`TENUO_LAB_EVENTS_URL` for participants.
+
+## Endpoints
+
+- `POST /v1/events` — one event or an array of up to 50. Returns `{ accepted, rejected }`.
+- `GET /v1/summary?cohort=CODE` — sessions, opt-ins, environments, versions, stage 4 fixes, and per stage: sessions entered, sessions with a working trip, runs, median attempts before the first working trip, median minutes in the stage, median score, the five most common failed checks, and how many sessions viewed the page, opened the hint, opened the reference, or marked the stage done.
+- `GET /healthz`

--- a/labs/agent-delegation/collector/schema.sql
+++ b/labs/agent-delegation/collector/schema.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS events (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  session             TEXT NOT NULL,
+  cohort              TEXT,
+  sent_at             TEXT NOT NULL,
+  received_at         TEXT NOT NULL,
+  event               TEXT NOT NULL,
+  stage               INTEGER NOT NULL,
+  lab_version         TEXT,
+  env                 TEXT,
+  command             TEXT,
+  scenario            TEXT,
+  functionality_ok    INTEGER,
+  score               INTEGER,
+  failed_checks       TEXT NOT NULL DEFAULT '[]',
+  central_calls       INTEGER,
+  exercise_load_error INTEGER,
+  elapsed_ms          INTEGER,
+  fix                 TEXT,
+  margin_points       INTEGER,
+  margin_agents       TEXT NOT NULL DEFAULT '[]',
+  platform            TEXT,
+  node                INTEGER
+);
+CREATE INDEX IF NOT EXISTS events_session ON events (session);
+CREATE INDEX IF NOT EXISTS events_cohort_stage ON events (cohort, stage);

--- a/labs/agent-delegation/collector/src/collector.ts
+++ b/labs/agent-delegation/collector/src/collector.ts
@@ -1,0 +1,324 @@
+/**
+ * The event collector, as a pure function over a store, so it can be tested
+ * without Cloudflare and deployed as a Worker with a one-line adapter.
+ *
+ * Accepts the events `src/telemetry.ts` sends, from the CLI and from the
+ * hosted guide. Rejects anything else. Stores exactly the fields it knows
+ * and nothing it does not. There is no identity here: `session` is a random
+ * id the participant's install generated.
+ */
+
+export interface StoredEvent {
+  readonly session: string;
+  readonly cohort: string | null;
+  readonly sentAt: string;
+  readonly receivedAt: string;
+  readonly event: string;
+  readonly stage: number;
+  readonly labVersion: string | null;
+  readonly env: string | null;
+  readonly command: string | null;
+  readonly scenario: string | null;
+  readonly functionalityOk: boolean | null;
+  readonly score: number | null;
+  readonly failedChecks: readonly string[];
+  readonly centralCalls: number | null;
+  readonly exerciseLoadError: boolean | null;
+  readonly elapsedMs: number | null;
+  readonly fix: string | null;
+  readonly marginPoints: number | null;
+  readonly marginAgents: readonly string[];
+  readonly platform: string | null;
+  readonly node: number | null;
+}
+
+export interface EventStore {
+  insert(event: StoredEvent): Promise<void>;
+  /** Every stored event, optionally for one cohort. Classrooms are small; the summary is computed in memory. */
+  all(cohort?: string): Promise<StoredEvent[]>;
+}
+
+export interface StageSummary {
+  readonly stage: number;
+  readonly sessionsEntered: number;
+  readonly sessionsWithWorkingTrip: number;
+  readonly runs: number;
+  /** Median runs (lab, attack, score) a session needed before its first working trip here. */
+  readonly medianAttemptsToWorkingTrip: number | null;
+  /** Median minutes from a session's first event in this stage to its first event in a later one. */
+  readonly medianMinutes: number | null;
+  /** Median of each session's last score here. */
+  readonly medianScore: number | null;
+  readonly topFailedChecks: ReadonlyArray<{ readonly label: string; readonly sessions: number }>;
+  readonly pageViews: number;
+  readonly hintOpens: number;
+  readonly answerOpens: number;
+  readonly markedDone: number;
+}
+
+export interface Summary {
+  readonly sessions: number;
+  readonly optIns: number;
+  readonly envs: Record<string, number>;
+  readonly versions: Record<string, number>;
+  readonly fixes: Record<string, number>;
+  readonly stages: StageSummary[];
+}
+
+const EVENTS = new Set(["opt_in", "opt_out", "stage_enter", "run", "share", "page_view", "hint_open", "answer_open", "mark_done"]);
+const ENVS = new Set(["local", "codespaces", "web"]);
+const FIXES = new Set(["per-task", "policy-service"]);
+const MAX_BODY_BYTES = 16 * 1024;
+const MAX_LABEL = 120;
+const MAX_LABELS = 40;
+const STAGE_COUNT = 8;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const COHORT = /^[A-Za-z0-9_-]{1,32}$/;
+
+export class RejectedEvent extends Error {}
+
+function str(v: unknown, max: number): string | null {
+  if (v === undefined || v === null) return null;
+  if (typeof v !== "string" || v.length === 0 || v.length > max) throw new RejectedEvent("bad string field");
+  return v;
+}
+
+function int(v: unknown, min: number, max: number): number | null {
+  if (v === undefined || v === null) return null;
+  if (typeof v !== "number" || !Number.isFinite(v) || v < min || v > max) throw new RejectedEvent("bad numeric field");
+  return Math.round(v);
+}
+
+function bool(v: unknown): boolean | null {
+  if (v === undefined || v === null) return null;
+  if (typeof v !== "boolean") throw new RejectedEvent("bad boolean field");
+  return v;
+}
+
+function labels(v: unknown, what: string): readonly string[] {
+  if (v === undefined) return [];
+  if (!Array.isArray(v) || v.length > MAX_LABELS) throw new RejectedEvent(`bad ${what}`);
+  return v.map((x) => {
+    if (typeof x !== "string" || x.length === 0 || x.length > MAX_LABEL) throw new RejectedEvent(`bad ${what} label`);
+    return x;
+  });
+}
+
+function oneOf(v: unknown, set: Set<string>, what: string): string | null {
+  if (v === undefined || v === null) return null;
+  if (typeof v !== "string" || !set.has(v)) throw new RejectedEvent(`bad ${what}`);
+  return v;
+}
+
+/** Validate one incoming event. Throws RejectedEvent on anything off-shape. */
+export function validate(raw: unknown, receivedAt: Date): StoredEvent {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) throw new RejectedEvent("event must be an object");
+  const e = raw as Record<string, unknown>;
+  if (e["v"] !== 1) throw new RejectedEvent("unsupported version");
+  if (typeof e["session"] !== "string" || !UUID.test(e["session"])) throw new RejectedEvent("bad session id");
+  if (e["cohort"] !== undefined && (typeof e["cohort"] !== "string" || !COHORT.test(e["cohort"]))) throw new RejectedEvent("bad cohort");
+  if (typeof e["event"] !== "string" || !EVENTS.has(e["event"])) throw new RejectedEvent("unknown event");
+  // Stage 0 is the guide's index and wrap-up pages.
+  const stage = int(e["stage"], 0, 10);
+  if (stage === null) throw new RejectedEvent("stage required");
+  const sentAt = typeof e["sentAt"] === "string" && !Number.isNaN(Date.parse(e["sentAt"])) ? new Date(e["sentAt"]).toISOString() : null;
+  if (sentAt === null) throw new RejectedEvent("bad sentAt");
+  return {
+    session: e["session"].toLowerCase(),
+    cohort: typeof e["cohort"] === "string" ? e["cohort"] : null,
+    sentAt,
+    receivedAt: receivedAt.toISOString(),
+    event: e["event"],
+    stage,
+    labVersion: str(e["labVersion"], 64),
+    env: oneOf(e["env"], ENVS, "env"),
+    command: str(e["command"], 32),
+    scenario: str(e["scenario"], 32),
+    functionalityOk: bool(e["functionalityOk"]),
+    score: int(e["score"], 0, 100),
+    failedChecks: labels(e["failedChecks"], "failedChecks"),
+    centralCalls: int(e["centralCalls"], 0, 100_000),
+    exerciseLoadError: bool(e["exerciseLoadError"]),
+    elapsedMs: int(e["elapsedMs"], 0, 7 * 24 * 3600 * 1000),
+    fix: oneOf(e["fix"], FIXES, "fix"),
+    marginPoints: int(e["marginPoints"], 0, 20),
+    marginAgents: labels(e["marginAgents"], "marginAgents"),
+    platform: str(e["platform"], 16),
+    node: int(e["node"], 0, 999),
+  };
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const m = sorted.length % 2 === 1 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
+  return Math.round(m * 10) / 10;
+}
+
+function count(values: Iterable<string | null>): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const v of values) {
+    if (v === null) continue;
+    out[v] = (out[v] ?? 0) + 1;
+  }
+  return out;
+}
+
+const RUN_COMMANDS = new Set(["lab", "attack", "score"]);
+
+/** Everything the summary endpoint reports, from the raw rows. */
+export function summarize(rows: readonly StoredEvent[]): Summary {
+  const bySession = new Map<string, StoredEvent[]>();
+  for (const r of rows) {
+    const list = bySession.get(r.session);
+    if (list === undefined) bySession.set(r.session, [r]);
+    else list.push(r);
+  }
+  for (const list of bySession.values()) list.sort((a, b) => a.sentAt.localeCompare(b.sentAt));
+
+  const perSessionLast = (pick: (r: StoredEvent) => string | null): Iterable<string | null> =>
+    [...bySession.values()].map((list) => {
+      for (let i = list.length - 1; i >= 0; i -= 1) {
+        const v = pick(list[i]!);
+        if (v !== null) return v;
+      }
+      return null;
+    });
+
+  const stages: StageSummary[] = [];
+  for (let stage = 1; stage <= STAGE_COUNT; stage += 1) {
+    const entered = new Set<string>();
+    const working = new Set<string>();
+    const attempts: number[] = [];
+    const minutes: number[] = [];
+    const scores: number[] = [];
+    const failed = new Map<string, Set<string>>();
+    const views = new Set<string>();
+    const hints = new Set<string>();
+    const answers = new Set<string>();
+    const done = new Set<string>();
+    let runs = 0;
+    for (const [session, list] of bySession) {
+      const here = list.filter((r) => r.stage === stage);
+      if (here.length === 0) continue;
+      entered.add(session);
+      let tries = 0;
+      let firstWorking: number | null = null;
+      let lastScore: number | null = null;
+      for (const r of here) {
+        if (r.event === "run") {
+          runs += 1;
+          if (r.command !== null && RUN_COMMANDS.has(r.command)) {
+            tries += 1;
+            if (firstWorking === null && r.functionalityOk === true) firstWorking = tries;
+          }
+          if (r.score !== null) lastScore = r.score;
+          for (const label of r.failedChecks) {
+            const set = failed.get(label) ?? new Set<string>();
+            set.add(session);
+            failed.set(label, set);
+          }
+        }
+        if (r.functionalityOk === true) working.add(session);
+        if (r.event === "page_view") views.add(session);
+        if (r.event === "hint_open") hints.add(session);
+        if (r.event === "answer_open") answers.add(session);
+        if (r.event === "mark_done") done.add(session);
+      }
+      if (firstWorking !== null) attempts.push(firstWorking);
+      if (lastScore !== null) scores.push(lastScore);
+      const first = Date.parse(here[0]!.sentAt);
+      const later = list.find((r) => r.stage > stage && Date.parse(r.sentAt) > first);
+      const end = later !== undefined ? Date.parse(later.sentAt) : Date.parse(here[here.length - 1]!.sentAt);
+      if (end > first) minutes.push((end - first) / 60_000);
+    }
+    stages.push({
+      stage,
+      sessionsEntered: entered.size,
+      sessionsWithWorkingTrip: working.size,
+      runs,
+      medianAttemptsToWorkingTrip: median(attempts),
+      medianMinutes: median(minutes),
+      medianScore: median(scores),
+      topFailedChecks: [...failed.entries()]
+        .map(([label, sessions]) => ({ label, sessions: sessions.size }))
+        .sort((a, b) => b.sessions - a.sessions || a.label.localeCompare(b.label))
+        .slice(0, 5),
+      pageViews: views.size,
+      hintOpens: hints.size,
+      answerOpens: answers.size,
+      markedDone: done.size,
+    });
+  }
+  return {
+    sessions: bySession.size,
+    optIns: rows.filter((r) => r.event === "opt_in").length,
+    // The CLI's env, never the guide's: a session that ran anything reports local or codespaces.
+    envs: count(perSessionLast((r) => (r.env !== null && r.env !== "web" ? r.env : null))),
+    versions: count(perSessionLast((r) => r.labVersion)),
+    fixes: count(perSessionLast((r) => r.fix)),
+    stages,
+  };
+}
+
+export interface CollectorResponse {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+/** Route one request. Framework-free so the Worker adapter is a few lines. */
+export async function handle(
+  method: string,
+  path: string,
+  bodyText: string | null,
+  query: URLSearchParams,
+  store: EventStore,
+  now: () => Date = () => new Date(),
+): Promise<CollectorResponse> {
+  if (method === "POST" && path === "/v1/events") {
+    if (bodyText === null || bodyText.length === 0) return { status: 400, body: { error: "empty body" } };
+    if (bodyText.length > MAX_BODY_BYTES) return { status: 413, body: { error: "body too large" } };
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(bodyText);
+    } catch {
+      return { status: 400, body: { error: "invalid json" } };
+    }
+    const items = Array.isArray(parsed) ? parsed : [parsed];
+    if (items.length > 50) return { status: 413, body: { error: "too many events" } };
+    let accepted = 0;
+    for (const item of items) {
+      try {
+        await store.insert(validate(item, now()));
+        accepted += 1;
+      } catch (error) {
+        if (error instanceof RejectedEvent) continue;
+        throw error;
+      }
+    }
+    return { status: 202, body: { accepted, rejected: items.length - accepted } };
+  }
+  if (method === "GET" && path === "/v1/summary") {
+    const cohort = query.get("cohort");
+    if (cohort !== null && !COHORT.test(cohort)) return { status: 400, body: { error: "bad cohort" } };
+    return { status: 200, body: summarize(await store.all(cohort ?? undefined)) };
+  }
+  if (method === "GET" && path === "/healthz") {
+    return { status: 200, body: { ok: true } };
+  }
+  return { status: 404, body: { error: "not found" } };
+}
+
+/** In-memory store, for tests and local runs. */
+export class MemoryStore implements EventStore {
+  readonly events: StoredEvent[] = [];
+
+  async insert(event: StoredEvent): Promise<void> {
+    this.events.push(event);
+  }
+
+  async all(cohort?: string): Promise<StoredEvent[]> {
+    return cohort === undefined ? [...this.events] : this.events.filter((e) => e.cohort === cohort);
+  }
+}

--- a/labs/agent-delegation/collector/src/worker.ts
+++ b/labs/agent-delegation/collector/src/worker.ts
@@ -1,0 +1,124 @@
+/**
+ * Cloudflare Worker adapter over `collector.ts`, backed by D1.
+ *
+ *   wrangler d1 create lab-events
+ *   wrangler d1 execute lab-events --file=schema.sql
+ *   wrangler deploy
+ *
+ * Point the CLI at it with TENUO_LAB_EVENTS_URL, or change DEFAULT_EVENTS_URL
+ * in src/telemetry.ts once the route is live. The hosted guide posts to the
+ * same address from the browser, so responses carry CORS headers.
+ */
+import { handle, type EventStore, type StoredEvent } from "./collector.ts";
+
+interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement;
+  run(): Promise<unknown>;
+  all<T>(): Promise<{ results: T[] }>;
+}
+interface D1Database {
+  prepare(sql: string): D1PreparedStatement;
+}
+interface Env {
+  readonly DB: D1Database;
+}
+
+interface Row {
+  session: string;
+  cohort: string | null;
+  sent_at: string;
+  received_at: string;
+  event: string;
+  stage: number;
+  lab_version: string | null;
+  env: string | null;
+  command: string | null;
+  scenario: string | null;
+  functionality_ok: number | null;
+  score: number | null;
+  failed_checks: string;
+  central_calls: number | null;
+  exercise_load_error: number | null;
+  elapsed_ms: number | null;
+  fix: string | null;
+  margin_points: number | null;
+  margin_agents: string;
+  platform: string | null;
+  node: number | null;
+}
+
+function flag(v: boolean | null): number | null {
+  return v === null ? null : v ? 1 : 0;
+}
+
+function fromRow(r: Row): StoredEvent {
+  return {
+    session: r.session,
+    cohort: r.cohort,
+    sentAt: r.sent_at,
+    receivedAt: r.received_at,
+    event: r.event,
+    stage: r.stage,
+    labVersion: r.lab_version,
+    env: r.env,
+    command: r.command,
+    scenario: r.scenario,
+    functionalityOk: r.functionality_ok === null ? null : r.functionality_ok === 1,
+    score: r.score,
+    failedChecks: JSON.parse(r.failed_checks) as string[],
+    centralCalls: r.central_calls,
+    exerciseLoadError: r.exercise_load_error === null ? null : r.exercise_load_error === 1,
+    elapsedMs: r.elapsed_ms,
+    fix: r.fix,
+    marginPoints: r.margin_points,
+    marginAgents: JSON.parse(r.margin_agents) as string[],
+    platform: r.platform,
+    node: r.node,
+  };
+}
+
+class D1Store implements EventStore {
+  constructor(private readonly db: D1Database) {}
+
+  async insert(e: StoredEvent): Promise<void> {
+    await this.db
+      .prepare(
+        `INSERT INTO events (session, cohort, sent_at, received_at, event, stage, lab_version, env, command, scenario, functionality_ok, score, failed_checks, central_calls, exercise_load_error, elapsed_ms, fix, margin_points, margin_agents, platform, node)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)`,
+      )
+      .bind(
+        e.session, e.cohort, e.sentAt, e.receivedAt, e.event, e.stage, e.labVersion, e.env, e.command, e.scenario,
+        flag(e.functionalityOk), e.score, JSON.stringify(e.failedChecks), e.centralCalls, flag(e.exerciseLoadError),
+        e.elapsedMs, e.fix, e.marginPoints, JSON.stringify(e.marginAgents), e.platform, e.node,
+      )
+      .run();
+  }
+
+  async all(cohort?: string): Promise<StoredEvent[]> {
+    const stmt = this.db.prepare(cohort === undefined ? "SELECT * FROM events ORDER BY sent_at" : "SELECT * FROM events WHERE cohort = ?1 ORDER BY sent_at");
+    const { results } = await (cohort === undefined ? stmt : stmt.bind(cohort)).all<Row>();
+    return results.map(fromRow);
+  }
+}
+
+const CORS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "POST, GET, OPTIONS",
+  "access-control-allow-headers": "content-type",
+  "access-control-max-age": "86400",
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS });
+    }
+    const url = new URL(request.url);
+    const body = request.method === "POST" ? await request.text() : null;
+    const result = await handle(request.method, url.pathname, body, url.searchParams, new D1Store(env.DB));
+    return new Response(JSON.stringify(result.body), {
+      status: result.status,
+      headers: { ...CORS, "content-type": "application/json", "cache-control": "no-store" },
+    });
+  },
+};

--- a/labs/agent-delegation/collector/wrangler.toml
+++ b/labs/agent-delegation/collector/wrangler.toml
@@ -1,0 +1,11 @@
+name = "tenuo-lab-events"
+main = "src/worker.ts"
+compatibility_date = "2025-06-01"
+
+# Route it at the URL src/telemetry.ts sends to, or set TENUO_LAB_EVENTS_URL.
+# routes = [{ pattern = "lab-events.tenuo.ai/*", zone_name = "tenuo.ai" }]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "lab-events"
+database_id = "replace-with-the-id-wrangler-prints"

--- a/labs/agent-delegation/package.json
+++ b/labs/agent-delegation/package.json
@@ -15,6 +15,7 @@
     "audit": "tsx src/cli/index.ts audit",
     "next": "tsx src/cli/index.ts next",
     "share": "tsx src/cli/index.ts share",
+    "telemetry": "tsx src/cli/index.ts telemetry",
     "reset": "tsx src/cli/index.ts reset",
     "ambassador": "tsx src/cli/index.ts ambassador",
     "test": "vitest run",

--- a/labs/agent-delegation/site/build.ts
+++ b/labs/agent-delegation/site/build.ts
@@ -10,16 +10,12 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { ROOT } from "../src/state.ts";
+import { labVersion } from "../src/telemetry.ts";
 import { capture } from "./capture.ts";
 import { CODESPACES_URL, GOOD_FIRST_ISSUES_URL, MISSION_DIAGRAM, REPO_URL, STAGES, type Capture, type CodeRef, type Explainer, type Snippet, type StageSpec, type Step } from "./spec.ts";
 
 const DOCS = join(ROOT, "..", "..", "docs", "lab");
 const TOTAL = 8;
-
-function labVersion(): string {
-  const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as { version?: string };
-  return pkg.version ?? "0.0.0";
-}
 
 function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -232,7 +228,8 @@ npm run audit      # what every agent can currently do
 npm run next       # move on to the next stage
 npm run reset      # start over from stage 1
 npm run share      # write an anonymous score breakdown for your session host
-npm run reset      # return to stage 1 without changing exercise files</code></pre>
+npm run telemetry  # see, turn on, or turn off anonymous progress events</code></pre>
+<p class="lab-muted">The first run asks once whether to share anonymous progress with the Tenuo team: stage numbers, scores, which checks did not land, the lab version, whether you run locally or in Codespaces, and which pages and hints you open here from the links the lab prints. Never your code or your name. If you say no, the lab sends nothing and these pages send nothing.</p>
 
 <aside class="lab-callout notice"><div class="lab-callout-title">One ground rule</div><p>You will be tempted to fix the agent that misbehaves: filter what it reads, tell it to ignore suspicious instructions, pick a smarter model. This lab sets those aside. Assume the agent will sometimes be fooled, and work on what still holds when it is.</p></aside>
 

--- a/labs/agent-delegation/src/cli/index.ts
+++ b/labs/agent-delegation/src/cli/index.ts
@@ -8,6 +8,7 @@
  *   npm run audit      what every agent can currently do
  *   npm run next       move to the next stage
  *   npm run share      write an anonymized score breakdown you can hand to your host
+ *   npm run telemetry  on | off | status: opt-in anonymous progress events
  *   npm run reset      back to stage 1
  */
 process.env.NODE_ENV ??= "development";
@@ -25,17 +26,30 @@ import type { AuditRecord } from "../audit.ts";
 import { AGENTS } from "../mission.ts";
 import { loadState, ROOT, saveState } from "../state.ts";
 import { STAGES, stage as stageDef, type Scenario, type StageDef } from "../stages.ts";
+import { CONSENT_LINES, emit, enterStage, eventsUrl, sessionParam, setTelemetry, telemetry, type Fix } from "../telemetry.ts";
 
 const SITE = "https://tenuo.ai";
-
+/** The stage page, with the stages this install has completed, so the site's progress matches the terminal. */
 function guideUrl(n: number): string {
   const params = new URLSearchParams();
   const done = [...loadState().completed].sort((a, b) => a - b);
   if (done.length > 0) params.set("done", done.join(","));
+  // Only when events are on: lets the guide file page and hint events under the same anonymous id.
+  const sid = sessionParam();
+  if (sid !== undefined) params.set("sid", sid);
   const query = params.toString();
   return `${SITE}/lab/stage-${n}${query.length > 0 ? `?${query}` : ""}`;
 }
 
+/** Which stage 4 repair a scoped policy file uses, for the progress events. */
+function fixOf(built: Built): Fix | undefined {
+  const config = built.exercise?.config;
+  if (config === undefined) return undefined;
+  if (config.policyService === true) return "policy-service";
+  return Object.keys(config.policy).some((k) => k.includes(":")) ? "per-task" : undefined;
+}
+
+/** Open a URL in the default browser without blocking or failing the command. */
 function openInBrowser(url: string): void {
   const [bin, pre] = process.platform === "darwin" ? ["open", []] : process.platform === "win32" ? ["cmd", ["/c", "start", ""]] : ["xdg-open", []];
   try {
@@ -66,12 +80,17 @@ function header(def: StageDef, scenario: Scenario): void {
   console.log("");
 }
 
+/** A link that opens the explorer on the chain Boarding Agent holds, so students can see every hop. */
 function explorerLink(built: Built): string | undefined {
   const tenuo = built.runtime.tenuo;
   const trip = built.plan.trips[0];
-  if (tenuo === undefined || trip === undefined) return undefined;
+  if (tenuo === undefined || trip === undefined) {
+    return undefined;
+  }
   const session = tenuo.session("boarding-agent", trip.taskId) ?? tenuo.session("checkin-agent", trip.taskId) ?? tenuo.session("flight-agent", trip.taskId);
-  if (session === undefined) return undefined;
+  if (session === undefined) {
+    return undefined;
+  }
   const chain = session.toWire();
   const state = {
     chain,
@@ -89,6 +108,27 @@ function printExplorerLink(built: Built): void {
     console.log(dim("  See the chain the agents are holding, hop by hop, in the explorer:"));
     console.log(dim(`  ${url}`));
     console.log("");
+  }
+}
+
+/** One-time question, TTY only. Silence is a no. */
+async function consent(): Promise<void> {
+  const state = loadState();
+  if (state.telemetry !== undefined || !process.stdin.isTTY) {
+    return;
+  }
+  console.log("");
+  for (const line of CONSENT_LINES) console.log(`  ${line}`);
+  console.log("");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = (await rl.question(dim("  Share? [y/N] "))).trim().toLowerCase();
+  rl.close();
+  const yes = answer === "y" || answer === "yes";
+  setTelemetry(yes, flag("cohort"));
+  console.log(dim(yes ? "  Thank you. npm run telemetry -- off stops it at any time." : "  Nothing will be sent. npm run telemetry -- on if you change your mind."));
+  console.log("");
+  if (yes) {
+    await emit("opt_in", state.stage);
   }
 }
 
@@ -206,6 +246,8 @@ async function warmup(): Promise<void> {
 
 async function cmdLab(def: StageDef): Promise<void> {
   await warmup();
+  await consent();
+  await enterStage(def.n);
   const scenario = def.scenario;
   header(def, scenario);
   if (args.includes("--open")) openInBrowser(guideUrl(def.n));
@@ -213,6 +255,7 @@ async function cmdLab(def: StageDef): Promise<void> {
   console.log("");
   const built = await runStage(def, scenario);
   if (printExerciseError(built)) {
+    await emit("run", def.n, { command: "lab", scenario, exerciseLoadError: true });
     return;
   }
   console.log(bold("WALLET  ") + walletLine(built));
@@ -224,6 +267,7 @@ async function cmdLab(def: StageDef): Promise<void> {
   const functionality = checkFunctionality(built.plan, built.runtime.audit.records, built.runtime.world);
   printFunctionality(functionality);
   printExplorerLink(built);
+  await emit("run", def.n, { command: "lab", scenario, functionalityOk: functionality.ok, centralCalls: built.runtime.audit.centralCalls() });
   if (def.breaksTrip === true) {
     console.log(dim("  The terminal link breaks the trip on purpose. Notice where, and who decided."));
     console.log("");
@@ -243,7 +287,7 @@ async function cmdTrace(def: StageDef): Promise<void> {
     console.log("");
     console.log(centralCallsLine(built));
     console.log("");
-    printExplorerLink(built);
+    await emit("run", def.n, { command: "trace", scenario, centralCalls: built.runtime.audit.centralCalls() });
   }
 }
 
@@ -270,9 +314,11 @@ async function attackAll(def: StageDef): Promise<Evaluated[]> {
 }
 
 async function cmdAttack(def: StageDef): Promise<void> {
+  await enterStage(def.n);
   for (const { built, probes, functionality } of await attackAll(def)) {
     header(def, built.plan.name);
     if (printExerciseError(built)) {
+      await emit("run", def.n, { command: "attack", scenario: built.plan.name, exerciseLoadError: true });
       return;
     }
     console.log(bold("WALLET  ") + walletLine(built));
@@ -292,6 +338,16 @@ async function cmdAttack(def: StageDef): Promise<void> {
     console.log(failed === 0 ? green(`  clean: all ${probes.length} checks landed as expected`) : yellow(`  ${failed} of ${probes.length} checks did not land as expected`));
     console.log(centralCallsLine(built));
     console.log("");
+    printExplorerLink(built);
+    const fix = fixOf(built);
+    await emit("run", def.n, {
+      command: "attack",
+      scenario: built.plan.name,
+      functionalityOk: functionality.ok,
+      failedChecks: probes.filter((p) => !p.ok).map((p) => p.label),
+      centralCalls: built.runtime.audit.centralCalls(),
+      ...(fix !== undefined ? { fix } : {}),
+    });
   }
   if (def.starAsk === true) {
     console.log(dim("  That check ran locally, in the agent's own process, with no server to ask."));
@@ -318,11 +374,13 @@ async function evaluateStage(def: StageDef): Promise<{ runs: Evaluated[]; functi
 }
 
 async function cmdScore(def: StageDef): Promise<void> {
+  await enterStage(def.n);
   header(def, def.scenario);
   const e = await evaluateStage(def);
   if (e === undefined) {
     const built = await runStage(def, def.scenario);
     printExerciseError(built);
+    await emit("run", def.n, { command: "score", scenario: def.scenario, exerciseLoadError: true });
     return;
   }
   const { functionality, probes, margin, score: s } = e;
@@ -367,6 +425,18 @@ async function cmdScore(def: StageDef): Promise<void> {
       console.log("");
     }
   }
+  const fix = e.runs[0] !== undefined ? fixOf(e.runs[0].built) : undefined;
+  await emit("run", def.n, {
+    command: "score",
+    scenario: def.scenario,
+    functionalityOk: functionality.ok,
+    score: s.total,
+    failedChecks: failed.map((p) => p.label),
+    marginPoints: s.margin.points,
+    marginAgents: AGENTS.filter((a) => margin.perAgent[a] > 0),
+    ...(e.runs[0] !== undefined ? { centralCalls: e.runs[0].built.runtime.audit.centralCalls() } : {}),
+    ...(fix !== undefined ? { fix } : {}),
+  });
 }
 
 async function cmdShare(def: StageDef): Promise<void> {
@@ -394,7 +464,31 @@ async function cmdShare(def: StageDef): Promise<void> {
   writeFileSync(file, JSON.stringify(report, null, 2));
   console.log(JSON.stringify(report, null, 2));
   console.log("");
-  console.log(dim(`  Written to ${file}. Hand the file to your session host if you want to; it carries no name, no key, and no code.`));
+  const t = telemetry();
+  if (t?.enabled === true) {
+    await emit("share", def.n, { command: "share", scenario: def.scenario, functionalityOk: !e.score.gated, score: e.score.total, failedChecks: report.failedChecks });
+    console.log(dim(`  Written to ${file}, and the same breakdown was sent as an anonymous event (npm run telemetry -- status).`));
+  } else {
+    console.log(dim(`  Written to ${file}. Nothing was sent anywhere. Hand the file to your session host if you want to; it carries no name, no key, and no code.`));
+  }
+}
+
+function cmdTelemetry(): void {
+  const sub = args[1] ?? "status";
+  if (sub === "on" || sub === "off") {
+    const t = setTelemetry(sub === "on", flag("cohort"));
+    console.log(sub === "on" ? `Anonymous progress events are on (session ${t.sessionId.slice(0, 8)}…). npm run telemetry -- off stops them.` : "Anonymous progress events are off. Nothing is sent.");
+    void emit(sub === "on" ? "opt_in" : "opt_out", loadState().stage);
+    return;
+  }
+  const t = telemetry();
+  if (t === undefined) {
+    console.log("Not decided yet: the first npm run lab asks. Nothing has been sent.");
+  } else {
+    console.log(`${t.enabled ? "On" : "Off"}. session ${t.sessionId.slice(0, 8)}…${t.cohort !== undefined ? `, cohort ${t.cohort}` : ""}, endpoint ${eventsUrl()}`);
+  }
+  console.log("");
+  for (const line of CONSENT_LINES.slice(2, 6)) console.log(`  ${line}`);
 }
 
 async function cmdAudit(def: StageDef): Promise<void> {
@@ -409,6 +503,7 @@ async function cmdAudit(def: StageDef): Promise<void> {
     for (const line of text) console.log(dim(line));
   }
   console.log("");
+  await emit("run", def.n, { command: "audit", scenario: def.scenario });
 }
 
 async function cmdNext(): Promise<void> {
@@ -419,15 +514,20 @@ async function cmdNext(): Promise<void> {
     return;
   }
   saveState({ ...state, stage: to });
+  await emit("run", to, { command: "next" });
   console.log(`Now on stage ${to}: ${stageDef(to).title}. Run npm run lab.`);
   console.log(dim(`  guide: ${guideUrl(to)}`));
   if (args.includes("--open")) openInBrowser(guideUrl(to));
+  await enterStage(to);
 }
 
 async function cmdReset(): Promise<void> {
   const state = loadState();
+  const before = state.stage;
+  // Progress goes; the consent answer and the warm-up flag stay.
   saveState({ ...state, stage: 1, completed: [] });
   console.log("Back to stage 1. Your edits in exercises/ are untouched; `git checkout exercises` restores the originals.");
+  await emit("run", before, { command: "reset" });
 }
 
 function cmdAmbassador(): void {
@@ -478,6 +578,9 @@ async function main(): Promise<void> {
   const state = loadState();
   const n = flag("stage") !== undefined && command !== "next" && command !== "ambassador" ? Number(flag("stage")) : state.stage;
   const def = stageDef(n);
+  if (flag("cohort") !== undefined && state.telemetry !== undefined) {
+    setTelemetry(state.telemetry.enabled, flag("cohort"));
+  }
   if (args.includes("--live")) {
     console.log(yellow("  --live is not wired in this build: the lab runs its recorded, deterministic agents. Every test and score is real."));
   }
@@ -487,12 +590,13 @@ async function main(): Promise<void> {
     case "attack": return cmdAttack(def);
     case "score": return cmdScore(def);
     case "share": return cmdShare(def);
+    case "telemetry": return cmdTelemetry();
     case "audit": return cmdAudit(def);
     case "next": return cmdNext();
     case "reset": return cmdReset();
     case "ambassador": return cmdAmbassador();
     default:
-      console.log(`unknown command ${command}. Try: lab, trace, attack, score, share, audit, next, reset, ambassador`);
+      console.log(`unknown command ${command}. Try: lab, trace, attack, score, share, telemetry, audit, next, reset, ambassador`);
   }
 }
 

--- a/labs/agent-delegation/src/state.ts
+++ b/labs/agent-delegation/src/state.ts
@@ -14,6 +14,14 @@ export interface LabState {
   completed: number[];
   /** The warm-up questions were shown once. */
   warmupDone?: boolean;
+  /** Opt-in progress events. Absent until the participant has been asked. */
+  telemetry?: {
+    enabled: boolean;
+    sessionId: string;
+    cohort?: string;
+    lastEventAt?: number;
+    lastStage?: number;
+  };
 }
 
 export function loadState(): LabState {
@@ -26,6 +34,9 @@ export function loadState(): LabState {
       stage: typeof parsed.stage === "number" && parsed.stage >= 1 && parsed.stage <= STAGES.length ? parsed.stage : 1,
       completed: Array.isArray(parsed.completed) ? parsed.completed.filter((n): n is number => typeof n === "number") : [],
       ...(parsed.warmupDone === true ? { warmupDone: true } : {}),
+      ...(parsed.telemetry !== undefined && typeof parsed.telemetry === "object" && typeof parsed.telemetry.sessionId === "string"
+        ? { telemetry: parsed.telemetry }
+        : {}),
     };
   } catch {
     return { stage: 1, completed: [] };

--- a/labs/agent-delegation/src/telemetry.ts
+++ b/labs/agent-delegation/src/telemetry.ts
@@ -1,0 +1,213 @@
+/**
+ * Opt-in, anonymous progress events.
+ *
+ * What is sent: stage numbers, which command ran, whether the trip worked,
+ * the score, the labels of checks that did not land, the central-call count,
+ * which stage 4 fix was used, which agents were over-granted, the lab version,
+ * whether the lab runs locally or in Codespaces, how long since the previous
+ * event, and (from the hosted guide, under the same id) which pages, hints,
+ * and reference solutions were opened. What is never sent: your code, your
+ * exercise files, your name, your machine's identity, or anything you typed.
+ *
+ * Nothing is sent unless you said yes to the one-time question, and
+ * `npm run telemetry -- off` stops it. Sending never blocks or fails the lab:
+ * a dead endpoint is silently ignored.
+ */
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { loadState, ROOT, saveState, type LabState } from "./state.ts";
+
+/** Override with TENUO_LAB_EVENTS_URL. */
+export const DEFAULT_EVENTS_URL = "https://lab-events.tenuo.ai/v1/events";
+
+export interface TelemetryState {
+  readonly enabled: boolean;
+  /** Random per install. Not derived from anything about the machine or the person. */
+  readonly sessionId: string;
+  /** Optional code a session host hands out so a room's events group together. */
+  readonly cohort?: string;
+  readonly lastEventAt?: number;
+  readonly lastStage?: number;
+}
+
+export type EventName =
+  | "opt_in"
+  | "opt_out"
+  | "stage_enter"
+  | "run"
+  | "share"
+  // Sent by the hosted guide, under the same session id, when the CLI's link carried it.
+  | "page_view"
+  | "hint_open"
+  | "answer_open"
+  | "mark_done";
+
+export type LabEnv = "local" | "codespaces" | "web";
+export type Fix = "per-task" | "policy-service";
+
+export interface LabEvent {
+  readonly v: 1;
+  readonly session: string;
+  readonly cohort?: string;
+  readonly sentAt: string;
+  readonly event: EventName;
+  readonly stage: number;
+  /** Package version plus the short commit, so cohorts can be compared across changes to the lab. */
+  readonly labVersion: string;
+  readonly env: LabEnv;
+  readonly command?: string;
+  readonly scenario?: string;
+  readonly functionalityOk?: boolean;
+  readonly score?: number;
+  readonly failedChecks?: readonly string[];
+  readonly centralCalls?: number;
+  readonly exerciseLoadError?: boolean;
+  readonly elapsedMs?: number;
+  /** Which stage 4 repair the policy file uses. */
+  readonly fix?: Fix;
+  readonly marginPoints?: number;
+  /** Agents the least-privilege check found over-granted. */
+  readonly marginAgents?: readonly string[];
+  readonly platform: string;
+  readonly node: number;
+}
+
+export function eventsUrl(): string {
+  const override = process.env["TENUO_LAB_EVENTS_URL"];
+  return override !== undefined && override.length > 0 ? override : DEFAULT_EVENTS_URL;
+}
+
+let cachedVersion: string | undefined;
+
+/** "0.1.0+1a2b3c4", or just the package version when git is not around. */
+export function labVersion(): string {
+  if (cachedVersion !== undefined) return cachedVersion;
+  let version = "0.0.0";
+  try {
+    version = String((JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as { version?: string }).version ?? version);
+  } catch {
+    // Keep the placeholder.
+  }
+  let sha = "";
+  try {
+    const r = spawnSync("git", ["rev-parse", "--short", "HEAD"], { cwd: ROOT, encoding: "utf8", timeout: 2000 });
+    if (r.status === 0) sha = r.stdout.trim();
+  } catch {
+    // No git: the version alone still says which release this is.
+  }
+  cachedVersion = sha.length > 0 ? `${version}+${sha}` : version;
+  return cachedVersion;
+}
+
+export function labEnv(): LabEnv {
+  return process.env["CODESPACES"] === "true" ? "codespaces" : "local";
+}
+
+export function telemetry(): TelemetryState | undefined {
+  return loadState().telemetry;
+}
+
+/** The session id, when events are on, so the hosted guide can file its own events under it. */
+export function sessionParam(): string | undefined {
+  const t = telemetry();
+  return t !== undefined && t.enabled ? t.sessionId : undefined;
+}
+
+export function setTelemetry(enabled: boolean, cohort?: string): TelemetryState {
+  const state = loadState();
+  const previous = state.telemetry;
+  const next: TelemetryState = {
+    enabled,
+    sessionId: previous?.sessionId ?? randomUUID(),
+    ...(cohort !== undefined ? { cohort } : previous?.cohort !== undefined ? { cohort: previous.cohort } : {}),
+    ...(previous?.lastEventAt !== undefined ? { lastEventAt: previous.lastEventAt } : {}),
+    ...(previous?.lastStage !== undefined ? { lastStage: previous.lastStage } : {}),
+  };
+  saveState({ ...state, telemetry: next });
+  return next;
+}
+
+function nodeMajor(): number {
+  const major = Number(process.versions.node.split(".")[0]);
+  return Number.isFinite(major) ? major : 0;
+}
+
+export type EventFields = Omit<Partial<LabEvent>, "v" | "session" | "cohort" | "sentAt" | "event" | "stage" | "platform" | "node" | "labVersion" | "env">;
+
+/**
+ * Send one event if telemetry is on. Fire and forget: resolves quickly, never
+ * throws, never delays the command that called it.
+ */
+export async function emit(event: EventName, stage: number, fields: EventFields = {}): Promise<void> {
+  const state: LabState = loadState();
+  const t = state.telemetry;
+  if (t === undefined || !t.enabled) {
+    return;
+  }
+  const now = Date.now();
+  const elapsed = t.lastEventAt !== undefined ? now - t.lastEventAt : undefined;
+  const payload: LabEvent = {
+    v: 1,
+    session: t.sessionId,
+    ...(t.cohort !== undefined ? { cohort: t.cohort } : {}),
+    sentAt: new Date(now).toISOString(),
+    event,
+    stage,
+    labVersion: labVersion(),
+    env: labEnv(),
+    ...(elapsed !== undefined ? { elapsedMs: elapsed } : {}),
+    platform: process.platform,
+    node: nodeMajor(),
+    ...strip(fields),
+  };
+  saveState({ ...state, telemetry: { ...t, lastEventAt: now, lastStage: stage } });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1500);
+  try {
+    await fetch(eventsUrl(), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+  } catch {
+    // A dead or slow endpoint must never be the participant's problem.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Emit `stage_enter` once per stage change. */
+export async function enterStage(stage: number): Promise<void> {
+  const t = telemetry();
+  if (t === undefined || !t.enabled || t.lastStage === stage) {
+    return;
+  }
+  await emit("stage_enter", stage);
+}
+
+function strip<T extends object>(obj: T): Partial<T> {
+  const out: Partial<T> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) {
+      (out as Record<string, unknown>)[k] = v;
+    }
+  }
+  return out;
+}
+
+/** The consent text, kept here so the CLI and the README say the same thing. */
+export const CONSENT_LINES = [
+  "Share anonymous progress with the Tenuo team, to make the lab better?",
+  "",
+  "  Sent: stage numbers, which command ran, whether the trip worked, the score,",
+  "        the names of checks that did not land, time between runs, the lab",
+  "        version, whether you run locally or in Codespaces, and which guide",
+  "        pages and hints you open from the links the lab prints.",
+  "  Never: your code, your files, your name, or anything about your machine",
+  "        beyond OS and Node version.",
+  "",
+  "  Change your mind any time: npm run telemetry -- off",
+];

--- a/labs/agent-delegation/test/collector.test.ts
+++ b/labs/agent-delegation/test/collector.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { handle, MemoryStore, RejectedEvent, summarize, validate, type Summary } from "../collector/src/collector.ts";
+
+const session = "3f2b4c1e-8d9a-4b7c-9e6f-1a2b3c4d5e6f";
+const other = "9f2b4c1e-8d9a-4b7c-9e6f-1a2b3c4d5e6f";
+const base = { v: 1, session, sentAt: "2026-09-06T20:00:00.000Z", event: "run", stage: 6, labVersion: "0.1.0+abc1234", env: "local", platform: "darwin", node: 20 };
+const at = (minutes: number) => new Date(Date.UTC(2026, 8, 6, 20, minutes)).toISOString();
+
+async function post(store: MemoryStore, events: unknown) {
+  return handle("POST", "/v1/events", JSON.stringify(events), new URLSearchParams(), store);
+}
+
+describe("collector", () => {
+  it("accepts a well-formed run event and stores only known fields", async () => {
+    const store = new MemoryStore();
+    const r = await post(store, { ...base, command: "score", scenario: "spring-break", functionalityOk: true, score: 100, failedChecks: [], centralCalls: 0, elapsedMs: 4200, fix: "per-task", marginPoints: 20, marginAgents: [], secret: "should not be stored" });
+    expect(r).toEqual({ status: 202, body: { accepted: 1, rejected: 0 } });
+    expect(store.events[0]).toMatchObject({ session, event: "run", stage: 6, score: 100, functionalityOk: true, labVersion: "0.1.0+abc1234", env: "local", fix: "per-task", marginPoints: 20 });
+    expect(JSON.stringify(store.events[0])).not.toContain("secret");
+  });
+
+  it("accepts the guide's page events, including stage 0 for the index", async () => {
+    const store = new MemoryStore();
+    const r = await post(store, [
+      { ...base, event: "page_view", stage: 0, env: "web", platform: "web", node: 0 },
+      { ...base, event: "hint_open", stage: 5, env: "web", platform: "web", node: 0 },
+      { ...base, event: "mark_done", stage: 8, env: "web", platform: "web", node: 0 },
+    ]);
+    expect(r.body).toEqual({ accepted: 3, rejected: 0 });
+  });
+
+  it("rejects off-shape events without failing the batch", async () => {
+    const store = new MemoryStore();
+    const r = await post(store, [
+      base,
+      { ...base, session: "not-a-uuid" },
+      { ...base, event: "keylog" },
+      { ...base, stage: 11 },
+      { ...base, failedChecks: ["x".repeat(500)] },
+      { ...base, cohort: "bad cohort!" },
+      { ...base, env: "office" },
+      { ...base, fix: "magic" },
+      { ...base, marginPoints: 21 },
+    ]);
+    expect(r.body).toEqual({ accepted: 1, rejected: 8 });
+  });
+
+  it("refuses oversized and malformed bodies", async () => {
+    const store = new MemoryStore();
+    expect((await handle("POST", "/v1/events", "{", new URLSearchParams(), store)).status).toBe(400);
+    expect((await handle("POST", "/v1/events", "x".repeat(20_000), new URLSearchParams(), store)).status).toBe(413);
+    expect((await handle("POST", "/v1/events", null, new URLSearchParams(), store)).status).toBe(400);
+    expect((await handle("GET", "/nope", null, new URLSearchParams(), store)).status).toBe(404);
+  });
+
+  it("summarizes attempts, time, scores, failed checks, and guide use per stage", async () => {
+    const store = new MemoryStore();
+    await post(store, [
+      { ...base, event: "opt_in", stage: 1, sentAt: at(0) },
+      // Session A: three tries in stage 4, working on the third, then moves to stage 5 after 30 minutes.
+      { ...base, event: "stage_enter", stage: 4, sentAt: at(1) },
+      { ...base, event: "page_view", stage: 4, env: "web", sentAt: at(2) },
+      { ...base, command: "attack", stage: 4, functionalityOk: false, failedChecks: ["Task A agent: check_in(DL331)", "check_in(UA214)   inherited?"], sentAt: at(5) },
+      { ...base, event: "hint_open", stage: 4, env: "web", sentAt: at(6) },
+      { ...base, command: "attack", stage: 4, functionalityOk: false, failedChecks: ["Task A agent: check_in(DL331)"], sentAt: at(15) },
+      { ...base, command: "score", stage: 4, functionalityOk: true, score: 82, fix: "per-task", sentAt: at(25) },
+      { ...base, command: "trace", stage: 4, sentAt: at(28) },
+      { ...base, event: "stage_enter", stage: 5, sentAt: at(31) },
+      // Session B: one try, working, in Codespaces, 10 minutes, then stage 5.
+      { ...base, session: other, env: "codespaces", command: "score", stage: 4, functionalityOk: true, score: 90, fix: "policy-service", failedChecks: ["Task A agent: check_in(DL331)"], sentAt: at(40) },
+      { ...base, session: other, env: "codespaces", event: "stage_enter", stage: 5, sentAt: at(50) },
+    ]);
+    const r = await handle("GET", "/v1/summary", null, new URLSearchParams(), store);
+    const s = r.body as Summary;
+    expect(s.sessions).toBe(2);
+    expect(s.optIns).toBe(1);
+    expect(s.envs).toEqual({ local: 1, codespaces: 1 });
+    expect(s.versions).toEqual({ "0.1.0+abc1234": 2 });
+    expect(s.fixes).toEqual({ "per-task": 1, "policy-service": 1 });
+    const stage4 = s.stages[3]!;
+    expect(stage4).toMatchObject({ stage: 4, sessionsEntered: 2, sessionsWithWorkingTrip: 2, runs: 5, medianAttemptsToWorkingTrip: 2, medianMinutes: 20, medianScore: 86, pageViews: 1, hintOpens: 1, answerOpens: 0, markedDone: 0 });
+    expect(stage4.topFailedChecks).toEqual([
+      { label: "Task A agent: check_in(DL331)", sessions: 2 },
+      { label: "check_in(UA214)   inherited?", sessions: 1 },
+    ]);
+    const cohort = await handle("GET", "/v1/summary", null, new URLSearchParams("cohort=room-a"), store);
+    expect((cohort.body as Summary).sessions).toBe(0);
+  });
+
+  it("validate() normalizes and bounds", () => {
+    const e = validate({ ...base, session: session.toUpperCase(), score: 99.6 }, new Date("2026-09-06T20:00:01Z"));
+    expect(e.session).toBe(session);
+    expect(e.score).toBe(100);
+    expect(() => validate({ ...base, v: 2 }, new Date())).toThrow(RejectedEvent);
+    expect(summarize([]).stages).toHaveLength(8);
+  });
+});

--- a/labs/agent-delegation/tsconfig.json
+++ b/labs/agent-delegation/tsconfig.json
@@ -18,6 +18,7 @@
     "exercises",
     "answers",
     "test",
+    "collector",
     "site"
   ]
 }


### PR DESCRIPTION
## Stack

Depends on #594, which depends on #587. This is intentionally a draft and must not merge with the current unresolved privacy and abuse-control items.

## What this layer adds

- Opt-in CLI progress events under a random per-install identifier.
- Hosted-guide page, hint, answer, and completion events.
- A Cloudflare Worker and D1 schema for event collection.
- Validation and aggregate cohort summaries.
- Collector validation and summary tests.

## Required before review-ready

- Make withdrawal effective across both CLI and hosted-guide events; the current browser identifier persists after `npm run telemetry -- off`.
- Fix `opt_out` emission, which currently occurs after telemetry has already been disabled.
- Describe the data accurately as pseudonymous analytics rather than anonymous telemetry.
- Add retention and deletion behavior for event rows and browser identifiers.
- Authenticate summary access and prevent cohort enumeration.
- Add ingestion abuse controls/rate limiting so arbitrary clients cannot poison analytics or exhaust D1 capacity.
- Add browser-level tests for consent, persistence, event emission, and withdrawal.

## Current verification

- `npm run typecheck`
- `npm test`: 20 tests pass
- `npm run site -- --check`: 10 generated pages current

Passing tests establish the current implementation baseline; they do not resolve the items above.