### PR TITLE
chore(ts): publish-ready 0.2.5-beta.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,7 +658,9 @@ jobs:
       - name: Cache Rust
         uses: swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
-          workspaces: tenuo-wasm
+          workspaces: |
+            tenuo-wasm
+            tenuo-python
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -672,6 +674,22 @@ jobs:
           cargo clippy --locked --target wasm32-unknown-unknown -- \
             -D warnings \
             -A clippy::too_many_arguments
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tenuo-python/pyproject.toml
+
+      - name: Build and install the Python binding
+        working-directory: tenuo-python
+        run: |
+          pip install uv
+          uv pip install --system maturin
+          maturin build --release
+          uv pip install --system target/wheels/*.whl "mcp>=1.9.4"
+          python -c "import tenuo; from tenuo.mcp.server import MCPVerifier; print(f'tenuo {tenuo.__version__}')"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -695,6 +713,8 @@ jobs:
 
       - name: Test
         working-directory: tenuo-ts
+        env:
+          TENUO_REQUIRE_INTEROP: "1"
         run: pnpm test
 
       # Optimized .wasm bytes and private export ordering vary across Rust and
@@ -746,6 +766,42 @@ jobs:
           pnpm typecheck
           pnpm --filter @tenuo/core test
           pnpm --filter @tenuo/mcp test
+
+      - name: Build and pack smoke
+        working-directory: tenuo-ts
+        run: pnpm --filter @tenuo/core build && pnpm --filter @tenuo/core pack:smoke && pnpm --filter @tenuo/mcp build && pnpm --filter @tenuo/mcp pack:smoke
+
+  # Committed WASM only — no wasm-pack. Catches Node path / createRequire /
+  # npm.cmd issues that Linux jobs will not see.
+  tenuo-ts-windows:
+    name: TypeScript SDK (Windows pack smoke)
+    runs-on: windows-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: 9.15.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: tenuo-ts/pnpm-lock.yaml
+
+      - name: Install
+        working-directory: tenuo-ts
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        working-directory: tenuo-ts
+        run: pnpm typecheck
 
       - name: Build and pack smoke
         working-directory: tenuo-ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,10 +204,14 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           if npm view "@tenuo/core@${VERSION}" version >/dev/null 2>&1; then
-            echo "@tenuo/core@${VERSION} already exists; skipping"
+            echo "@tenuo/core@${VERSION} already exists; skipping publish"
           else
             npm publish --access public --provenance --tag beta
           fi
+          # Stay on the beta dist-tag. Also move latest so an untagged
+          # `npm i @tenuo/core` is not stuck on an older prerelease.
+          npm dist-tag add "@tenuo/core@${VERSION}" beta
+          npm dist-tag add "@tenuo/core@${VERSION}" latest
 
       - name: Publish @tenuo/mcp beta
         working-directory: tenuo-ts/packages/mcp
@@ -216,10 +220,12 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           if npm view "@tenuo/mcp@${VERSION}" version >/dev/null 2>&1; then
-            echo "@tenuo/mcp@${VERSION} already exists; skipping"
+            echo "@tenuo/mcp@${VERSION} already exists; skipping publish"
           else
             npm publish --access public --provenance --tag beta
           fi
+          npm dist-tag add "@tenuo/mcp@${VERSION}" beta
+          npm dist-tag add "@tenuo/mcp@${VERSION}" latest
 
   # Docker: native amd64 + arm64 per platform (no QEMU), then merge manifests.
   docker-authorizer-build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Python extras declare the floors the code actually needs.** `tenuo[mcp]`
+  and `tenuo[fastmcp]` now require `mcp>=1.9.4` (streamable-HTTP transport
+  shape, `CallToolRequestParams.meta`); `tenuo[crewai]` requires `crewai>=1.5`
+  (`crewai.hooks`). Both were previously declared as `>=1.0` but failed at
+  import or first use on those versions.
+
+### Fixed
+
+- **FastMCP 4 middleware denials.** `TenuoMiddleware` returns a real
+  `ToolResult` (with `isError=True` on the wire) on FastMCP 3.2 through 4.x,
+  and version-pinned FastMCP 4 calls no longer lose the `_meta.tenuo` block.
+- **MCP SDK 2.x tool schemas.** `SecureMCPClient` and the LangChain bridge read
+  `Tool.input_schema` on SDK 2.x (previously an empty schema).
+
+## [0.2.5-beta.0] - 2026-09-06
+
+TypeScript SDK only (`@tenuo/core` / `@tenuo/mcp` on the npm `beta` tag).
+Rust and Python remain 0.2.4. `latest` is moved to this beta after publish
+so `npm i @tenuo/core` is not stuck on `0.2.4-beta.0`. Install with
+`@tenuo/core@beta` until a stable tag is declared.
+
 ### Added
 
 - **TypeScript: delegation across agents.** `tenuo.narrow(session, allow,
@@ -70,15 +93,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TypeScript: `sessionFromWire()` with the wrong holder key** now throws
   `AuthorizationDeniedError` with `TENUO_INVALID_POP` (was a configuration
   error). A copied warrant is not authority.
+- **@tenuo/mcp peer** is now `@tenuo/core@>=0.2.5-beta.0 <0.2.6`.
 - **tenuo-wasm `SdkContext.mint`** takes optional `holder_hex` and `max_depth`;
   `SdkContext.narrow` takes an optional options object; `SdkSession` gains
   `describe()`; `sdkPublicKeyFromHolderKey` is exported. Existing call sites
   are unchanged.
-- **Python extras declare the floors the code actually needs.** `tenuo[mcp]`
-  and `tenuo[fastmcp]` now require `mcp>=1.9.4` (streamable-HTTP transport
-  shape, `CallToolRequestParams.meta`); `tenuo[crewai]` requires `crewai>=1.5`
-  (`crewai.hooks`). Both were previously declared as `>=1.0` but failed at
-  import or first use on those versions.
 - **tenuo-wasm parity module** (`sdk_ext.rs`): `SdkContext.fromIssuerSecret`,
   `mintExtended`, `issue`, `explain`, `approvalRequest`,
   `approvalContextAttestation`, `signRevocationListVersioned`; free functions
@@ -86,14 +105,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sdkSignRevocationListVersioned`, `sdkInspectRevocationList`.
   `describe()` reports kind, clearance, ids, issuer fields, approvers, and
   gated tools.
-
-### Fixed
-
-- **FastMCP 4 middleware denials.** `TenuoMiddleware` returns a real
-  `ToolResult` (with `isError=True` on the wire) on FastMCP 3.2 through 4.x,
-  and version-pinned FastMCP 4 calls no longer lose the `_meta.tenuo` block.
-- **MCP SDK 2.x tool schemas.** `SecureMCPClient` and the LangChain bridge read
-  `Tool.input_schema` on SDK 2.x (previously an empty schema).
 
 ## [0.2.4] - 2026-09-01
 

--- a/tenuo-ts/packages/core/package.json
+++ b/tenuo-ts/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tenuo/core",
-  "version": "0.2.4-beta.0",
+  "version": "0.2.5-beta.0",
   "description": "Tenuo TypeScript SDK — authorization decisions run in the Rust core (WASM).",
   "license": "Apache-2.0",
   "author": "Tenuo Contributors",

--- a/tenuo-ts/packages/core/package.json
+++ b/tenuo-ts/packages/core/package.json
@@ -46,7 +46,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "build": "tsc -p tsconfig.build.json && mkdir -p dist/generated && cp src/generated/package.json src/generated/tenuo_wasm.js src/generated/tenuo_wasm.d.ts src/generated/tenuo_wasm_bg.wasm src/generated/tenuo_wasm_bg.wasm.d.ts dist/generated/ && cp ../../../LICENSE LICENSE",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-build-assets.mjs",
     "pack:smoke": "node scripts/pack-smoke.mjs",
     "publish:npm": "npm publish --access public --provenance --tag beta",
     "build:wasm": "pnpm --dir ../.. build:wasm"

--- a/tenuo-ts/packages/core/scripts/copy-build-assets.mjs
+++ b/tenuo-ts/packages/core/scripts/copy-build-assets.mjs
@@ -1,0 +1,19 @@
+import { copyFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const coreDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const generatedDir = join(coreDir, "src", "generated");
+const outputDir = join(coreDir, "dist", "generated");
+
+mkdirSync(outputDir, { recursive: true });
+for (const file of [
+  "package.json",
+  "tenuo_wasm.js",
+  "tenuo_wasm.d.ts",
+  "tenuo_wasm_bg.wasm",
+  "tenuo_wasm_bg.wasm.d.ts",
+]) {
+  copyFileSync(join(generatedDir, file), join(outputDir, file));
+}
+copyFileSync(join(coreDir, "..", "..", "..", "LICENSE"), join(coreDir, "LICENSE"));

--- a/tenuo-ts/packages/core/scripts/pack-smoke-consumer.mjs
+++ b/tenuo-ts/packages/core/scripts/pack-smoke-consumer.mjs
@@ -1,0 +1,132 @@
+import {
+  createTenuo,
+  range,
+  under,
+} from "@tenuo/core";
+
+const issuerSecret = createTenuo.generateIssuerKey();
+const tenuo = createTenuo({
+  root: createTenuo.issuerKeyFromBytes(issuerSecret),
+});
+
+const readFile = tenuo.tool(
+  { execute: async ({ path }) => path },
+  { capability: "read_file", allow: { path: under("/data") } },
+);
+const pay = tenuo.tool(
+  { execute: async ({ amount }) => amount },
+  { capability: "pay", allow: { amount: range({ min: 1, max: 100 }) } },
+);
+
+const session = tenuo.session({
+  tools: [readFile, pay],
+  ttlSeconds: 600,
+});
+
+const got = await tenuo.withSession(session, () =>
+  readFile.execute({ path: "/data/q3.pdf" }),
+);
+if (got !== "/data/q3.pdf") {
+  throw new Error("unexpected execute result: " + got);
+}
+
+const paid = await tenuo.withSession(session, () => pay.execute({ amount: 25 }));
+if (paid !== 25) {
+  throw new Error("unexpected range allow: " + paid);
+}
+
+await tenuo.withSession(session, () => pay.execute({ amount: 250 })).then(
+  () => {
+    throw new Error("range deny must not execute");
+  },
+  (error) => {
+    if (error?.code !== "TENUO_CONSTRAINT_VIOLATION") {
+      throw new Error("unexpected range deny: " + error);
+    }
+  },
+);
+
+const explained = tenuo.explain(session, "read_file", { path: "/data/q3.pdf" });
+if (explained.outcome !== "allow") {
+  throw new Error("unexpected explain: " + JSON.stringify(explained));
+}
+
+const workerKey = createTenuo.generateHolderKey();
+const issued = tenuo.session({
+  allow: { read_file: { path: under("/data") } },
+  holder: createTenuo.publicKeyFromHolderKey(workerKey),
+});
+if (issued.inspect().canAuthorize !== false) {
+  throw new Error("issued session must be wire-only");
+}
+if (tenuo.explain(issued, "read_file", { path: "/data/q3.pdf" }).outcome !== "allow") {
+  throw new Error("explain on a wire-only session must still decide");
+}
+
+const worker = createTenuo({ trustedRoots: [tenuo.issuerPublicKey()] });
+const mine = worker.sessionFromWire({
+  warrant: issued.toWire(),
+  holderKey: workerKey,
+});
+const presented = worker.present(mine, "read_file", { path: "/data/q3.pdf" });
+const verified = await tenuo.verify(presented, "read_file", { path: "/data/q3.pdf" }, {
+  allow: { path: under("/data") },
+});
+if (verified.path !== "/data/q3.pdf") {
+  throw new Error("unexpected present/verify: " + JSON.stringify(verified));
+}
+
+const orchestratorKey = createTenuo.generateHolderKey();
+const issuerHanded = tenuo.session({
+  kind: "issuer",
+  issuableTools: ["read_file"],
+  constraintBounds: { path: under("/data") },
+  holder: createTenuo.publicKeyFromHolderKey(orchestratorKey),
+  ttlSeconds: 600,
+});
+const orchestrator = createTenuo({ trustedRoots: [tenuo.issuerPublicKey()] });
+const issuer = orchestrator.sessionFromWire({
+  warrant: issuerHanded.toWire(),
+  holderKey: orchestratorKey,
+});
+const childKey = createTenuo.generateHolderKey();
+const child = orchestrator.issue(issuer, {
+  allow: { read_file: { path: under("/data/reports") } },
+  holder: createTenuo.publicKeyFromHolderKey(childKey),
+  ttlSeconds: 60,
+});
+const childSession = worker.sessionFromWire({
+  warrant: child.toWire(),
+  holderKey: childKey,
+});
+const childRead = worker.tool(
+  { execute: async ({ path }) => path },
+  { capability: "read_file", allow: {} },
+);
+const report = await childRead.execute({ path: "/data/reports/q3.pdf" }, { session: childSession });
+if (report !== "/data/reports/q3.pdf") {
+  throw new Error("unexpected issued execute: " + report);
+}
+
+const receipts = [];
+await readFile.execute(
+  { path: "/data/q3.pdf" },
+  { session, requestId: "smoke-1", onReceipt: (receipt) => receipts.push(receipt) },
+);
+if (receipts.length !== 1) {
+  throw new Error("expected one receipt");
+}
+const receipt = createTenuo.verifyReceipt(receipts[0]);
+if (receipt.outcome !== "allow" || receipt.authentic !== true || receipt.requestId !== "smoke-1") {
+  throw new Error("unexpected receipt: " + JSON.stringify(receipt));
+}
+
+const call = tenuo.mcp.attach(session, "read_file", { path: "/data/q3.pdf" });
+const mcpVerified = await tenuo.mcp.verify(call.name, call.arguments, call._meta, {
+  allow: { path: under("/data") },
+});
+if (mcpVerified.path !== "/data/q3.pdf") {
+  throw new Error("unexpected mcp verify: " + JSON.stringify(mcpVerified));
+}
+
+console.log("pack smoke ok");

--- a/tenuo-ts/packages/core/scripts/pack-smoke.mjs
+++ b/tenuo-ts/packages/core/scripts/pack-smoke.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,16 +11,15 @@ const installDir = mkdtempSync(join(tmpdir(), "tenuo-core-smoke-"));
 
 try {
   const tarball = packPackage(coreDir, packDir);
-  assertPacked(tarball, [
-    "package/dist/index.js",
-    "package/dist/generated/tenuo_wasm_bg.wasm",
-    "package/dist/generated/tenuo_wasm.js",
-    "package/LICENSE",
-    "package/README.md",
-  ]);
-
   writeFileSync(join(installDir, "package.json"), JSON.stringify({ private: true, type: "module" }));
   run("npm", ["install", "--omit=dev", tarball], { cwd: installDir, stdio: "inherit" });
+  assertInstalled(installDir, "@tenuo/core", [
+    "dist/index.js",
+    "dist/generated/tenuo_wasm_bg.wasm",
+    "dist/generated/tenuo_wasm.js",
+    "LICENSE",
+    "README.md",
+  ]);
   copyFileSync(join(coreDir, "scripts", "pack-smoke-consumer.mjs"), join(installDir, "smoke.mjs"));
   execFileSync(process.execPath, [join(installDir, "smoke.mjs")], {
     cwd: installDir,
@@ -53,12 +52,11 @@ function packPackage(cwd, destination) {
   return isAbsolute(packed) ? packed : join(destination, packed);
 }
 
-function assertPacked(tarball, required) {
-  const listing = execFileSync("tar", ["-tzf", tarball], { encoding: "utf8" });
-  const entries = listing.split(/\r?\n/);
+function assertInstalled(root, packageName, required) {
+  const packageDir = join(root, "node_modules", ...packageName.split("/"));
   for (const path of required) {
-    if (!entries.includes(path)) {
-      throw new Error(`packed tarball is missing ${path}`);
+    if (!existsSync(join(packageDir, path))) {
+      throw new Error(`installed ${packageName} is missing ${path}`);
     }
   }
 }

--- a/tenuo-ts/packages/core/scripts/pack-smoke.mjs
+++ b/tenuo-ts/packages/core/scripts/pack-smoke.mjs
@@ -33,17 +33,10 @@ try {
 }
 
 function run(command, args, options) {
-  return execFileSync(resolveBin(command), args, options);
-}
-
-function resolveBin(command) {
-  if (process.platform !== "win32") {
-    return command;
-  }
-  if (command.endsWith(".cmd") || command.endsWith(".exe")) {
-    return command;
-  }
-  return `${command}.cmd`;
+  return execFileSync(command, args, {
+    ...options,
+    shell: process.platform === "win32",
+  });
 }
 
 function packPackage(cwd, destination) {

--- a/tenuo-ts/packages/core/scripts/pack-smoke.mjs
+++ b/tenuo-ts/packages/core/scripts/pack-smoke.mjs
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const coreDir = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -20,76 +20,51 @@ try {
   ]);
 
   writeFileSync(join(installDir, "package.json"), JSON.stringify({ private: true, type: "module" }));
-  execFileSync("npm", ["install", "--omit=dev", tarball], {
+  run("npm", ["install", "--omit=dev", tarball], { cwd: installDir, stdio: "inherit" });
+  copyFileSync(join(coreDir, "scripts", "pack-smoke-consumer.mjs"), join(installDir, "smoke.mjs"));
+  execFileSync(process.execPath, [join(installDir, "smoke.mjs")], {
     cwd: installDir,
     stdio: "inherit",
+    env: { ...process.env, NODE_ENV: "test" },
   });
-  execFileSync(
-    process.execPath,
-    [
-      "--input-type=module",
-      "--eval",
-      `
-        import { createTenuo, under } from "@tenuo/core";
-        const tenuo = createTenuo({ root: createTenuo.devRoot() });
-        const readFile = tenuo.tool(
-          { execute: async ({ path }) => path },
-          { capability: "read_file", allow: { path: under("/data") } },
-        );
-        const session = tenuo.session({ tools: [readFile] });
-        const got = await tenuo.withSession(session, () =>
-          readFile.execute({ path: "/data/q3.pdf" }),
-        );
-        if (got !== "/data/q3.pdf") {
-          throw new Error("unexpected execute result: " + got);
-        }
-        await tenuo.withSession(session, () => readFile.execute({ path: "/etc/passwd" })).then(
-          () => { throw new Error("deny must not execute"); },
-          (error) => {
-            if (error?.code !== "TENUO_CONSTRAINT_VIOLATION") {
-              throw new Error("unexpected deny: " + error);
-            }
-          },
-        );
-        const call = tenuo.mcp.attach(session, "read_file", { path: "/data/q3.pdf" });
-        const verified = await tenuo.mcp.verify(call.name, call.arguments, call._meta, {
-          allow: { path: under("/data") },
-        });
-        if (verified.path !== "/data/q3.pdf") {
-          throw new Error("unexpected verify result: " + JSON.stringify(verified));
-        }
-        console.log("pack smoke ok");
-      `,
-    ],
-    {
-      cwd: installDir,
-      stdio: "inherit",
-      env: { ...process.env, NODE_ENV: "test" },
-    },
-  );
 } finally {
   rmSync(packDir, { recursive: true, force: true });
   rmSync(installDir, { recursive: true, force: true });
 }
 
+function run(command, args, options) {
+  return execFileSync(resolveBin(command), args, options);
+}
+
+function resolveBin(command) {
+  if (process.platform !== "win32") {
+    return command;
+  }
+  if (command.endsWith(".cmd") || command.endsWith(".exe")) {
+    return command;
+  }
+  return `${command}.cmd`;
+}
+
 function packPackage(cwd, destination) {
-  const packed = execFileSync("pnpm", ["pack", "--pack-destination", destination], {
+  const packed = run("pnpm", ["pack", "--pack-destination", destination], {
     cwd,
     encoding: "utf8",
   })
     .trim()
-    .split("\n")
+    .split(/\r?\n/)
     .at(-1);
   if (packed === undefined || packed.length === 0) {
     throw new Error("pnpm pack did not print a tarball path");
   }
-  return packed.startsWith("/") ? packed : join(destination, packed);
+  return isAbsolute(packed) ? packed : join(destination, packed);
 }
 
 function assertPacked(tarball, required) {
   const listing = execFileSync("tar", ["-tzf", tarball], { encoding: "utf8" });
+  const entries = listing.split(/\r?\n/);
   for (const path of required) {
-    if (!listing.split("\n").includes(path)) {
+    if (!entries.includes(path)) {
       throw new Error(`packed tarball is missing ${path}`);
     }
   }

--- a/tenuo-ts/packages/core/test/interop.test.ts
+++ b/tenuo-ts/packages/core/test/interop.test.ts
@@ -131,6 +131,11 @@ function expectAgree(
 }
 
 const pythonBin = python();
+if (process.env.TENUO_REQUIRE_INTEROP === "1" && pythonBin === undefined) {
+  throw new Error(
+    "TENUO_REQUIRE_INTEROP=1 but `import tenuo` failed. Install the Python package before this suite.",
+  );
+}
 
 describe.skipIf(pythonBin === undefined)("Python ↔ TypeScript compatibility", () => {
   describe("Python mints, TypeScript imports", () => {

--- a/tenuo-ts/packages/core/test/mcp-interop.test.ts
+++ b/tenuo-ts/packages/core/test/mcp-interop.test.ts
@@ -50,6 +50,11 @@ function runPython<T>(bin: string, command: string, stdin: unknown): T {
 }
 
 const pythonBin = python();
+if (process.env.TENUO_REQUIRE_INTEROP === "1" && pythonBin === undefined) {
+  throw new Error(
+    "TENUO_REQUIRE_INTEROP=1 but `from tenuo.mcp.server import MCPVerifier` failed. Install tenuo and mcp before this suite.",
+  );
+}
 
 describe.skipIf(pythonBin === undefined)("Python ↔ TypeScript MCP wire", () => {
   it("verifies a Python-attached envelope in TypeScript", async () => {

--- a/tenuo-ts/packages/mcp/package.json
+++ b/tenuo-ts/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tenuo/mcp",
-  "version": "0.2.4-beta.0",
+  "version": "0.2.5-beta.0",
   "description": "Optional adapter: guard @modelcontextprotocol/server v2 tools with @tenuo/core.",
   "license": "Apache-2.0",
   "author": "Tenuo Contributors",
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "@modelcontextprotocol/server": "^2.0.0",
-    "@tenuo/core": ">=0.2.4-beta.0 <0.2.5"
+    "@tenuo/core": ">=0.2.5-beta.0 <0.2.6"
   },
   "devDependencies": {
     "@modelcontextprotocol/client": "2.0.0",

--- a/tenuo-ts/packages/mcp/package.json
+++ b/tenuo-ts/packages/mcp/package.json
@@ -42,7 +42,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "build": "tsc -p tsconfig.build.json && cp ../../../LICENSE LICENSE",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-build-assets.mjs",
     "pack:smoke": "node scripts/pack-smoke.mjs",
     "publish:npm": "npm publish --access public --provenance --tag beta"
   },

--- a/tenuo-ts/packages/mcp/scripts/copy-build-assets.mjs
+++ b/tenuo-ts/packages/mcp/scripts/copy-build-assets.mjs
@@ -1,0 +1,6 @@
+import { copyFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const mcpDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+copyFileSync(join(mcpDir, "..", "..", "..", "LICENSE"), join(mcpDir, "LICENSE"));

--- a/tenuo-ts/packages/mcp/scripts/pack-smoke.mjs
+++ b/tenuo-ts/packages/mcp/scripts/pack-smoke.mjs
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const mcpDir = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -18,7 +18,7 @@ try {
   assertPacked(mcpTarball, ["package/dist/index.js", "package/LICENSE", "package/README.md"]);
 
   writeFileSync(join(installDir, "package.json"), JSON.stringify({ private: true, type: "module" }));
-  execFileSync("npm", ["install", "--omit=dev", coreTarball, mcpTarball], {
+  run("npm", ["install", "--omit=dev", coreTarball, mcpTarball], {
     cwd: installDir,
     stdio: "inherit",
   });
@@ -68,24 +68,39 @@ try {
   rmSync(installDir, { recursive: true, force: true });
 }
 
+function run(command, args, options) {
+  return execFileSync(resolveBin(command), args, options);
+}
+
+function resolveBin(command) {
+  if (process.platform !== "win32") {
+    return command;
+  }
+  if (command.endsWith(".cmd") || command.endsWith(".exe")) {
+    return command;
+  }
+  return `${command}.cmd`;
+}
+
 function packPackage(cwd, destination) {
-  const packed = execFileSync("pnpm", ["pack", "--pack-destination", destination], {
+  const packed = run("pnpm", ["pack", "--pack-destination", destination], {
     cwd,
     encoding: "utf8",
   })
     .trim()
-    .split("\n")
+    .split(/\r?\n/)
     .at(-1);
   if (packed === undefined || packed.length === 0) {
     throw new Error("pnpm pack did not print a tarball path");
   }
-  return packed.startsWith("/") ? packed : join(destination, packed);
+  return isAbsolute(packed) ? packed : join(destination, packed);
 }
 
 function assertPacked(tarball, required) {
   const listing = execFileSync("tar", ["-tzf", tarball], { encoding: "utf8" });
+  const entries = listing.split(/\r?\n/);
   for (const path of required) {
-    if (!listing.split("\n").includes(path)) {
+    if (!entries.includes(path)) {
       throw new Error(`packed tarball is missing ${path}`);
     }
   }

--- a/tenuo-ts/packages/mcp/scripts/pack-smoke.mjs
+++ b/tenuo-ts/packages/mcp/scripts/pack-smoke.mjs
@@ -69,17 +69,10 @@ try {
 }
 
 function run(command, args, options) {
-  return execFileSync(resolveBin(command), args, options);
-}
-
-function resolveBin(command) {
-  if (process.platform !== "win32") {
-    return command;
-  }
-  if (command.endsWith(".cmd") || command.endsWith(".exe")) {
-    return command;
-  }
-  return `${command}.cmd`;
+  return execFileSync(command, args, {
+    ...options,
+    shell: process.platform === "win32",
+  });
 }
 
 function packPackage(cwd, destination) {

--- a/tenuo-ts/packages/mcp/scripts/pack-smoke.mjs
+++ b/tenuo-ts/packages/mcp/scripts/pack-smoke.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,13 +15,12 @@ const installDir = mkdtempSync(join(tmpdir(), "tenuo-mcp-smoke-"));
 try {
   const coreTarball = packPackage(coreDir, packDir);
   const mcpTarball = packPackage(mcpDir, packDir);
-  assertPacked(mcpTarball, ["package/dist/index.js", "package/LICENSE", "package/README.md"]);
-
   writeFileSync(join(installDir, "package.json"), JSON.stringify({ private: true, type: "module" }));
   run("npm", ["install", "--omit=dev", coreTarball, mcpTarball], {
     cwd: installDir,
     stdio: "inherit",
   });
+  assertInstalled(installDir, "@tenuo/mcp", ["dist/index.js", "LICENSE", "README.md"]);
   execFileSync(
     process.execPath,
     [
@@ -89,12 +88,11 @@ function packPackage(cwd, destination) {
   return isAbsolute(packed) ? packed : join(destination, packed);
 }
 
-function assertPacked(tarball, required) {
-  const listing = execFileSync("tar", ["-tzf", tarball], { encoding: "utf8" });
-  const entries = listing.split(/\r?\n/);
+function assertInstalled(root, packageName, required) {
+  const packageDir = join(root, "node_modules", ...packageName.split("/"));
   for (const path of required) {
-    if (!entries.includes(path)) {
-      throw new Error(`packed tarball is missing ${path}`);
+    if (!existsSync(join(packageDir, path))) {
+      throw new Error(`installed ${packageName} is missing ${path}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bump `@tenuo/core` and `@tenuo/mcp` to `0.2.5-beta.0` and widen the MCP peer to `>=0.2.5-beta.0 <0.2.6`, so the next GitHub release actually publishes instead of skipping the version already on npm.
- Keep npm on the `beta` dist-tag and move `latest` to the new beta after publish.
- Make Python↔TypeScript interop required on the TypeScript CI job (`TENUO_REQUIRE_INTEROP=1` after installing the Python wheel and `mcp`).
- Expand `@tenuo/core` pack-smoke to issuer keys, `range`, `issue`, `explain`, `present`/`verify`, and receipts; add a Windows committed-WASM pack-smoke job.

## Test plan
- [x] `pnpm --filter @tenuo/core build && pack:smoke` (local)
- [x] `pnpm --filter @tenuo/mcp build && pack:smoke` (local)
- [ ] CI TypeScript SDK job installs Python and does not skip interop
- [ ] CI TypeScript SDK (Windows pack smoke) is green
- [ ] After merge + GitHub release, `npm view @tenuo/core version` is `0.2.5-beta.0` and both `beta` and `latest` tags point at it