### PR TITLE
fix(ts): validate in-memory nonce TTL

### DIFF
--- a/tenuo-ts/README.md
+++ b/tenuo-ts/README.md
@@ -733,7 +733,8 @@ keys, never the client's holder secret.
 Proof-of-possession v1 is replayable within its validity window unless a nonce
 store is configured. Use `memoryNonceStore()` for one-process deployments or
 provide an async `NonceStore` backed by shared storage. A nonce-store failure
-fails closed.
+fails closed. Its `ttlSeconds` option defaults to 180 and, when provided, must
+be positive, finite, and small enough to represent in milliseconds.
 
 See the [`@tenuo/mcp` README](packages/mcp/README.md) for handler behavior,
 error mapping, and replay protection. A complete multi-agent scenario lives in

--- a/tenuo-ts/packages/core/README.md
+++ b/tenuo-ts/packages/core/README.md
@@ -87,6 +87,8 @@ For `@modelcontextprotocol/sdk` v1, copy the recipe in `examples/mcp/host.ts`.
 or an async Redis `checkAndRecord`) to reject an exact replayed PoP; that is
 opt-in. PoP v1 is otherwise replayable in-window, including approval-gated
 calls. Pass `nonceStore` on those tools if an approval must be one-use.
+`memoryNonceStore({ ttlSeconds })` defaults to 180 seconds; an explicit TTL must
+be positive, finite, and small enough to represent in milliseconds.
 
 See the [workspace README](../../README.md) for the full API, refuse list, and
 how to rebuild WASM from this monorepo.

--- a/tenuo-ts/packages/core/src/nonce.ts
+++ b/tenuo-ts/packages/core/src/nonce.ts
@@ -1,14 +1,27 @@
 import { createHash } from "node:crypto";
 import type { NonceStore } from "./api.ts";
+import { TenuoConfigurationError } from "./errors.ts";
 
 /**
  * In-process PoP replay store. Same shape as Python `NonceStore`.
  * Not on by default. Does not work across processes — implement
  * `NonceStore` with an async Redis `checkAndRecord` (return
  * `Promise<boolean>`). A rejected Promise fails closed.
+ *
+ * `ttlSeconds` defaults to 180 and must be greater than zero and finite.
+ * Values too large to convert to milliseconds are also rejected.
+ *
+ * @throws {TenuoConfigurationError} If `ttlSeconds` is not a supported
+ * positive, finite duration.
  */
 export function memoryNonceStore(options?: { readonly ttlSeconds?: number }): NonceStore {
-  const ttlMs = (options?.ttlSeconds ?? 180) * 1000;
+  const ttlSeconds = options?.ttlSeconds ?? 180;
+  const ttlMs = ttlSeconds * 1000;
+  if (ttlSeconds <= 0 || !Number.isFinite(ttlSeconds) || !Number.isFinite(ttlMs)) {
+    throw new TenuoConfigurationError(
+      "memoryNonceStore() ttlSeconds must be positive, finite, and representable in milliseconds",
+    );
+  }
   const seen = new Map<string, number>();
   return {
     checkAndRecord(popSignature: string): boolean {

--- a/tenuo-ts/packages/core/test/nonce.test.ts
+++ b/tenuo-ts/packages/core/test/nonce.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { memoryNonceStore, TenuoConfigurationError } from "../src/index.ts";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("memoryNonceStore", () => {
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.MAX_VALUE])(
+    "rejects ttlSeconds=%s at configuration time",
+    (ttlSeconds) => {
+      expect(() => memoryNonceStore({ ttlSeconds })).toThrow(TenuoConfigurationError);
+      expect(() => memoryNonceStore({ ttlSeconds })).toThrow(
+        /ttlSeconds must be positive, finite, and representable in milliseconds/,
+      );
+
+      try {
+        memoryNonceStore({ ttlSeconds });
+      } catch (error) {
+        expect(error).toMatchObject({ code: "TENUO_CONFIGURATION" });
+      }
+    },
+  );
+
+  it("uses the 180-second default TTL", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const store = memoryNonceStore();
+
+    expect(store.checkAndRecord("signature")).toBe(true);
+    expect(store.checkAndRecord("signature")).toBe(false);
+
+    vi.setSystemTime(179_999);
+    expect(store.checkAndRecord("signature")).toBe(false);
+
+    vi.setSystemTime(180_000);
+    expect(store.checkAndRecord("signature")).toBe(true);
+  });
+
+  it("accepts a positive custom TTL and releases the signature at expiry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const store = memoryNonceStore({ ttlSeconds: 0.25 });
+
+    expect(store.checkAndRecord("signature")).toBe(true);
+    expect(store.checkAndRecord("signature")).toBe(false);
+
+    vi.setSystemTime(10_249);
+    expect(store.checkAndRecord("signature")).toBe(false);
+
+    vi.setSystemTime(10_250);
+    expect(store.checkAndRecord("signature")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- reject non-positive and non-finite `memoryNonceStore({ ttlSeconds })` values at configuration time
- also reject finite second values that overflow when converted to milliseconds
- preserve the 180-second default and allow positive fractional TTLs
- document the accepted TTL range in the SDK and package READMEs
- add deterministic tests for default TTL, custom expiry, replay rejection, and invalid inputs

Closes #567

## Security behavior

Invalid replay-store lifetimes now fail closed with `TenuoConfigurationError` and `TENUO_CONFIGURATION`. The `NonceStore` interface, default TTL, MCP verification flow, and nonce-store failure handling are unchanged.

## Test plan

- `pnpm --filter @tenuo/core exec vitest run test/nonce.test.ts`
- `pnpm --filter @tenuo/core typecheck`
- `pnpm --filter @tenuo/core test` (227 tests passed, including Python/TypeScript interop and differential tests)