### PR TITLE
chore(release): coordinated 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,104 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [0.2.5] - 2026-09-06
 
-- **Python extras declare the floors the code actually needs.** `tenuo[mcp]`
-  and `tenuo[fastmcp]` now require `mcp>=1.9.4` (streamable-HTTP transport
-  shape, `CallToolRequestParams.meta`); `tenuo[crewai]` requires `crewai>=1.5`
-  (`crewai.hooks`). Both were previously declared as `>=1.0` but failed at
-  import or first use on those versions.
-
-### Fixed
-
-- **FastMCP 4 middleware denials.** `TenuoMiddleware` returns a real
-  `ToolResult` (with `isError=True` on the wire) on FastMCP 3.2 through 4.x,
-  and version-pinned FastMCP 4 calls no longer lose the `_meta.tenuo` block.
-- **MCP SDK 2.x tool schemas.** `SecureMCPClient` and the LangChain bridge read
-  `Tool.input_schema` on SDK 2.x (previously an empty schema).
-
-## [0.2.5-beta.0] - 2026-09-06
-
-TypeScript SDK only (`@tenuo/core` / `@tenuo/mcp` on the npm `beta` tag).
-Rust and Python remain 0.2.4. `latest` is moved to this beta after publish
-so `npm i @tenuo/core` is not stuck on `0.2.4-beta.0`. Install with
-`@tenuo/core@beta` until a stable tag is declared.
+Python `tenuo==0.2.5`, Rust `tenuo@0.2.5`, TypeScript `@tenuo/core@0.2.5-beta.0`
+(npm `beta`). Same protocol line; TypeScript stays on the beta dist-tag.
 
 ### Added
 
-- **TypeScript: delegation across agents.** `tenuo.narrow(session, allow,
-  options)` accepts `{ holder, ttlSeconds, terminal, maxDepth }`. With
-  `holder`, the child is bound to another agent's public key and signed by the
-  current holder; the returned session is wire-only (`toWire()`), and that
-  agent imports it with `sessionFromWire()`. Core rejects any child not within
-  its parent before a token exists.
-- **TypeScript: issue to an agent's key.** `tenuo.session({ holder, maxDepth })`
-  binds a fresh session to another holder and caps delegation depth
-  (`0` = terminal). `tenuo.issuerPublicKey()` returns the dev issuer's public
-  key for other processes' `trustedRoots`.
-- **TypeScript: holder keys.** `createTenuo.generateHolderKey()` and
-  `createTenuo.publicKeyFromHolderKey(secret)`.
-- **TypeScript: `session.inspect()`.** Holder public key, root public key,
-  depth, `maxDepth`, `terminal`, `expiresAt`, tools, warrant ids, and
-  `canAuthorize`. Never the holder secret.
-- **TypeScript: `TENUO_DEPTH_EXCEEDED`.** Narrowing a terminal session, or
-  past the chain's `maxDepth`, raises `AuthorizationDeniedError` with this
-  code instead of the generic `TENUO_CHAIN_INVALID`.
-- **TypeScript: full constraint set.** `min`, `range`, `notOneOf`, `regex`,
-  `wildcard`, `cidr`, `urlPattern`, `urlSafe`, `shlex`, `contains`, `subset`,
-  `anyOf`, `all`, `not`, `cel`, and `under(root, { caseSensitive, allowEqual })`
-  join the existing six. Every kind is evaluated and attenuated in core; the
-  set now matches the Python SDK and the core `Constraint` enum.
-- **TypeScript: stable issuer key.** `createTenuo({ root:
-  createTenuo.issuerKeyFromEnv("TENUO_ISSUER_SECRET") })` (also `FromHex`,
-  `FromBytes`, `generateIssuerKey`) makes a Node process a control plane that
-  mints with a persistent key and works outside `NODE_ENV=development`.
-- **TypeScript: issuer sessions.** `session({ kind: "issuer", issuableTools,
-  constraintBounds, maxIssueDepth })` and `tenuo.issue(issuerSession, {
-  allow, holder, ... })` mint execution sessions without the root key; core
-  checks tools, bounds, clearance, and issue depth.
-- **TypeScript: warrant metadata.** `clearance` (name or 0-255), `sessionId`,
-  `agentId` on `session()`, `issue()`, and `narrow()` (clearance only lowers,
-  session id is inherited); all reported by `session.inspect()`.
-- **TypeScript: approvals end to end.** `requireApproval.gates` with per-tool
-  messages and per-argument `"all"` / `{ when }` / `{ exempt }` triggers;
-  `narrow({ addApprovers, minApprovals })`; `ApprovalRequiredError.request`;
-  `tenuo.approvalRequest()`, `tenuo.attestApprovalRequest()`,
-  `createTenuo.signApproval()`, `createTenuo.inspectApproval()`, and the
-  control-plane v1 wire helpers `controlPlaneApprovalRequestV1()` /
-  `signedApprovalsFromResponseV1()` matching the Python shape.
-- **TypeScript: revocation lists.** `tenuo.revocationList({ revoke, version })`
-  on issuer contexts, `createTenuo.signRevocationList()` with an explicit
-  secret, `createTenuo.inspectRevocationList()`.
-- **TypeScript: receipts are public.** `createTenuo.verifyReceipt()` and
-  `createTenuo.verifyReceiptChain()` with camelCase results.
-- **TypeScript: `tenuo.explain(session, tool, args)`.** Field-by-field
-  verdicts, unknown and missing arguments, chain validity, and the decision,
-  with no proof-of-possession, so it works on wire-only sessions.
-- **TypeScript: `tenuo.present()` / `tenuo.verify()`.** The MCP attach/verify
-  path without the MCP envelope, for HTTP or any other boundary.
-  `mcp.attach()` and `mcp.verify()` now share it.
-- **Core: CEL compiles on wasm32.** The compiled-program cache uses a bounded
-  map on `wasm32` instead of moka, whose eviction needs a monotonic clock the
-  target does not have. Native builds are unchanged.
+- **TypeScript: full constraint set**, matching Python: `range`, `min`,
+  `notOneOf`, `regex`, `wildcard`, `cidr`, `urlPattern`, `urlSafe`, `shlex`,
+  `contains`, `subset`, `anyOf`, `all`, `not`, `cel`, plus `under(root, {
+  caseSensitive, allowEqual })`.
+- **TypeScript: persistent issuer keys.** `createTenuo({ root:
+  createTenuo.issuerKeyFromEnv(...) })` (also `FromHex` / `FromBytes` /
+  `generateIssuerKey`) mints warrants from a Node control plane without
+  `NODE_ENV=development`.
+- **TypeScript: delegation to another agent.** `session({ holder, maxDepth })`
+  and `narrow(session, allow, { holder, terminal, maxDepth })` bind a child to
+  someone else's key. `session({ kind: "issuer", issuableTools, ... })` plus
+  `tenuo.issue()` mint execution warrants without the root key. Depth and
+  terminal violations raise `TENUO_DEPTH_EXCEEDED`.
+- **TypeScript: inspect, explain, present, verify.** `session.inspect()`,
+  `tenuo.explain()`, and `tenuo.present()` / `tenuo.verify()` for any
+  HTTP/RPC boundary (`mcp.attach` / `mcp.verify` use the same path).
+  Approvals, signed revocation lists, and `createTenuo.verifyReceipt()` /
+  `verifyReceiptChain()` are public.
 
 ### Changed
 
-- **TypeScript: `sessionFromWire()` with the wrong holder key** now throws
-  `AuthorizationDeniedError` with `TENUO_INVALID_POP` (was a configuration
-  error). A copied warrant is not authority.
-- **@tenuo/mcp peer** is now `@tenuo/core@>=0.2.5-beta.0 <0.2.6`.
-- **tenuo-wasm `SdkContext.mint`** takes optional `holder_hex` and `max_depth`;
-  `SdkContext.narrow` takes an optional options object; `SdkSession` gains
-  `describe()`; `sdkPublicKeyFromHolderKey` is exported. Existing call sites
-  are unchanged.
-- **tenuo-wasm parity module** (`sdk_ext.rs`): `SdkContext.fromIssuerSecret`,
-  `mintExtended`, `issue`, `explain`, `approvalRequest`,
-  `approvalContextAttestation`, `signRevocationListVersioned`; free functions
-  `sdkSignApprovalForRequest`, `sdkInspectApproval`,
-  `sdkSignRevocationListVersioned`, `sdkInspectRevocationList`.
-  `describe()` reports kind, clearance, ids, issuer fields, approvers, and
-  gated tools.
+- **`tenuo[mcp]` / `tenuo[fastmcp]` require `mcp>=1.9.4`.** `tenuo[crewai]`
+  requires `crewai>=1.5`. Older extras installed versions that failed at
+  import or first use.
+- **TypeScript: `sessionFromWire()` with the wrong holder key** throws
+  `AuthorizationDeniedError` (`TENUO_INVALID_POP`). A copied warrant is not
+  authority. `@tenuo/mcp` requires `@tenuo/core@0.2.5-beta.0`.
+
+### Fixed
+
+- **FastMCP 4 denials** return a real error `ToolResult` and keep
+  `_meta.tenuo` on version-pinned 4.x calls.
+- **MCP SDK 2.x tool schemas.** `SecureMCPClient` and the LangChain bridge
+  read `Tool.input_schema` (was empty).
+- **TypeScript: `memoryNonceStore({ ttlSeconds })`** rejects non-positive or
+  non-finite TTLs at construction (default remains 180 seconds).
 
 ## [0.2.4] - 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -350,8 +350,8 @@ This runs the [orchestrator -> worker -> authorizer](https://tenuo.ai/demo.html)
 **Official Images** on [Docker Hub](https://hub.docker.com/u/tenuo):
 
 ```bash
-docker pull tenuo/authorizer:0.2.4  # Sidecar for warrant verification
-docker pull tenuo/control:0.2.4     # Control plane (demo/reference)
+docker pull tenuo/authorizer:0.2.5  # Sidecar for warrant verification
+docker pull tenuo/control:0.2.5     # Control plane (demo/reference)
 ```
 
 **Helm Chart**:
@@ -388,7 +388,7 @@ The core crate is the protocol. The `sdk` feature is the enforcement surface: a 
 
 ```toml
 [dependencies]
-tenuo = { version = "0.2.4", features = ["sdk"] }
+tenuo = { version = "0.2.5", features = ["sdk"] }
 ```
 
 ```rust

--- a/charts/tenuo-authorizer/Chart.yaml
+++ b/charts/tenuo-authorizer/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tenuo-authorizer
 description: Tenuo authorization service for Kubernetes
 type: application
-version: 0.2.4
-appVersion: "0.2.4"
+version: 0.2.5
+appVersion: "0.2.5"
 keywords:
   - authorization
   - security

--- a/charts/tenuo-authorizer/README.md
+++ b/charts/tenuo-authorizer/README.md
@@ -218,7 +218,7 @@ helm install tenuo-authorizer ./charts/tenuo-authorizer \
 helm upgrade tenuo-authorizer ./charts/tenuo-authorizer -f new-values.yaml
 
 # Upgrade to a new chart version
-helm upgrade tenuo-authorizer ./charts/tenuo-authorizer --version 0.2.4
+helm upgrade tenuo-authorizer ./charts/tenuo-authorizer --version 0.2.5
 ```
 
 ## Troubleshooting

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -138,7 +138,7 @@ print(info())
 Tenuo Configuration
 ==================================================
 
-[OK] SDK Version: 0.2.4
+[OK] SDK Version: 0.2.5
 [OK] Rust Core: loaded (wire version 1)
 [OK] Issuer Key: configured
 ```

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -88,7 +88,7 @@ Tenuo runs as a separate container in the same Kubernetes pod. All tool traffic 
 spec:
   containers:
     - name: tenuo-authorizer
-      image: tenuo/authorizer:0.2.4
+      image: tenuo/authorizer:0.2.5
       ports: [{ containerPort: 9090 }]
     - name: tool-api
       image: your-tool:latest
@@ -463,7 +463,7 @@ services:
       - tenuo-authorizer
 
   tenuo-authorizer:
-    image: tenuo/authorizer:0.2.4
+    image: tenuo/authorizer:0.2.5
     ports:
       - "9090:9090"
     environment:

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -183,7 +183,7 @@ env:
 ```yaml
 containers:
 - name: tenuo-authorizer
-  image: tenuo/authorizer:0.2.4
+  image: tenuo/authorizer:0.2.5
   args: ["serve", "--config", "/etc/tenuo/gateway.yaml"]
   ports:
   - name: http
@@ -451,7 +451,7 @@ curl -s localhost:9090/status | jq
 
 ```json
 {
-  "version": "0.2.4",
+  "version": "0.2.5",
   "uptime_secs": 42,
   "cp": {
     "enabled": true,

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "axum",

--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Agent Capability Flow Control - Rust core library"

--- a/tenuo-core/fuzz/Cargo.lock
+++ b/tenuo-core/fuzz/Cargo.lock
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.23.1",
  "chrono",

--- a/tenuo-python/Cargo.lock
+++ b/tenuo-python/Cargo.lock
@@ -2197,7 +2197,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tenuo"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "axum",
  "base64",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-python"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "pyo3",
  "tenuo",

--- a/tenuo-python/Cargo.toml
+++ b/tenuo-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-python"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Capability tokens for AI agents - Python SDK"

--- a/tenuo-python/pyproject.toml
+++ b/tenuo-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tenuo"
-version = "0.2.4"
+version = "0.2.5"
 description = "Capability tokens for AI agents - Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tenuo-python/tenuo/__init__.py
+++ b/tenuo-python/tenuo/__init__.py
@@ -377,4 +377,4 @@ __all__ = [
     "get_default_nonce_store",
 ]
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/tenuo-wasm/Cargo.lock
+++ b/tenuo-wasm/Cargo.lock
@@ -1410,7 +1410,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tenuo"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.23.1",
  "cel-interpreter",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-wasm"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/tenuo-wasm/Cargo.toml
+++ b/tenuo-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-wasm"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "WASM bindings for Tenuo"


### PR DESCRIPTION
## Summary
- Bump Rust (`tenuo` 0.2.5), Python (`tenuo==0.2.5`), WASM crate, Helm chart, and current-version docs so a GitHub `v0.2.5` release publishes one line.
- TypeScript stays `@tenuo/core@0.2.5-beta.0` / `@tenuo/mcp@0.2.5-beta.0` on the npm `beta` tag.
- Fold the TypeScript beta notes and the unpublished Python FastMCP / extras fixes into one user-facing `[0.2.5]` changelog. Supersedes #600.

## Test plan
- [ ] `grep` product versions: Cargo.toml / pyproject / `__version__` / Chart.yaml are 0.2.5
- [ ] TS packages remain `0.2.5-beta.0`
- [ ] Changelog has no WASM/`sdk_ext.rs` internals and no leftover `[0.2.5-beta.0]` section
- [ ] After merge, publish GitHub **`v0.2.5`** (not a TS-only tag)