### PR TITLE
fix(ci): align lab deploy verifier with homepage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -107,7 +107,7 @@ jobs:
             index="$(curl --fail --silent --show-error --location "${base_url}/lab/?deploy=${CACHE_BUSTER}-${attempt}" || true)"
             stage5="$(curl --fail --silent --show-error --location "${base_url}/lab/stage-5?deploy=${CACHE_BUSTER}-${attempt}" || true)"
             if [[ "$index" == *"Book the trip. Stop the rogue agent."* ]] && \
-               [[ "$index" == *"A ninety-minute security game"* ]] && \
+               [[ "$index" == *"A ninety-minute security challenge"* ]] && \
                [[ "$index" != *"AI Agent Delegation Challenge"* ]] && \
                [[ "$stage5" == *"Open the Stage 5 reference on GitHub"* ]] && \
                [[ "$stage5" != *"One solution to the TODO"* ]]; then

--- a/labs/agent-delegation/test/cli.test.ts
+++ b/labs/agent-delegation/test/cli.test.ts
@@ -127,6 +127,9 @@ describe("generated Stage 5 guide", () => {
     expect(page).toContain("A ninety-minute security challenge");
     expect(page).not.toContain("security game");
     expect(page.match(/npm run reset/g)).toHaveLength(1);
+    const deployWorkflow = readFileSync(join(ROOT, "..", "..", ".github", "workflows", "docs.yml"), "utf8");
+    expect(deployWorkflow).toContain("A ninety-minute security challenge");
+    expect(deployWorkflow).not.toContain("A ninety-minute security game");
   });
 
   it("keeps the reference implementation out of the page body", () => {


### PR DESCRIPTION
## Summary
- update the public lab verifier for the canonical “security challenge” wording
- test that the generated homepage and deploy assertion cannot drift again

## Validation
- live `tenuo.ai/lab` verifier conditions pass
- `npm run typecheck`
- `npm test` (26/26)
- `npm run site -- --check`