### PR TITLE
feat(lab): submit redacted challenge scorecards

### DIFF
--- a/docs/lab/index.md
+++ b/docs/lab/index.md
@@ -99,7 +99,7 @@ npm run score      # your score and why
 npm run trace      # every decision, with its reason
 npm run audit      # what every agent can currently do
 npm run next       # move on to the next stage
-npm run share      # write an anonymous score breakdown for your session host
+npm run share      # send Tenuo a redacted scorecard to improve the challenge
 npm run reset      # restore stage 1 and every starter exercise</code></pre>
 
 <aside class="lab-callout notice"><div class="lab-callout-title">One ground rule</div><p><strong>The injected instruction is in the flight service. Do not delete or filter it.</strong> Assume an agent will sometimes be fooled; this game is about what still holds when it is.</p></aside>

--- a/docs/lab/wrap-up.md
+++ b/docs/lab/wrap-up.md
@@ -17,5 +17,8 @@ lab_version: "0.2.0"
 <h2>Going further</h2>
 <p>The authorization system you used in stages 5 to 7 is open source at <a href="https://github.com/tenuo-ai/tenuo">github.com/tenuo-ai/tenuo</a>. The delegation rules behind it are being standardized in the public <a href="https://datatracker.ietf.org/doc/draft-niyikiza-oauth-attenuating-agent-tokens/">IETF draft on attenuating agent tokens</a>. A star on the repository is the main way maintainers find out anyone is using their work.</p>
 <pre class="lab-cmd"><code>npm run star       # optional: support the project without changing screens
-npm run share      # write the anonymous local scorecard for your session host</code></pre>
+npm run share      # send Tenuo a redacted scorecard
+npm run share -- --username YOUR_GITHUB_USERNAME
+                   # optional: use this unverified name on future leaderboards</code></pre>
+<p class="lab-muted">Sharing is explicit. Tenuo receives the star results, attempt count, redacted first-attempt and first-green summaries, a random local challenge-session ID, and runtime versions. It never receives source, keys, argument values, filesystem paths, or client timestamps. The same scorecard is saved locally, and a failed delivery is clearly reported.</p>
 <nav class="lab-nav"><a class="prev" href="/lab/stage-7">← Stage 7</a><a class="next" href="/lab/contribute">Contribute to Tenuo →</a></nav>

--- a/labs/agent-delegation/README.md
+++ b/labs/agent-delegation/README.md
@@ -46,7 +46,7 @@ npm run attack     # run the rogue behavior and the security tests
 npm run score      # see your score and why
 npm run audit      # what every agent can currently do
 npm run next       # move to the next stage
-npm run share      # write an anonymous score breakdown for your session host
+npm run share      # send Tenuo a redacted scorecard to improve the challenge
 npm run star       # optionally star Tenuo without leaving the terminal
 npm run reset      # restore stage 1 and every starter exercise
 ```
@@ -88,13 +88,18 @@ After the core lab, the hosted guide has an unnumbered, optional contribution ep
 
 ## What leaves your machine
 
-Nothing automatically. The lab runs locally and makes no network requests.
+Nothing automatically. The challenge runs locally; only `npm run share` makes
+a network request, after you explicitly run it.
 It keeps attempt counts and small semantic summaries—tool names, per-handoff
 behavioral constraint results, whether the holder was correct, a coarse TTL
 bucket, and which stars were missing—in `.lab/`. It never records source code,
-keys, names, argument values, or exact timestamps.
-`npm run share` writes an anonymous local JSON artifact; you choose whether to
-hand that file to a session host.
+keys, traveler names, argument values, or exact timestamps.
+`npm run share` saves that redacted scorecard locally and submits it to Tenuo
+so the maintainers can analyze the developer experience. Add
+`-- --username YOUR_GITHUB_USERNAME` only if you want that unverified display
+name associated with the result for future challenge leaderboards. Without it,
+the scorecard has only a random local challenge-session ID. If delivery fails,
+the local file remains and the command tells you that Tenuo did not receive it.
 
 ## How it works
 

--- a/labs/agent-delegation/site/build.ts
+++ b/labs/agent-delegation/site/build.ts
@@ -269,7 +269,7 @@ npm run score      # your score and why
 npm run trace      # every decision, with its reason
 npm run audit      # what every agent can currently do
 npm run next       # move on to the next stage
-npm run share      # write an anonymous score breakdown for your session host
+npm run share      # send Tenuo a redacted scorecard to improve the challenge
 npm run reset      # restore stage 1 and every starter exercise</code></pre>
 
 <aside class="lab-callout notice"><div class="lab-callout-title">One ground rule</div><p><strong>The injected instruction is in the flight service. Do not delete or filter it.</strong> Assume an agent will sometimes be fooled; this game is about what still holds when it is.</p></aside>
@@ -315,7 +315,10 @@ function wrapUpPage(): string {
 <h2>Going further</h2>
 <p>The authorization system you used in stages 5 to 7 is open source at <a href="${REPO_URL}">github.com/tenuo-ai/tenuo</a>. The delegation rules behind it are being standardized in the public <a href="${IETF_DRAFT_URL}">IETF draft on attenuating agent tokens</a>. A star on the repository is the main way maintainers find out anyone is using their work.</p>
 <pre class="lab-cmd"><code>npm run star       # optional: support the project without changing screens
-npm run share      # write the anonymous local scorecard for your session host</code></pre>
+npm run share      # send Tenuo a redacted scorecard
+npm run share -- --username YOUR_GITHUB_USERNAME
+                   # optional: use this unverified name on future leaderboards</code></pre>
+<p class="lab-muted">Sharing is explicit. Tenuo receives the star results, attempt count, redacted first-attempt and first-green summaries, a random local challenge-session ID, and runtime versions. It never receives source, keys, argument values, filesystem paths, or client timestamps. The same scorecard is saved locally, and a failed delivery is clearly reported.</p>
 <nav class="lab-nav"><a class="prev" href="/lab/stage-${TOTAL_STAGE_COUNT}">← Stage ${TOTAL_STAGE_COUNT}</a><a class="next" href="/lab/${EPILOGUE.slug}">${esc(EPILOGUE.title)} →</a></nav>
 `;
   return frontMatter({ layout: "lab", title: "What you just learned", description: "The two sentences the lab was built around, and the terms for them.", lab_stage: 0 }) + body;

--- a/labs/agent-delegation/site/capture.ts
+++ b/labs/agent-delegation/site/capture.ts
@@ -23,14 +23,14 @@ export function capture(cmd: string, stage: number, answer?: string): string {
   }
   const home = mkdtempSync(join(tmpdir(), "tenuo-lab-site-"));
   try {
-    const result = spawnSync(process.execPath, [join(ROOT, "node_modules", "tsx", "dist", "cli.mjs"), join(ROOT, "src", "cli", "index.ts"), cmd, "--stage", String(stage)], {
+    const result = spawnSync(process.execPath, ["--import", "tsx", join(ROOT, "src", "cli", "index.ts"), cmd, "--stage", String(stage)], {
       cwd: ROOT,
       env: {
         ...process.env,
         TENUO_LAB_HOME: home,
         ...(answer !== undefined ? { TENUO_LAB_ANSWER: answer } : {}),
         // Captured pages must not send events, whatever the builder's own install says.
-        TENUO_LAB_EVENTS_URL: "http://127.0.0.1:9/",
+        TENUO_LAB_EVENTS_URL: "off",
         NODE_ENV: "development",
       },
       encoding: "utf8",

--- a/labs/agent-delegation/src/cli/index.ts
+++ b/labs/agent-delegation/src/cli/index.ts
@@ -7,7 +7,7 @@
  *   npm run score      see your score and why
  *   npm run audit      what every agent can currently do
  *   npm run next       move to the next stage
- *   npm run share      write an anonymized score breakdown you can hand to your host
+ *   npm run share      submit a redacted scorecard (optionally add --username)
  *   npm run star       optionally star Tenuo without leaving the terminal
  *   npm run reset      back to stage 1
  */
@@ -28,6 +28,7 @@ import { LAB_HOME, loadState, ROOT, saveState } from "../state.ts";
 import { STAGES, stage as stageDef, type Scenario, type StageDef } from "../stages.ts";
 import { recordAttempt, snapshot } from "../telemetry.ts";
 import { starRepository } from "../star.ts";
+import { buildShareReport, submitShareReport } from "../share.ts";
 
 const SITE = "https://tenuo.ai";
 
@@ -438,18 +439,41 @@ async function cmdShare(def: StageDef): Promise<void> {
     console.log("Your exercise file does not load; fix that first (npm run lab shows the error).");
     return;
   }
-  const report = {
-    schema: "tenuo-lab-share-v1",
-    stage: def.n,
-    stars: Object.fromEntries(e.score.stars.map((star) => [star.id, star.earned])),
-    attempts: loadState().attempts?.[String(def.n)] ?? { count: 0 },
-  };
+  let report;
+  try {
+    report = buildShareReport(
+      def.n,
+      Object.fromEntries(e.score.stars.map((star) => [star.id, star.earned])),
+      loadState().attempts?.[String(def.n)],
+      flag("username"),
+    );
+  } catch (error) {
+    console.log(red(`  ${error instanceof Error ? error.message : String(error)}`));
+    process.exitCode = 1;
+    return;
+  }
   const dir = LAB_HOME;
   mkdirSync(dir, { recursive: true });
   const file = join(dir, `share-stage-${def.n}.json`);
   writeFileSync(file, JSON.stringify(report, null, 2));
   printHud(walletLine(e.runs[0]!.built), e.probes, e.score, e.runs.length);
-  console.log(dim(`  Anonymous local artifact: ${file}`));
+  console.log(dim(`  Redacted scorecard saved locally: ${file}`));
+  try {
+    const receipt = await submitShareReport(report);
+    if (receipt === undefined) {
+      console.log(dim("  Submission disabled; no data left this machine."));
+    } else {
+      console.log(green(`  Scorecard received. Receipt: ${receipt.receiptId}`));
+      if (receipt.leaderboardEligible) console.log(dim(`  Leaderboard display name: ${report.username} (unverified)`));
+    }
+  } catch (error) {
+    console.log(yellow(`  Tenuo did not receive it: ${error instanceof Error ? error.message : String(error)}`));
+    console.log(dim("  Your local scorecard is intact; run npm run share again when online."));
+  }
+  if (report.username === undefined) {
+    console.log(dim("  Want a display name on future challenge leaderboards?"));
+    console.log(`  ${bold("npm run share -- --username YOUR_GITHUB_USERNAME")} ${dim("(optional; not identity-verified)")}`);
+  }
   console.log(dim("  If the lab was useful, you can support the project without leaving this terminal:"));
   console.log(`  ${bold("npm run star")} ${dim("(optional; works locally and in Codespaces)")}`);
   console.log("");

--- a/labs/agent-delegation/src/share.ts
+++ b/labs/agent-delegation/src/share.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ROOT, getOrCreateSessionId, type AttemptSnapshot, type StageAttempts } from "./state.ts";
+
+export const SHARE_SCHEMA = "tenuo-lab-share-v2";
+export const DEFAULT_SHARE_ENDPOINT = "https://api.tenuo.ai/v1/lab/submissions";
+
+const USERNAME = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+
+interface ShareHandoff {
+  readonly tools: readonly string[];
+  readonly constraintChecks: { readonly passed: number; readonly total: number };
+  readonly holderBound: boolean;
+  readonly ttl: string;
+}
+
+interface ShareAttempt {
+  readonly starsMissing: readonly string[];
+  readonly checks: { readonly passed: number; readonly total: number };
+  readonly handoffs?: Record<string, ShareHandoff | null>;
+}
+
+export interface ShareReport {
+  readonly schema: typeof SHARE_SCHEMA;
+  readonly sessionId: string;
+  readonly challengeVersion: string;
+  readonly sdkVersion: string;
+  readonly stage: number;
+  readonly stars: Record<string, boolean>;
+  readonly attempts: { readonly count: number; readonly firstAttempt?: ShareAttempt; readonly firstGreen?: ShareAttempt };
+  readonly runtime: { readonly nodeMajor: number; readonly platform: "darwin" | "linux" | "win32" };
+  readonly username?: string;
+}
+
+export interface ShareReceipt {
+  readonly receiptId: string;
+  readonly leaderboardEligible: boolean;
+}
+
+function packageVersions(): { challengeVersion: string; sdkVersion: string } {
+  const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as {
+    version?: unknown;
+    dependencies?: Record<string, unknown>;
+  };
+  const challengeVersion = typeof pkg.version === "string" ? pkg.version : "unknown";
+  const sdk = pkg.dependencies?.["@tenuo/core"];
+  const sdkVersion = typeof sdk === "string" ? sdk.replace(/^[^0-9]*/, "") : "unknown";
+  return { challengeVersion, sdkVersion };
+}
+
+export function normalizeUsername(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const username = value.trim();
+  if (!USERNAME.test(username) || username.includes("--")) {
+    throw new Error("--username must be a GitHub-style username (1–39 letters, numbers, or single hyphens)");
+  }
+  return username;
+}
+
+function shareAttempt(attempt: AttemptSnapshot): ShareAttempt {
+  if (attempt.handoffs === undefined) {
+    return { starsMissing: attempt.starsMissing, checks: attempt.checks };
+  }
+  return {
+    ...attempt,
+    handoffs: Object.fromEntries(Object.entries(attempt.handoffs).map(([name, handoff]) => [
+      name,
+      handoff === "missing" ? null : handoff,
+    ])),
+  };
+}
+
+function shareAttempts(attempts: StageAttempts | undefined): ShareReport["attempts"] {
+  if (attempts === undefined) return { count: 0 };
+  return {
+    count: attempts.count,
+    firstAttempt: shareAttempt(attempts.firstAttempt),
+    ...(attempts.firstGreen === undefined ? {} : { firstGreen: shareAttempt(attempts.firstGreen) }),
+  };
+}
+
+export function buildShareReport(
+  stage: number,
+  stars: Record<string, boolean>,
+  attempts: StageAttempts | undefined,
+  usernameValue?: string,
+): ShareReport {
+  const username = normalizeUsername(usernameValue);
+  const versions = packageVersions();
+  const platform = process.platform;
+  if (platform !== "darwin" && platform !== "linux" && platform !== "win32") {
+    throw new Error(`sharing is not supported on platform ${platform}`);
+  }
+  return {
+    schema: SHARE_SCHEMA,
+    sessionId: getOrCreateSessionId(),
+    ...versions,
+    stage,
+    stars,
+    attempts: shareAttempts(attempts),
+    runtime: { nodeMajor: Number(process.versions.node.split(".")[0]), platform },
+    ...(username === undefined ? {} : { username }),
+  };
+}
+
+export async function submitShareReport(
+  report: ShareReport,
+  options: { endpoint?: string; fetch?: typeof fetch; timeoutMs?: number } = {},
+): Promise<ShareReceipt | undefined> {
+  const configured = options.endpoint ?? process.env["TENUO_LAB_EVENTS_URL"]?.trim() ?? DEFAULT_SHARE_ENDPOINT;
+  if (configured === "off") return undefined;
+  const endpoint = new URL(configured);
+  if (endpoint.protocol !== "https:" && endpoint.hostname !== "localhost" && endpoint.hostname !== "127.0.0.1") {
+    throw new Error("share endpoint must use HTTPS");
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? 8_000);
+  try {
+    const response = await (options.fetch ?? fetch)(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(report),
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`receiver returned HTTP ${response.status}`);
+    const body = await response.json() as Partial<ShareReceipt>;
+    if (typeof body.receiptId !== "string" || typeof body.leaderboardEligible !== "boolean") {
+      throw new Error("receiver returned an invalid receipt");
+    }
+    return { receiptId: body.receiptId, leaderboardEligible: body.leaderboardEligible };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/labs/agent-delegation/src/state.ts
+++ b/labs/agent-delegation/src/state.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { TOOLS } from "./mission.ts";
@@ -11,6 +12,8 @@ const STATE_FILE = join(LAB_HOME, "state.json");
 
 export interface LabState {
   stage: number;
+  /** Random local challenge-session identifier used only on explicit share. */
+  sessionId?: string;
   /** Stages the participant has scored full functionality on. */
   completed: number[];
   /** The warm-up questions were shown once. */
@@ -115,12 +118,21 @@ export function loadState(): LabState {
     return {
       stage: typeof parsed.stage === "number" && parsed.stage >= 1 && parsed.stage <= STAGES.length ? parsed.stage : 1,
       completed: Array.isArray(parsed.completed) ? parsed.completed.filter((n): n is number => typeof n === "number") : [],
+      ...(typeof parsed.sessionId === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(parsed.sessionId) ? { sessionId: parsed.sessionId } : {}),
       ...(parsed.warmupDone === true ? { warmupDone: true } : {}),
       ...(attempts !== undefined ? { attempts } : {}),
     };
   } catch {
     return { stage: 1, completed: [] };
   }
+}
+
+export function getOrCreateSessionId(): string {
+  const state = loadState();
+  if (state.sessionId !== undefined) return state.sessionId;
+  const sessionId = randomUUID();
+  saveState({ ...state, sessionId });
+  return sessionId;
 }
 
 export function saveState(state: LabState): void {

--- a/labs/agent-delegation/test/cli.test.ts
+++ b/labs/agent-delegation/test/cli.test.ts
@@ -15,13 +15,16 @@ function home(): string {
 }
 
 function cli(labHome: string, command: string, stage?: number, answer?: string): string {
-  const args = [join(ROOT, "node_modules", "tsx", "dist", "cli.mjs"), join(ROOT, "src", "cli", "index.ts"), command];
+  // Use Node's loader entry directly: unlike the tsx CLI it does not need an
+  // IPC socket, so this end-to-end test also runs in locked-down CI sandboxes.
+  const args = ["--import", "tsx", join(ROOT, "src", "cli", "index.ts"), command];
   if (stage !== undefined) args.push("--stage", String(stage));
   const result = spawnSync(process.execPath, args, {
     cwd: ROOT,
     env: {
       ...process.env,
       TENUO_LAB_HOME: labHome,
+      TENUO_LAB_EVENTS_URL: "off",
       ...(answer !== undefined ? { TENUO_LAB_ANSWER: answer } : {}),
       NODE_ENV: "development",
     },
@@ -74,11 +77,21 @@ describe("participant CLI", () => {
     expect(share).toContain("works locally and in Codespaces");
     const report = JSON.parse(readFileSync(join(labHome, "share-stage-5.json"), "utf8")) as {
       schema: string;
+      sessionId: string;
+      challengeVersion: string;
+      sdkVersion: string;
       stage: number;
+      runtime: { nodeMajor: number; platform: string };
       attempts: { count: number; firstAttempt: AttemptSnapshot; firstGreen?: AttemptSnapshot };
     };
-    expect(report.schema).toBe("tenuo-lab-share-v1");
+    expect(report.schema).toBe("tenuo-lab-share-v2");
     expect(report.stage).toBe(5);
+    expect(report).toMatchObject({
+      challengeVersion: "0.2.0",
+      sdkVersion: "0.2.5-beta.0",
+      runtime: { nodeMajor: expect.any(Number), platform: expect.any(String) },
+    });
+    expect(report.sessionId).toMatch(/^[0-9a-f-]{36}$/i);
     expect(report.attempts.count).toBe(2);
     expect(report.attempts.firstAttempt.starsMissing.length).toBeGreaterThan(0);
     const firstGreen = report.attempts.firstGreen;
@@ -91,13 +104,15 @@ describe("participant CLI", () => {
       if (handoffs === undefined) throw new Error("share artifact omitted handoff telemetry");
       expect(Object.keys(handoffs)).toEqual(["flight-to-checkin", "checkin-to-boarding"]);
       for (const handoff of Object.values(handoffs)) {
-        if (handoff === "missing") continue;
+        if (handoff === "missing" || handoff === null) continue;
         expect(Object.keys(handoff).sort()).toEqual(["constraintChecks", "holderBound", "tools", "ttl"]);
       }
     }
     const serialized = JSON.stringify(report);
     expect(serialized).not.toMatch(/Alice|Cancún|source|privateKey|publicKey|timestamp/i);
     expect(serialized).not.toMatch(/[0-9a-f]{64}/i);
+    expect(share).toContain("Submission disabled; no data left this machine.");
+    expect(share).toContain("--username YOUR_GITHUB_USERNAME");
   }, 120_000);
 
   it("marks observation stages complete when the documented next command advances them", () => {

--- a/labs/agent-delegation/test/share.test.ts
+++ b/labs/agent-delegation/test/share.test.ts
@@ -1,0 +1,71 @@
+process.env.NODE_ENV = "development";
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+let labHome = "";
+
+beforeAll(() => {
+  labHome = mkdtempSync(join(tmpdir(), "tenuo-share-test-"));
+  process.env.TENUO_LAB_HOME = labHome;
+});
+
+afterAll(() => rmSync(labHome, { recursive: true, force: true }));
+
+describe("lab score submission", () => {
+  it("submits only the fixed redacted contract and accepts a receipt", async () => {
+    vi.resetModules();
+    const { buildShareReport, submitShareReport } = await import("../src/share.ts");
+    const report = buildShareReport(5, {
+      "trip-booked": true,
+      "rogue-stopped": true,
+      "tight-handoff": false,
+      "no-spare-authority": false,
+    }, {
+      count: 1,
+      firstAttempt: {
+        starsMissing: ["tight-handoff", "no-spare-authority"],
+        checks: { passed: 12, total: 14 },
+        handoffs: {
+          "flight-to-checkin": {
+            tools: ["get_reservation", "check_in"],
+            constraintChecks: { passed: 6, total: 7 },
+            holderBound: true,
+            ttl: "under-6m",
+          },
+          "checkin-to-boarding": "missing",
+        },
+      },
+    }, "octo-cat");
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      receiptId: "receipt-1",
+      leaderboardEligible: true,
+    }), { status: 201, headers: { "Content-Type": "application/json" } }));
+    await expect(submitShareReport(report, {
+      endpoint: "http://localhost/v1/lab/submissions",
+      fetch: fetchMock,
+    })).resolves.toEqual({ receiptId: "receipt-1", leaderboardEligible: true });
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual([
+      "attempts", "challengeVersion", "runtime", "schema", "sdkVersion", "sessionId", "stage", "stars", "username",
+    ]);
+    expect(JSON.stringify(body)).not.toMatch(/Alice|Cancún|source|privateKey|publicKey|timestamp/i);
+    expect(JSON.stringify(body)).toContain('"checkin-to-boarding":null');
+  });
+
+  it("rejects names that cannot safely become leaderboard labels", async () => {
+    vi.resetModules();
+    const { normalizeUsername } = await import("../src/share.ts");
+    expect(normalizeUsername("octo-cat")).toBe("octo-cat");
+    expect(() => normalizeUsername("name with spaces")).toThrow(/GitHub-style username/);
+    expect(() => normalizeUsername("two--hyphens")).toThrow(/GitHub-style username/);
+  });
+
+  it("requires HTTPS except for a local end-to-end receiver", async () => {
+    vi.resetModules();
+    const { submitShareReport } = await import("../src/share.ts");
+    await expect(submitShareReport({} as never, { endpoint: "http://example.com/collect" })).rejects.toThrow(/HTTPS/);
+  });
+});


### PR DESCRIPTION
Makes npm run share send the redacted DX scorecard to Tenuo while preserving a local copy and clearly reporting delivery failures. Participants can optionally add an unverified display name for future leaderboards. Nothing is sent automatically.\n\nDepends on private receiver tenuo-ai/tenuo-cloud#255 being deployed first.\n\nTested: lab typecheck, site generation, and 38 tests.