### PR TITLE
fix(lab): share the Stage 5 learning signal

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -107,8 +107,8 @@ jobs:
             index="$(curl --fail --silent --show-error --location "${base_url}/lab/?deploy=${CACHE_BUSTER}-${attempt}" || true)"
             stage5="$(curl --fail --silent --show-error --location "${base_url}/lab/stage-5?deploy=${CACHE_BUSTER}-${attempt}" || true)"
             if [[ "$index" == *"Book the trip. Stop the rogue agent."* ]] && \
-               [[ "$index" == *"A ninety-minute security lab"* ]] && \
-               [[ "$index" != *"AI Agent Delegation Challenge"* ]] && \
+               [[ "$index" == *"A ninety-minute security challenge"* ]] && \
+               [[ "$index" == *"AI Agent Delegation Security Challenge"* ]] && \
                [[ "$stage5" == *"Open the Stage 5 reference on GitHub"* ]] && \
                [[ "$stage5" != *"One solution to the TODO"* ]]; then
               echo "Public lab is current: ${base_url}/lab/"

--- a/docs/lab/index.md
+++ b/docs/lab/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "lab"
-title: "AI Agent Delegation Security Lab"
+title: "AI Agent Delegation Security Challenge"
 og_title: "Security Challenge: Stop a Rogue AI Agent From Ruining Your Trip"
 description: "Give each agent only the authority its part of the trip needs. A free, hands-on lab in AI agent delegation security."
 og_image: "/images/challenge-image.png"
@@ -11,7 +11,7 @@ lab_stage: 0
 lab_version: "0.2.0"
 ---
 <nav class="lab-stepper" aria-label="Stages"><a href="/lab/" class="home" title="Overview">Lab</a><a href="/lab/stage-1" data-n="1" title="Stage 1">1</a><a href="/lab/stage-2" data-n="2" title="Stage 2">2</a><a href="/lab/stage-3" data-n="3" title="Stage 3">3</a><a href="/lab/stage-4" data-n="4" title="Stage 4">4</a><a href="/lab/stage-5" data-n="5" title="Stage 5">5</a><a href="/lab/stage-6" data-n="6" title="Stage 6">6</a><a href="/lab/stage-7" data-n="7" title="Stage 7">7</a><a href="/lab/contribute" title="Optional: Contribute to Tenuo">+</a></nav>
-<header class="lab-hero"><div class="lab-kicker">A ninety-minute security lab · TypeScript · no account needed</div><h1>AI Agent Delegation Security Lab</h1><p class="lab-goal"><strong>Book the trip. Stop the rogue agent.</strong> Six AI agents book a trip. One reads an injected instruction and follows it. Change what the agents may do until the trip succeeds and the rogue gets nowhere.</p></header>
+<header class="lab-hero"><div class="lab-kicker">A ninety-minute security challenge · TypeScript · no account needed</div><h1>AI Agent Delegation Security Challenge</h1><p class="lab-goal"><strong>Book the trip. Stop the rogue agent.</strong> Six AI agents book a trip. One reads an injected instruction and follows it. Change what the agents may do until the trip succeeds and the rogue gets nowhere.</p></header>
 
 <figure class="lab-cover"><img src="/images/challenge-image.svg" width="1200" height="630" alt="A boarding pass from Toronto to Cancún for Alice Chen, stamped denied because it is outside the granted scope." decoding="async" fetchpriority="high"></figure>
 
@@ -23,7 +23,7 @@ cd tenuo/labs/agent-delegation
 npm install
 npm run star       # optional; skip if you are not signed in to GitHub
 npm run lab</code></pre>
-<p class="lab-muted">Node 20 or newer. The lab itself needs no account, API key, or network. The optional star command uses GitHub CLI; skip it if you are not signed in. Every lab check and score is real.</p>
+<p class="lab-muted">Node 20 or newer. The core challenge runs locally with no account or API key; only <code>npm run share</code> and the optional star command use the network. Skip the star command if you are not signed in to GitHub. Every challenge check and score is real.</p>
 </div>
 <div>
 <h2>What to expect</h2>

--- a/labs/agent-delegation/README.md
+++ b/labs/agent-delegation/README.md
@@ -1,4 +1,4 @@
-# AI Agent Delegation Security Lab
+# AI Agent Delegation Security Challenge
 
 Your mission is simple: **book the trip and stop the rogue agent**. A travel
 assistant made of six AI agents is booking spring break in Cancún. One reads
@@ -26,9 +26,10 @@ npm run star       # optional; skip if you are not signed in to GitHub
 npm run lab
 ```
 
-The lab itself needs no account, sign-in, API key, or credit card, and sends
-nothing automatically. The optional star command contacts GitHub through its
-CLI; skip it if you are not signed in. If npm fights you, open the repository
+The core challenge runs locally with no account, sign-in, API key, or credit
+card, and sends nothing automatically. Only `npm run share` and the optional
+star command use the network. The star command contacts GitHub through its CLI;
+skip it if you are not signed in. If npm fights you, open the repository
 in GitHub Codespaces and pick the "Agent Delegation Lab" configuration instead.
 Its terminal opens in this folder, so the same optional `npm run star` followed
 by `npm run lab` applies.

--- a/labs/agent-delegation/package.json
+++ b/labs/agent-delegation/package.json
@@ -2,7 +2,7 @@
   "name": "agent-delegation-lab",
   "version": "0.2.0",
   "private": true,
-  "description": "AI Agent Delegation Security Lab: book the trip, stop the rogue agent, and learn least-privilege handoffs.",
+  "description": "AI Agent Delegation Security Challenge: book the trip, stop the rogue agent, and learn least-privilege handoffs.",
   "type": "module",
   "engines": {
     "node": ">=20"

--- a/labs/agent-delegation/site/build.ts
+++ b/labs/agent-delegation/site/build.ts
@@ -203,7 +203,7 @@ function indexPage(): string {
     ["No spare authority", 20, "Every grant stays at or below the mission's least-privilege ceiling."],
   ] as const;
   const body = `${stepper(0)}
-<header class="lab-hero"><div class="lab-kicker">A ninety-minute security lab · TypeScript · no account needed</div><h1>AI Agent Delegation Security Lab</h1><p class="lab-goal"><strong>Book the trip. Stop the rogue agent.</strong> Six AI agents book a trip. One reads an injected instruction and follows it. Change what the agents may do until the trip succeeds and the rogue gets nowhere.</p></header>
+<header class="lab-hero"><div class="lab-kicker">A ninety-minute security challenge · TypeScript · no account needed</div><h1>AI Agent Delegation Security Challenge</h1><p class="lab-goal"><strong>Book the trip. Stop the rogue agent.</strong> Six AI agents book a trip. One reads an injected instruction and follows it. Change what the agents may do until the trip succeeds and the rogue gets nowhere.</p></header>
 
 <figure class="lab-cover"><img src="/images/challenge-image.svg" width="1200" height="630" alt="A boarding pass from Toronto to Cancún for Alice Chen, stamped denied because it is outside the granted scope." decoding="async" fetchpriority="high"></figure>
 
@@ -215,7 +215,7 @@ cd tenuo/labs/agent-delegation
 npm install
 npm run star       # optional; skip if you are not signed in to GitHub
 npm run lab</code></pre>
-<p class="lab-muted">Node 20 or newer. The lab itself needs no account, API key, or network. The optional star command uses GitHub CLI; skip it if you are not signed in. Every lab check and score is real.</p>
+<p class="lab-muted">Node 20 or newer. The core challenge runs locally with no account or API key; only <code>npm run share</code> and the optional star command use the network. Skip the star command if you are not signed in to GitHub. Every challenge check and score is real.</p>
 </div>
 <div>
 <h2>What to expect</h2>
@@ -278,7 +278,7 @@ npm run reset      # restore stage 1 and every starter exercise</code></pre>
 `;
   return frontMatter({
     layout: "lab",
-    title: "AI Agent Delegation Security Lab",
+    title: "AI Agent Delegation Security Challenge",
     og_title: "Security Challenge: Stop a Rogue AI Agent From Ruining Your Trip",
     description: "Give each agent only the authority its part of the trip needs. A free, hands-on lab in AI agent delegation security.",
     og_image: "/images/challenge-image.png",

--- a/labs/agent-delegation/src/cli/index.ts
+++ b/labs/agent-delegation/src/cli/index.ts
@@ -434,7 +434,13 @@ async function cmdScore(def: StageDef): Promise<void> {
 }
 
 async function cmdShare(def: StageDef): Promise<void> {
-  const e = await evaluateStage(def);
+  const state = loadState();
+  // Stage 5 contains the SDK interaction we most need to learn from: the
+  // participant's first narrowing attempt and their first complete chain.
+  // Keep sharing useful at the wrap-up by reporting that recorded stage even
+  // after the participant has moved on to the optional boss levels.
+  const reportDef = def.n > 5 && state.attempts?.["5"] !== undefined ? stageDef(5) : def;
+  const e = await evaluateStage(reportDef);
   if (e === undefined) {
     console.log("Your exercise file does not load; fix that first (npm run lab shows the error).");
     return;
@@ -442,9 +448,9 @@ async function cmdShare(def: StageDef): Promise<void> {
   let report;
   try {
     report = buildShareReport(
-      def.n,
+      reportDef.n,
       Object.fromEntries(e.score.stars.map((star) => [star.id, star.earned])),
-      loadState().attempts?.[String(def.n)],
+      state.attempts?.[String(reportDef.n)],
       flag("username"),
     );
   } catch (error) {
@@ -454,8 +460,11 @@ async function cmdShare(def: StageDef): Promise<void> {
   }
   const dir = LAB_HOME;
   mkdirSync(dir, { recursive: true });
-  const file = join(dir, `share-stage-${def.n}.json`);
+  const file = join(dir, `share-stage-${reportDef.n}.json`);
   writeFileSync(file, JSON.stringify(report, null, 2));
+  if (reportDef.n !== def.n) {
+    console.log(dim("  Sharing the Stage 5 first-attempt → first-green handoff scorecard."));
+  }
   printHud(walletLine(e.runs[0]!.built), e.probes, e.score, e.runs.length);
   console.log(dim(`  Redacted scorecard saved locally: ${file}`));
   try {

--- a/labs/agent-delegation/test/cli.test.ts
+++ b/labs/agent-delegation/test/cli.test.ts
@@ -115,6 +115,25 @@ describe("participant CLI", () => {
     expect(share).toContain("--username YOUR_GITHUB_USERNAME");
   }, 120_000);
 
+  it("shares the Stage 5 handoff history from the final boss level", () => {
+    const labHome = home();
+    cli(labHome, "lab", 5);
+    cli(labHome, "attack", 5, "answers/05-tenuo/chain.ts");
+
+    const share = cli(labHome, "share", 7, "answers/07-incident/chain.ts");
+    expect(share).toContain("Sharing the Stage 5 first-attempt → first-green handoff scorecard.");
+    expect(share).toMatch(/ROGUE ATTEMPTS BLOCKED \(2 SCENARIOS\)\s+14 \/ 14/);
+    expect(existsSync(join(labHome, "share-stage-7.json"))).toBe(false);
+
+    const report = JSON.parse(readFileSync(join(labHome, "share-stage-5.json"), "utf8")) as {
+      stage: number;
+      attempts: { firstAttempt?: AttemptSnapshot; firstGreen?: AttemptSnapshot };
+    };
+    expect(report.stage).toBe(5);
+    expect(report.attempts.firstAttempt?.handoffs).toBeDefined();
+    expect(report.attempts.firstGreen?.handoffs).toBeDefined();
+  }, 120_000);
+
   it("marks observation stages complete when the documented next command advances them", () => {
     const labHome = home();
     cli(labHome, "next");
@@ -141,14 +160,16 @@ describe("participant CLI", () => {
 describe("generated lab guide", () => {
   it("keeps the public landing-page promise and one reset command", () => {
     const page = readFileSync(join(ROOT, "..", "..", "docs", "lab", "index.md"), "utf8");
-    expect(page).toContain("AI Agent Delegation Security Lab");
+    expect(page).toContain("AI Agent Delegation Security Challenge");
     expect(page).toContain("Book the trip. Stop the rogue agent.");
-    expect(page).toContain("A ninety-minute security lab");
-    expect(page).not.toMatch(/security (?:game|challenge)/);
+    expect(page).toContain("A ninety-minute security challenge");
+    expect(page).not.toMatch(/security (?:game|lab)/);
+    expect(page).toContain("The core challenge runs locally");
+    expect(page).toContain("only <code>npm run share</code> and the optional star command use the network");
     expect(page.match(/npm run reset/g)).toHaveLength(1);
     const deployWorkflow = readFileSync(join(ROOT, "..", "..", ".github", "workflows", "docs.yml"), "utf8");
-    expect(deployWorkflow).toContain("A ninety-minute security lab");
-    expect(deployWorkflow).not.toMatch(/A ninety-minute security (?:game|challenge)/);
+    expect(deployWorkflow).toContain("A ninety-minute security challenge");
+    expect(deployWorkflow).not.toMatch(/A ninety-minute security (?:game|lab)/);
   });
 
   it("keeps the first action focused on setup and offers the optional star in both terminals", () => {


### PR DESCRIPTION
## Summary

- share Stage 5 handoff telemetry from the optional boss levels
- make Challenge the landing-page title and clarify network use
- add an end-to-end regression for the wrap-up share path

## Validation

- npm test (39 passed)
- npm run typecheck
- npm run site -- --check