### PR TITLE
fix(docs): simplify the shared site header

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -603,8 +603,8 @@
       }
 
       .top-nav a {
-        margin-right: 16px;
-        font-size: 0.8rem;
+        margin-right: 12px;
+        font-size: 0.75rem;
       }
     }
   </style>
@@ -617,7 +617,7 @@
     <a href="{{ site.baseurl }}/quickstart">Docs</a>
     <a href="{{ site.baseurl }}/explorer">Explorer</a>
     <a href="https://github.com/tenuo-ai/tenuo">GitHub</a>
-    <a href="https://cloud.tenuo.ai">Sign in</a>
+    <a href="https://cloud.tenuo.ai">Tenuo Cloud</a>
   </nav>
 
   <div class="layout">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -176,6 +176,10 @@
       color: var(--text);
     }
 
+    .top-nav a:last-child {
+      margin-right: 0;
+    }
+
     .top-nav .brand {
       color: var(--text);
       font-weight: 600;
@@ -592,6 +596,17 @@
         padding: 32px 24px;
       }
     }
+
+    @media (max-width: 480px) {
+      .top-nav {
+        padding: 0 16px;
+      }
+
+      .top-nav a {
+        margin-right: 16px;
+        font-size: 0.8rem;
+      }
+    }
   </style>
 </head>
 
@@ -599,17 +614,10 @@
   <nav class="top-nav">
     <a href="{{ site.baseurl }}/" class="brand">tenuo</a>
     <span class="spacer"></span>
-    <a href="{{ site.baseurl }}/quickstart">Quick Start</a>
-    <a href="{{ site.baseurl }}/lab/">Challenge</a>
-    <a href="{{ site.baseurl }}/concepts">Concepts</a>
-    <a href="{{ site.baseurl }}/api-reference">API</a>
-    <a href="{{ site.baseurl }}/openai">OpenAI</a>
-    <a href="{{ site.baseurl }}/crewai">CrewAI</a>
-    <a href="{{ site.baseurl }}/langchain">LangChain</a>
-    <a href="{{ site.baseurl }}/temporal">Temporal</a>
-    <a href="{{ site.baseurl }}/google-adk">Google ADK</a>
-    <a href="{{ site.baseurl }}/early-access.html">Early Access</a>
+    <a href="{{ site.baseurl }}/quickstart">Docs</a>
+    <a href="{{ site.baseurl }}/explorer">Explorer</a>
     <a href="https://github.com/tenuo-ai/tenuo">GitHub</a>
+    <a href="https://cloud.tenuo.ai">Sign in</a>
   </nav>
 
   <div class="layout">

--- a/docs/index.html
+++ b/docs/index.html
@@ -792,7 +792,7 @@
                 <a href="quickstart">Docs</a>
                 <a href="/explorer">Explorer</a>
                 <a href="https://github.com/tenuo-ai/tenuo">GitHub</a>
-                <a href="https://cloud.tenuo.ai">Sign in</a>
+                <a href="https://cloud.tenuo.ai">Tenuo Cloud</a>
             </div>
         </nav>
 

--- a/labs/agent-delegation/test/theme.test.ts
+++ b/labs/agent-delegation/test/theme.test.ts
@@ -61,4 +61,23 @@ describe("public-site theme", () => {
       expect(surface).toContain("letter-spacing: 0.04em");
     }
   });
+
+  it("keeps the documentation and challenge header as focused as the main website", () => {
+    const main = readFileSync(join(REPO, "docs", "index.html"), "utf8");
+    const docs = readFileSync(join(REPO, "docs", "_layouts", "default.html"), "utf8");
+    const mainNav = /<nav>([\s\S]*?)<\/nav>/.exec(main)?.[1];
+    const docsNav = /<nav class="top-nav">([\s\S]*?)<\/nav>/.exec(docs)?.[1];
+
+    expect(mainNav).toBeDefined();
+    expect(docsNav).toBeDefined();
+    expect(docsNav?.match(/<a /g)).toHaveLength(5); // brand plus the four main-site links
+    for (const label of ["Docs", "Explorer", "GitHub", "Sign in"]) {
+      expect(mainNav).toContain(`>${label}<`);
+      expect(docsNav).toContain(`>${label}<`);
+    }
+    for (const label of ["OpenAI", "CrewAI", "LangChain", "Temporal", "Google ADK"]) {
+      expect(docsNav).not.toContain(`>${label}<`);
+    }
+    expect(docs).toContain("@media (max-width: 480px)");
+  });
 });

--- a/labs/agent-delegation/test/theme.test.ts
+++ b/labs/agent-delegation/test/theme.test.ts
@@ -71,7 +71,7 @@ describe("public-site theme", () => {
     expect(mainNav).toBeDefined();
     expect(docsNav).toBeDefined();
     expect(docsNav?.match(/<a /g)).toHaveLength(5); // brand plus the four main-site links
-    for (const label of ["Docs", "Explorer", "GitHub", "Sign in"]) {
+    for (const label of ["Docs", "Explorer", "GitHub", "Tenuo Cloud"]) {
       expect(mainNav).toContain(`>${label}<`);
       expect(docsNav).toContain(`>${label}<`);
     }


### PR DESCRIPTION
## Summary
- match the documentation and challenge header to the main site's four links
- remove framework-specific links from the global header
- keep the compact navigation usable on small screens

## Verification
- npm run typecheck
- npm test (45 tests)
- generated-site freshness check