### PR TITLE
ci: run CodeQL on fork pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,9 @@ concurrency:
 
 jobs:
   analyze:
+    # Keep this false during the default-to-advanced setup transition. Enable
+    # CODEQL_ADVANCED_ENABLED immediately before disabling default setup.
+    if: vars.CODEQL_ADVANCED_ENABLED == 'true'
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+
+# Fork pull requests receive a read-only token and no repository secrets.
+# GitHub permits code-scanning result uploads for pull_request events.
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+          - python
+          - rust
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- add an advanced CodeQL workflow for Actions, JavaScript/TypeScript, Python, and Rust
- run analysis on pull requests, pushes to `main`, a weekly schedule, and manual dispatch
- preserve the existing required check names
- use read-only source access, no secrets, and immutable action pins

## Motivation

GitHub CodeQL default setup excludes pull requests from forks. Because the repository ruleset requires the generated `Analyze (...)` checks, first-time external contributions can otherwise remain permanently blocked.

## Rollout

Keep default setup enabled until this PR merges. After merge, switch CodeQL from default to advanced setup and manually dispatch this workflow once to verify all four language jobs.