### PR TITLE
ci: activate advanced CodeQL on pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,6 @@ concurrency:
 
 jobs:
   analyze:
-    # Keep this false during the default-to-advanced setup transition. Enable
-    # CODEQL_ADVANCED_ENABLED immediately before disabling default setup.
-    if: vars.CODEQL_ADVANCED_ENABLED == 'true'
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

Remove the completed `CODEQL_ADVANCED_ENABLED` transition gate so the advanced CodeQL matrix expands and runs for fork pull requests.

Default setup is already disabled, and the advanced workflow has passed all four language jobs on `main`. The repository variable is not needed after rollout.