### PR TITLE
fix(core): type tool policy fields

### DIFF
--- a/tenuo-ts/packages/core/src/api.ts
+++ b/tenuo-ts/packages/core/src/api.ts
@@ -182,13 +182,25 @@ export type ToolLike<
   execute: (args: TArgs, options?: unknown) => TResult | Promise<TResult>;
 };
 
-export type ToolPolicy = {
+type KeysOfUnion<T> = T extends unknown ? keyof T : never;
+
+export type ToolPolicy<TArgs = undefined> = {
   /**
    * Host ceiling. AND'd with the session in Rust.
    * Non-empty maps are zero-trust: every call argument must be named here.
    * `{}` means no extra ceiling (session/warrant only).
    */
-  readonly allow: AllowPolicy;
+  readonly allow: [NonNullable<TArgs>] extends [object]
+    ? [KeysOfUnion<NonNullable<TArgs>>] extends [never]
+      ? AllowPolicy
+      : string extends KeysOfUnion<NonNullable<TArgs>>
+        ? AllowPolicy
+        : number extends KeysOfUnion<NonNullable<TArgs>>
+          ? AllowPolicy
+          : symbol extends KeysOfUnion<NonNullable<TArgs>>
+            ? AllowPolicy
+            : { readonly [Field in KeysOfUnion<NonNullable<TArgs>>]?: ConstraintExpr }
+    : AllowPolicy;
   readonly capability?: string;
 };
 
@@ -645,7 +657,7 @@ export interface Tenuo {
    */
   tool<T extends { execute: (args: never) => unknown }>(
     inner: T,
-    policy: ToolPolicy,
+    policy: ToolPolicy<Parameters<T["execute"]>[0]>,
   ): ProtectedTool<T>;
   session(input: SessionInput): Session;
   /** Import a warrant minted elsewhere (Rust / Python / another process). */

--- a/tenuo-ts/packages/core/src/client.ts
+++ b/tenuo-ts/packages/core/src/client.ts
@@ -291,7 +291,7 @@ function hasTrustAnchor(options: CreateTenuoOptions): boolean {
   return (options.trustedRoots?.length ?? 0) > 0;
 }
 
-function capabilityName(inner: object, policy: ToolPolicy): string {
+function capabilityName(inner: object, policy: Pick<ToolPolicy, "capability">): string {
   if (policy.capability !== undefined && policy.capability.length > 0) {
     return policy.capability;
   }
@@ -371,7 +371,7 @@ class TenuoClient implements Tenuo {
 
   tool<T extends { execute: (args: never) => unknown }>(
     inner: T,
-    policy: ToolPolicy,
+    policy: ToolPolicy<Parameters<T["execute"]>[0]>,
   ): ProtectedTool<T> {
     if (toolPolicies.has(inner) || wrappedInners.has(inner)) {
       throw new TenuoConfigurationError("tenuo.tool() already wrapped this tool");
@@ -404,7 +404,7 @@ class TenuoClient implements Tenuo {
       execute,
     }) as ProtectedTool<T>;
     wrappedInners.add(inner);
-    toolPolicies.set(wrapped, { capability, allow: { ...policy.allow } });
+    toolPolicies.set(wrapped, { capability, allow: { ...policy.allow } as AllowPolicy });
     return wrapped;
   }
 

--- a/tenuo-ts/packages/core/test/core.test.ts
+++ b/tenuo-ts/packages/core/test/core.test.ts
@@ -28,7 +28,13 @@ import {
   under,
   urlPattern,
 } from "../src/index.ts";
-import type { ExecuteOptions, ProtectedTool, ToolLike } from "../src/index.ts";
+import type {
+  AllowPolicy,
+  ExecuteOptions,
+  ProtectedTool,
+  ToolLike,
+  ToolPolicy,
+} from "../src/index.ts";
 import {
   devContext,
   exportSession,
@@ -53,6 +59,157 @@ describe("ProtectedTool types", () => {
     expectTypeOf<Ctx>().toHaveProperty("session");
     expectTypeOf<Ctx>().toHaveProperty("abortSignal");
     expectTypeOf<ReturnType<Wrapped["execute"]>>().toEqualTypeOf<Promise<string>>();
+  });
+});
+
+describe("ToolPolicy types", () => {
+  it("binds allow fields to tool argument keys", () => {
+    const tenuo = createTenuo({ root: createTenuo.devRoot() });
+    const wrapped = tenuo.tool(
+      {
+        execute: async (
+          { path }: { path: string; encoding?: string },
+          _options?: { abortSignal?: AbortSignal },
+        ) => path,
+      },
+      { capability: "read_file", allow: { path: under("/data") } },
+    );
+
+    tenuo.tool(
+      { execute: async ({ encoding }: { path: string; encoding?: string }) => encoding },
+      { capability: "read_optional", allow: { encoding: exact("utf8") } },
+    );
+    tenuo.tool(
+      { execute: async ({ path }: { path: string }) => path },
+      { capability: "read_unrestricted", allow: {} },
+    );
+
+    type Ctx = NonNullable<Parameters<typeof wrapped.execute>[1]>;
+    expectTypeOf<Ctx>().toMatchTypeOf<ExecuteOptions & { abortSignal?: AbortSignal }>();
+    expectTypeOf<ReturnType<typeof wrapped.execute>>().toEqualTypeOf<Promise<string>>();
+  });
+
+  it("rejects unknown literal policy fields", () => {
+    const tenuo = createTenuo({ root: createTenuo.devRoot() });
+    tenuo.tool(
+      { execute: async ({ path }: { path: string }) => path },
+      {
+        capability: "read_file",
+        allow: {
+          // @ts-expect-error -- tool policies reject unknown literal fields
+          paht: under("/data"),
+        },
+      },
+    );
+  });
+
+  it("keeps bare and no-argument policies open without admitting undefined", () => {
+    const policy: ToolPolicy = { allow: { path: under("/data") } };
+    expectTypeOf(policy.allow).toEqualTypeOf<AllowPolicy>();
+
+    const tenuo = createTenuo({ root: createTenuo.devRoot() });
+    tenuo.tool(
+      { execute: async () => "ok" },
+      { capability: "read_file", allow: { path: under("/data") } },
+    );
+
+    const invalid: ToolPolicy = {
+      allow: {
+        // @ts-expect-error -- bare policies reject undefined constraints
+        path: undefined,
+      },
+    };
+    expectTypeOf(invalid).toEqualTypeOf<ToolPolicy>();
+  });
+
+  it("rejects unknown fields when the whole argument is optional", () => {
+    const tenuo = createTenuo({ root: createTenuo.devRoot() });
+    tenuo.tool(
+      { execute: async (args?: { path: string }) => args?.path },
+      {
+        capability: "read_file",
+        allow: {
+          // @ts-expect-error -- optional tool arguments still restrict policy fields
+          paht: under("/data"),
+        },
+      },
+    );
+  });
+
+  it("keeps broad argument policies constraint-typed", () => {
+    const tenuo = createTenuo({ root: createTenuo.devRoot() });
+    tenuo.tool(
+      { execute: async (args: unknown) => args },
+      {
+        capability: "unknown_args",
+        allow: {
+          // @ts-expect-error -- broad arguments still require constraint expressions
+          bad: 1,
+        },
+      },
+    );
+    tenuo.tool(
+      { execute: async (args: {}) => args },
+      {
+        capability: "empty_args",
+        allow: {
+          // @ts-expect-error -- empty-key arguments fall back to AllowPolicy
+          bad: 1,
+        },
+      },
+    );
+    tenuo.tool(
+      { execute: async (args: Record<string, never>) => args },
+      {
+        capability: "indexed_args",
+        allow: {
+          // @ts-expect-error -- indexed arguments reject undefined constraints
+          bad: undefined,
+        },
+      },
+    );
+    tenuo.tool(
+      { execute: async (args: Record<number, never>) => args },
+      {
+        capability: "numeric_args",
+        allow: {
+          // @ts-expect-error -- numeric index arguments reject undefined constraints
+          0: undefined,
+        },
+      },
+    );
+  });
+
+  it("uses all keys from union argument types", () => {
+    type ReadArgs =
+      | { kind: "file"; path: string }
+      | { kind: "url"; url: string };
+    const tenuo = createTenuo({ root: createTenuo.devRoot() });
+    tenuo.tool(
+      { execute: async (args: ReadArgs) => args.kind },
+      {
+        capability: "read",
+        allow: { path: under("/data"), url: exact("https://example.com") },
+      },
+    );
+    tenuo.tool(
+      { execute: async (args: ReadArgs) => args.kind },
+      {
+        capability: "read",
+        allow: {
+          // @ts-expect-error -- union policies reject fields absent from every member
+          paht: under("/data"),
+        },
+      },
+    );
+  });
+
+  it("does not infer constraint compatibility from field value types", () => {
+    const tenuo = createTenuo({ root: createTenuo.devRoot() });
+    tenuo.tool(
+      { execute: async ({ count }: { count: number }) => count },
+      { capability: "count", allow: { count: under("/data") } },
+    );
   });
 });
 


### PR DESCRIPTION
## Related Issue

Closes #568

## Summary

- Bind `ToolPolicy.allow` keys to the wrapped tool's argument keys.
- Preserve partial, optional, empty, zero-argument, and broad-index policies.
- Add positive and negative compile-time coverage, including union argument types.

## Test Plan

- [x] Tests added/updated
- [x] `pnpm typecheck`
- [x] `pnpm --filter @tenuo/core test`
- [x] `pnpm --filter @tenuo/mcp test`
- [x] `pnpm --filter @tenuo/core build`
- [x] `pnpm --filter @tenuo/core pack:smoke`
- [ ] `./scripts/check.sh` passes — not run because the change is confined to TypeScript public types; the project-specific checks above passed.

## Security Invariants

- [x] Authorization decisions still run in the Rust core; this change only narrows TypeScript authoring types.
- [x] Missing, malformed, expired, untrusted, or denied authority behavior is unchanged.
- [x] Delegation, holder secrets, wire formats, and canonicalization are unchanged.
- [x] N/A for new security-sensitive behavior; no runtime path changed.

## Notes for Reviewer

`ToolPolicy` remains usable without an explicit type argument, and tools without a finite argument-key set fall back to `AllowPolicy`. Union argument types use the union of member keys. This intentionally does not infer constraint compatibility from argument value types and does not change runtime or wire behavior.