### PR TITLE
chore(release): coordinated 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.6] - 2026-09-10
+## [0.3.0] - 2026-09-11
+
+0.2.6 was prepared on `main` but never published. This release supersedes
+it and carries the same changes under a minor version bump, because the
+Rust API changes below are source-incompatible with 0.2.5.
+
+### Breaking
+
+- **Public enums are `#[non_exhaustive]`.** Thirty-seven public enums in
+  `tenuo` now carry the attribute, including `GuardError`,
+  `DelegationError`, `RevocationMode`, `DenialReporting`, `RevocationError`
+  (new `UnavailableAt` arm names the floor path), `TransportError`,
+  `RuntimeError`, `ApprovalRequirement`, and the SDK build-error enums.
+  Exhaustive `match` expressions in downstream crates need a wildcard arm.
+  Cargo treats `0.2.x` as one compatible line, so this ships as 0.3.0 rather
+  than 0.2.6.
+- **Connect token version is required.** `ConnectToken::parse` rejects a
+  missing `v`, `v=0`, and any version other than 1. Tokens issued without
+  `v` fail at parse after upgrade.
+- **Malformed `settings.trusted_roots` entries fail startup** instead of
+  being ignored. Existing gateway configs that contained invalid hex must be
+  corrected before upgrading the authorizer.
+- **`Tenuo::local` and `DataPlane` are deprecated.** `Runtime` is the
+  primary holder entry (`Runtime::builder()`), and `drain_receipts` /
+  `drainReceipts` are deprecated in favour of `peek_receipts` +
+  `acknowledge_receipts`. Crates that deny warnings need to migrate or
+  allow `deprecated`.
 
 ### Added
 
@@ -150,6 +176,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PoP denials use the before-PoP shape. Async holder denials carry the
   PoP after it is signed. Preflight cancellation and deadline denials
   emit a deny receipt.
+- **TypeScript `ToolPolicy.allow` is typed against the wrapped tool.**
+  Keys are bound to the tool's argument keys, so a policy naming an
+  argument the tool does not take is a compile-time error. Partial,
+  optional, empty, zero-argument, and broad-index policies still
+  type-check.
 - **TypeScript: published source maps are usable.** `@tenuo/core` and
   `@tenuo/mcp` JavaScript maps embed the original TypeScript
   (`sourcesContent`), so debuggers and `node --enable-source-maps` show SDK
@@ -162,27 +193,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WASM `evaluate_approval_gates` fails closed** on an invalid warrant,
   malformed gate map, or unparseable arguments (`approval_required: true`
   plus `error`). Previously those cases returned `approval_required: false`.
-- **Connect token version is required.** `ConnectToken::parse` rejects a
-  missing `v`, `v=0`, and any version other than 1. Tokens issued without
-  `v` fail at parse after upgrade. This is a breaking change from 0.2.5.
 - **`drainReceipts()` is a snapshot.** It matches `peekReceipts()`. Only
   `acknowledgeReceipts(n)` removes items. A second drain is not empty.
-- **`RevocationError` is `#[non_exhaustive]`.** A new `UnavailableAt` arm
-  names the floor path; downstream matches need a wildcard.
 - **TypeScript: invalid constraint definitions throw `TenuoConfigurationError`**
   (`TENUO_CONFIGURATION`) instead of a generic `Error`. Validation rules and
   messages are unchanged. Code that catches `TenuoError` or switches on `code`
   now sees builder mistakes too.
-- **`tenuo-wasm` 0.2.6.** `make version-check` runs in CI and covers Rust,
+- **`tenuo-wasm` 0.3.0.** `make version-check` runs in CI and covers Rust,
   WASM, Python, TypeScript, and `@tenuo/mcp`. Compatibility matrix lists
   those artifacts.
 - **Python `AnyValue`.** Importing `Any` emits `DeprecationWarning`. The OR
   combinator is `AnyOf` (Rust type alias, Python, TypeScript `anyOf`).
   `email`, `min`, `max`, and `Shlex` stay product features.
 - **Gateway `clock_tolerance_secs` is applied** to the live `Authorizer`.
-- **Malformed `settings.trusted_roots` entries fail startup** instead of
-  being ignored. This is a breaking change for existing configs that
-  contained invalid hex.
 - **Sidecar graceful shutdown.** SIGTERM/ctrl-c drain the HTTP server, then
   the audit flush. SRL fetch goes through `RevocationTracker` with a file
   floor; a file-loaded list is accepted into the tracker. The sidecar

--- a/README.md
+++ b/README.md
@@ -350,8 +350,8 @@ This runs the [orchestrator -> worker -> authorizer](https://tenuo.ai/demo.html)
 **Official Images** on [Docker Hub](https://hub.docker.com/u/tenuo):
 
 ```bash
-docker pull tenuo/authorizer:0.2.5  # Sidecar for warrant verification
-docker pull tenuo/control:0.2.5     # Control plane (demo/reference)
+docker pull tenuo/authorizer:0.3.0  # Sidecar for warrant verification
+docker pull tenuo/control:0.3.0     # Control plane (demo/reference)
 ```
 
 **Helm Chart**:
@@ -388,7 +388,7 @@ The core crate is the protocol. The `sdk` feature is the enforcement surface: a 
 
 ```toml
 [dependencies]
-tenuo = { version = "0.2.5", features = ["sdk"] }
+tenuo = { version = "0.3.0", features = ["sdk"] }
 ```
 
 ```rust

--- a/charts/tenuo-authorizer/Chart.yaml
+++ b/charts/tenuo-authorizer/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tenuo-authorizer
 description: Tenuo authorization service for Kubernetes
 type: application
-version: 0.2.5
-appVersion: "0.2.5"
+version: 0.3.0
+appVersion: "0.3.0"
 keywords:
   - authorization
   - security

--- a/charts/tenuo-authorizer/README.md
+++ b/charts/tenuo-authorizer/README.md
@@ -218,7 +218,7 @@ helm install tenuo-authorizer ./charts/tenuo-authorizer \
 helm upgrade tenuo-authorizer ./charts/tenuo-authorizer -f new-values.yaml
 
 # Upgrade to a new chart version
-helm upgrade tenuo-authorizer ./charts/tenuo-authorizer --version 0.2.5
+helm upgrade tenuo-authorizer ./charts/tenuo-authorizer --version 0.3.0
 ```
 
 ## Troubleshooting

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -4,17 +4,17 @@
 
 Tracks compatibility between Tenuo artifacts and upstream integration libraries.
 
-## Tenuo artifacts (0.2.6)
+## Tenuo artifacts (0.3.0)
 
 These four packages share the same protocol line. TypeScript stays on the
-`beta` npm dist-tag (`0.2.6-beta.0`).
+`beta` npm dist-tag (`0.3.0-beta.0`).
 
 | Artifact | Package | Version |
 |----------|---------|---------|
-| Rust core | `tenuo` | 0.2.6 |
-| WASM | `tenuo-wasm` | 0.2.6 |
-| Python | `tenuo` / `tenuo_core` | 0.2.6 |
-| TypeScript | `@tenuo/core` | 0.2.6-beta.0 |
+| Rust core | `tenuo` | 0.3.0 |
+| WASM | `tenuo-wasm` | 0.3.0 |
+| Python | `tenuo` / `tenuo_core` | 0.3.0 |
+| TypeScript | `@tenuo/core` | 0.3.0-beta.0 |
 
 `make version-check` (and the CI job of the same name) fails if the Rust,
 Python, and WASM crate versions diverge, or if `@tenuo/core` does not start

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -138,7 +138,7 @@ print(info())
 Tenuo Configuration
 ==================================================
 
-[OK] SDK Version: 0.2.5
+[OK] SDK Version: 0.3.0
 [OK] Rust Core: loaded (wire version 1)
 [OK] Issuer Key: configured
 ```

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -88,7 +88,7 @@ Tenuo runs as a separate container in the same Kubernetes pod. All tool traffic 
 spec:
   containers:
     - name: tenuo-authorizer
-      image: tenuo/authorizer:0.2.5
+      image: tenuo/authorizer:0.3.0
       ports: [{ containerPort: 9090 }]
     - name: tool-api
       image: your-tool:latest
@@ -463,7 +463,7 @@ services:
       - tenuo-authorizer
 
   tenuo-authorizer:
-    image: tenuo/authorizer:0.2.5
+    image: tenuo/authorizer:0.3.0
     ports:
       - "9090:9090"
     environment:

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -183,7 +183,7 @@ env:
 ```yaml
 containers:
 - name: tenuo-authorizer
-  image: tenuo/authorizer:0.2.5
+  image: tenuo/authorizer:0.3.0
   args: ["serve", "--config", "/etc/tenuo/gateway.yaml"]
   ports:
   - name: http
@@ -451,7 +451,7 @@ curl -s localhost:9090/status | jq
 
 ```json
 {
-  "version": "0.2.5",
+  "version": "0.3.0",
   "uptime_secs": 42,
   "cp": {
     "enabled": true,

--- a/tenuo-core/Cargo.lock
+++ b/tenuo-core/Cargo.lock
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/tenuo-core/Cargo.toml
+++ b/tenuo-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Agent Capability Flow Control - Rust core library"

--- a/tenuo-core/fuzz/Cargo.lock
+++ b/tenuo-core/fuzz/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
@@ -724,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.105"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -1317,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.128"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1330,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.128"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1340,22 +1340,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.128"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.128"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]

--- a/tenuo-core/src/planes.rs
+++ b/tenuo-core/src/planes.rs
@@ -605,7 +605,7 @@ fn ensure_srl_not_replaced_or_rolled_back(
 
 #[derive(Debug)]
 #[deprecated(
-    since = "0.2.6",
+    since = "0.3.0",
     note = "use `Authorizer` or `tenuo::sdk::Runtime` as the primary entry point"
 )]
 pub struct DataPlane {

--- a/tenuo-core/src/sdk/runtime.rs
+++ b/tenuo-core/src/sdk/runtime.rs
@@ -238,7 +238,7 @@ impl Session {
     /// Snapshot of pending receipts. They are removed only by
     /// [`acknowledge_receipts`].
     #[cfg(feature = "receipts")]
-    #[deprecated(since = "0.2.6", note = "use `peek_receipts`")]
+    #[deprecated(since = "0.3.0", note = "use `peek_receipts`")]
     pub fn drain_receipts(&self) -> Vec<Receipt> {
         self.peek_receipts()
     }

--- a/tenuo-core/src/sdk/tenuo.rs
+++ b/tenuo-core/src/sdk/tenuo.rs
@@ -58,7 +58,7 @@ impl Tenuo {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[deprecated(
-        since = "0.2.6",
+        since = "0.3.0",
         note = "use `Runtime::builder()` for a long-lived holder process"
     )]
     pub fn local() -> LocalBuilder<NeedRoot> {

--- a/tenuo-python/Cargo.lock
+++ b/tenuo-python/Cargo.lock
@@ -2203,7 +2203,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tenuo"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-python"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "pyo3",
  "tenuo",

--- a/tenuo-python/Cargo.toml
+++ b/tenuo-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-python"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "Capability tokens for AI agents - Python SDK"

--- a/tenuo-python/pyproject.toml
+++ b/tenuo-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tenuo"
-version = "0.2.6"
+version = "0.3.0"
 description = "Capability tokens for AI agents - Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tenuo-python/tenuo/__init__.py
+++ b/tenuo-python/tenuo/__init__.py
@@ -399,7 +399,7 @@ __all__ = [
     "get_default_nonce_store",
 ]
 
-__version__ = "0.2.6"
+__version__ = "0.3.0"
 
 
 def __getattr__(name: str):

--- a/tenuo-ts/packages/core/package.json
+++ b/tenuo-ts/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tenuo/core",
-  "version": "0.2.6-beta.0",
+  "version": "0.3.0-beta.0",
   "description": "Tenuo TypeScript SDK — authorization decisions run in the Rust core (WASM).",
   "license": "Apache-2.0",
   "author": "Tenuo Contributors",

--- a/tenuo-ts/packages/mcp/package.json
+++ b/tenuo-ts/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tenuo/mcp",
-  "version": "0.2.6-beta.0",
+  "version": "0.3.0-beta.0",
   "description": "Optional adapter: guard @modelcontextprotocol/server v2 tools with @tenuo/core.",
   "license": "Apache-2.0",
   "author": "Tenuo Contributors",
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "@modelcontextprotocol/server": "^2.0.0",
-    "@tenuo/core": ">=0.2.6-beta.0 <0.2.7"
+    "@tenuo/core": ">=0.3.0-beta.0 <0.3.1"
   },
   "devDependencies": {
     "@modelcontextprotocol/client": "2.0.0",

--- a/tenuo-wasm/Cargo.lock
+++ b/tenuo-wasm/Cargo.lock
@@ -1410,7 +1410,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tenuo"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "base64 0.23.1",
  "cel-interpreter",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "tenuo-wasm"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/tenuo-wasm/Cargo.toml
+++ b/tenuo-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenuo-wasm"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 authors = ["Tenuo Contributors"]
 description = "WASM bindings for Tenuo"


### PR DESCRIPTION
## Summary

- Coordinated bump to **0.3.0**: Rust `tenuo`, Python `tenuo`, `tenuo-wasm`, Helm chart, and current-version docs, so publishing a GitHub `v0.3.0` release ships one line.
- TypeScript moves to `@tenuo/core@0.3.0-beta.0` / `@tenuo/mcp@0.3.0-beta.0` on the npm `beta` tag; the `@tenuo/mcp` dependency range on core follows.
- The `[0.2.6]` changelog section becomes `[0.3.0]` with a new **Breaking** section. 0.2.6 was prepared on `main` but never published to any registry.
- `#[deprecated(since = "0.2.6")]` attributes now say `0.3.0`, since 0.2.6 never shipped.
- Adds the PR #636 TypeScript `ToolPolicy` typing fix to the changelog.

## Why a minor bump

PR #635 made 37 public enums `#[non_exhaustive]` (including `GuardError`, `DelegationError`, `RevocationMode`, `DenialReporting`). Cargo treats `0.2.5 -> 0.2.6` as a compatible upgrade, so downstream crates with exhaustive matches would break on `cargo update`. Verified against `tenuo-ai/tenuo-rig-demo`, which pins `tenuo = "0.2.5"`: built against `main` it fails with three E0004 non-exhaustive-pattern errors plus a `Tenuo::local` deprecation. `0.3.0` signals the break honestly.

## What was missed by #635 and is fixed here

- `charts/tenuo-authorizer/Chart.yaml` was still `0.2.5` although the chart templates changed (SRL floor mount, `TENUO_TRUSTED_KEYS`). `make version-check` does not cover the chart.
- README Docker pull tags and Cargo snippet, `docs/enforcement.md`, `docs/kubernetes.md`, `docs/debugging.md` still said `0.2.5`.
- Changelog heading date, and the undocumented `#[non_exhaustive]` sweep.

## Test plan

- [x] `make version-check` → `All versions in sync: 0.3.0 (0.3.0-beta.0, 0.3.0-beta.0)`
- [x] `cargo check --locked --all-targets --all-features` in `tenuo-core`; `cargo check --locked` in `tenuo-wasm` and `tenuo-python`
- [x] `cargo update -p tenuo --offline` refreshed all four `Cargo.lock` files (core, python, wasm, fuzz)
- [x] `pnpm install --frozen-lockfile` and `pnpm typecheck` in `tenuo-ts` (lockfile unchanged)
- [x] `helm lint charts/tenuo-authorizer`
- [ ] After merge: publish GitHub release **`v0.3.0`** (not a TS-only tag). `release.yml` publishes crates.io, PyPI, npm `beta`, Docker images, and authorizer binaries from that event.
- [ ] After publish: update `tenuo-ai/tenuo-rig-demo` to `tenuo = "0.3.0"` (wildcard match arms, migrate off `Tenuo::local`).
