### PR TITLE
ci: name the Node versions in the TypeScript SDK lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,8 +650,10 @@ jobs:
   # ============================================================================
   # TYPESCRIPT SDK (WASM-backed @tenuo/core)
   # ============================================================================
+  # Node 20 is the minimum in tenuo-ts/package.json engines. This lane
+  # rebuilds the Rust/WASM package and the Python binding.
   tenuo-ts:
-    name: TypeScript SDK
+    name: TypeScript SDK (Node 20)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -736,7 +738,7 @@ jobs:
             tenuo-ts/packages/core/src/generated/tenuo_wasm.js \
             tenuo-ts/packages/core/src/generated/tenuo_wasm.d.ts
 
-      - name: Pack smoke (Node 20)
+      - name: Build and pack smoke
         working-directory: tenuo-ts
         run: pnpm --filter @tenuo/core build && pnpm --filter @tenuo/core pack:smoke && pnpm --filter @tenuo/mcp build && pnpm --filter @tenuo/mcp pack:smoke
 
@@ -746,8 +748,8 @@ jobs:
           NEXT_TELEMETRY_DISABLED: "1"
         run: node examples/nextjs-node/scripts/verify-packed.mjs
 
-  # Test the committed WASM package on every supported active Node line without
-  # rebuilding it. Node 20 above remains the reproducible Rust/WASM build lane.
+  # Test the committed WASM package on the remaining supported Node lines
+  # without rebuilding it. Node 24 is the active LTS.
   tenuo-ts-node-compat:
     name: TypeScript SDK (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,8 @@ security model.
 
 ### Prerequisites
 
-- Node.js 20 or newer
+- Node.js 24 (the active LTS) for local development. Node.js 20 is the minimum
+  supported version, and CI runs the SDK checks on both.
 - pnpm 9.15.9, as pinned by `tenuo-ts/package.json`
 
 Rust and `wasm-pack` are not required for ordinary TypeScript-only changes. The


### PR DESCRIPTION
## Related Issue

Closes #589

## Summary

- Rename the Node 20 lane to `TypeScript SDK (Node 20)` so the checks list names all three tested majors instead of two.
- Fix the job comments: which lane is the `engines` minimum and rebuilds Rust/WASM, and which matrix entry is the active LTS.
- CONTRIBUTING recommends Node 24 for local development and keeps Node 20 as the stated minimum.

Names and comments only: no step, action, or Node version changed, and the supported range is untouched.

Scope: 681b935 already added the Node 22 and 24 matrix, so exercising both supported points, the pinned pnpm on every entry, both packages, and failing on either runtime already held. What was left is that the minimum ran under a lane named `TypeScript SDK`, which reads as though it goes untested, and that CONTRIBUTING gave a floor but no recommended version.

Ruleset: `Core security invariants` requires a check named `TypeScript SDK`, which stops reporting once the lane is renamed. It needs to become `TypeScript SDK (Node 20)` next to the `(Node 22)` and `(Node 24)` entries already listed. Happy to drop the rename if you would rather not touch the ruleset.

## Test Plan

- [ ] Tests added/updated: N/A, the change is job names, comments, and docs. `actionlint` reports only the three shellcheck notes already on `main`.
- [x] Node 20.19.4 and Node 24.21.0, pnpm 9.15.9: `pnpm typecheck`, core (265 passed, 10 skipped), mcp (20 passed), then build and `pack:smoke` for both packages.
- [x] Rebased onto 307fa02 and rechecked. The four `TypeScript SDK` lanes on this PR cover the same ground upstream.
- [ ] `./scripts/check.sh` not run: Rust, Python, and Explorer only.

## Security Invariants

N/A: CI job names, comments, and contributor documentation. No authorization, wire, WASM, or release changes.
