### PR TITLE
docs(ts): add a minimal runnable @tenuo/mcp v2 example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **TypeScript minimal `@tenuo/mcp` v2 example.**
+  `tenuo-ts/packages/mcp/examples/v2` runs an in-memory official v2 client
+  and server with one `guardTools()` tool, one `tenuo.mcp.attach()` call
+  that is allowed, and one swapped-argument call that is denied before the
+  handler runs. `pnpm example:mcp:v2` runs it. (#570)
+
 ## [0.3.0] - 2026-09-11
 
 0.2.6 was prepared on `main` but never published. This release supersedes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,7 @@ inputs. Editors fall back to the published `.d.ts` files.
 pnpm example:mcp          # quarterly-close wire scenario
 pnpm example:mcp:host     # official MCP v1 recipe
 pnpm example:mcp:adapter  # @tenuo/mcp v2 adapter tests
+pnpm example:mcp:v2       # minimal @tenuo/mcp v2 client/server example
 ```
 
 ### TypeScript contribution rules

--- a/tenuo-ts/README.md
+++ b/tenuo-ts/README.md
@@ -806,7 +806,9 @@ fails closed. Its `ttlSeconds` option defaults to 180 and, when provided, must
 be positive, finite, and small enough to represent in milliseconds.
 
 See the [`@tenuo/mcp` README](packages/mcp/README.md) for handler behavior,
-error mapping, and replay protection. A complete multi-agent scenario lives in
+error mapping, and replay protection. The smallest runnable v2 client/server
+pair is [`packages/mcp/examples/v2`](packages/mcp/examples/v2/README.md)
+(`pnpm example:mcp:v2`). A complete multi-agent scenario lives in
 [`packages/core/examples/mcp`](packages/core/examples/mcp/README.md).
 
 ## Packages and compatibility

--- a/tenuo-ts/package.json
+++ b/tenuo-ts/package.json
@@ -9,6 +9,7 @@
     "example:mcp": "pnpm --filter @tenuo/core exec vitest run test/mcp.test.ts -t quarterly-close",
     "example:mcp:host": "pnpm --filter @tenuo/core exec vitest run test/mcp-host.smoke.test.ts",
     "example:mcp:adapter": "pnpm --filter @tenuo/mcp test",
+    "example:mcp:v2": "pnpm --filter @tenuo/mcp exec vitest run test/example-v2.test.ts",
     "test:mutation": "stryker run stryker.core.config.mjs && stryker run stryker.mcp.config.mjs"
   },
   "engines": {

--- a/tenuo-ts/packages/mcp/README.md
+++ b/tenuo-ts/packages/mcp/README.md
@@ -63,6 +63,10 @@ failure returns the constant "Replay store unavailable"; pass
 `onNonceStoreError` for the original cause. Unknown option keys, including
 mixed typos like `{ allow, nonceStroe }`, throw at register time.
 
+A minimal runnable version of the above, with an in-memory v2 client and
+server, one allowed call, and one denied call, lives in
+[`examples/v2`](examples/v2/README.md). From `tenuo-ts`: `pnpm example:mcp:v2`.
+
 There is no FastMCP adapter and no v1 adapter package. For
 `@modelcontextprotocol/sdk` v1, copy the recipe in
 `packages/core/examples/mcp/host.ts`.

--- a/tenuo-ts/packages/mcp/examples/v2/README.md
+++ b/tenuo-ts/packages/mcp/examples/v2/README.md
@@ -1,0 +1,33 @@
+# Minimal `@tenuo/mcp` v2 example
+
+The smallest runnable picture of where Tenuo attaches and verifies MCP
+authority with the official `@modelcontextprotocol/client` and
+`@modelcontextprotocol/server` v2 packages. No network, no credentials.
+
+```text
+main.ts   in-memory server + client, one guarded tool, one allowed and one denied call
+```
+
+Client side, `tenuo.mcp.attach()` from `@tenuo/core` checks the arguments
+against the agent's session and signs them onto `_meta.tenuo`. Server side,
+`guardTools()` from `@tenuo/mcp` verifies that envelope in Rust before the
+handler runs. The denied call reuses a valid envelope with swapped arguments;
+the proof no longer matches, the guard answers with a JSON-RPC error, and the
+handler never executes.
+
+From `tenuo-ts`:
+
+```bash
+pnpm example:mcp:v2
+```
+
+Expected output:
+
+```text
+allowed  read_file /data/reports/q3.pdf -> contents of /data/reports/q3.pdf
+denied   read_file /data/hr/payroll.csv -> TENUO_INVALID_POP (JSON-RPC -32001)
+handler executed for: ["/data/reports/q3.pdf"]
+```
+
+For the full multi-agent quarterly-close scenario, see
+[`packages/core/examples/mcp`](../../../core/examples/mcp/README.md).

--- a/tenuo-ts/packages/mcp/examples/v2/main.ts
+++ b/tenuo-ts/packages/mcp/examples/v2/main.ts
@@ -1,0 +1,121 @@
+/**
+ * Minimal `@tenuo/mcp` example for the official MCP TypeScript v2 packages.
+ *
+ * One in-memory server, one in-memory client, one guarded tool.
+ *
+ *   client side  tenuo.mcp.attach()   (@tenuo/core)  puts a warrant and a
+ *                                      proof-of-possession on `_meta.tenuo`
+ *   server side  guardTools()         (@tenuo/mcp)   verifies that envelope in
+ *                                      Rust before the tool handler runs
+ *
+ * Two requests are sent: one that is allowed and one whose arguments were
+ * changed after attach. The second is denied and the handler never executes.
+ *
+ * Run from `tenuo-ts`: `pnpm example:mcp:v2`
+ */
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
+import { McpServer } from "@modelcontextprotocol/server";
+import { createTenuo, under } from "@tenuo/core";
+import { guardTools } from "@tenuo/mcp";
+import { z } from "zod";
+
+export type ExampleOutcome = {
+  /** The allowed call: the handler ran and returned its text. */
+  readonly allowed: { readonly isError: boolean; readonly text: string };
+  /** The denied call: a JSON-RPC error body, and the handler never ran. */
+  readonly denied: {
+    readonly isError: boolean;
+    readonly rpc?: { readonly code: number; readonly data?: { readonly tenuo?: { readonly code: string } } };
+  };
+  /** Every path the `read_file` handler actually executed for. */
+  readonly executed: readonly string[];
+};
+
+export async function runMinimalExample(log: (line: string) => void = console.log): Promise<ExampleOutcome> {
+  // Dev-only: one process holds the root key and also verifies. In production
+  // the server is built with `trustedRoots: [publicKey]` and never sees a
+  // holder secret.
+  const tenuo = createTenuo({ root: createTenuo.devRoot() });
+
+  // ---------------------------------------------------------------- server
+  // The host ceiling: `read_file` may only ever touch `/data`, whatever the
+  // warrant says. `allow` is AND'd with the warrant in Rust and is not
+  // advertised to clients.
+  const executed: string[] = [];
+  const server = new McpServer({ name: "tenuo-minimal", version: "0.3.0" });
+  guardTools(tenuo, server).register(
+    "read_file",
+    {
+      description: "Read a file under /data",
+      inputSchema: z.object({ path: z.string() }),
+      allow: { path: under("/data") },
+    },
+    async ({ path }) => {
+      executed.push(path);
+      return { content: [{ type: "text", text: `contents of ${path}` }] };
+    },
+  );
+
+  // ---------------------------------------------------------------- client
+  // A session is a warrant for one agent. This one may read `/data/reports`.
+  const session = tenuo.session({
+    allow: { read_file: { path: under("/data/reports") } },
+  });
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "tenuo-minimal-client", version: "0.3.0" });
+  await client.connect(clientTransport);
+
+  try {
+    // 1. Allowed. `attach` checks the arguments against the session, then
+    //    signs them so the server can prove they were not changed in flight.
+    const call = tenuo.mcp.attach(session, "read_file", { path: "/data/reports/q3.pdf" });
+    const allowed = summarize(
+      await client.callTool({ name: call.name, arguments: call.arguments, _meta: call._meta }),
+    );
+    log(`allowed  read_file ${call.arguments.path} -> ${allowed.text}`);
+
+    // 2. Denied. Same envelope, but the arguments are swapped after attach.
+    //    The proof-of-possession no longer matches, so the guard rejects the
+    //    call before the handler runs.
+    const denied = summarize(
+      await client.callTool({
+        name: call.name,
+        arguments: { path: "/data/hr/payroll.csv" },
+        _meta: call._meta,
+      }),
+    );
+    log(
+      `denied   read_file /data/hr/payroll.csv -> ${String(denied.rpc?.data?.tenuo?.code)} (JSON-RPC ${String(denied.rpc?.code)})`,
+    );
+    log(`handler executed for: ${JSON.stringify(executed)}`);
+
+    return { allowed, denied, executed };
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+function summarize(result: Awaited<ReturnType<Client["callTool"]>>): {
+  isError: boolean;
+  text: string;
+  rpc?: { code: number; data?: { tenuo?: { code: string } } };
+} {
+  const isError = "isError" in result && result.isError === true;
+  const content = "content" in result && Array.isArray(result.content) ? result.content : [];
+  const first = content[0];
+  const text =
+    first !== undefined && typeof first === "object" && "text" in first && typeof first.text === "string"
+      ? first.text
+      : "";
+  if (!isError) {
+    return { isError, text };
+  }
+  try {
+    return { isError, text, rpc: JSON.parse(text) as { code: number; data?: { tenuo?: { code: string } } } };
+  } catch {
+    return { isError, text };
+  }
+}

--- a/tenuo-ts/packages/mcp/examples/v2/main.ts
+++ b/tenuo-ts/packages/mcp/examples/v2/main.ts
@@ -79,6 +79,10 @@ export async function runMinimalExample(log: (line: string) => void = console.lo
     // 2. Denied. Same envelope, but the arguments are swapped after attach.
     //    The proof-of-possession no longer matches, so the guard rejects the
     //    call before the handler runs.
+    //    Note the session ceiling above: `attach()` would have refused
+    //    `/data/hr/payroll.csv` outright, since it is outside
+    //    `/data/reports`. This call is the in-flight swap, which only the
+    //    server can catch.
     const denied = summarize(
       await client.callTool({
         name: call.name,

--- a/tenuo-ts/packages/mcp/test/example-v2.test.ts
+++ b/tenuo-ts/packages/mcp/test/example-v2.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { runMinimalExample } from "../examples/v2/main.ts";
+
+describe("examples/v2", () => {
+  it("allows the attached call and denies the swapped one without running the handler", async () => {
+    const outcome = await runMinimalExample();
+    expect(outcome.allowed).toEqual({ isError: false, text: "contents of /data/reports/q3.pdf" });
+    expect(outcome.denied.isError).toBe(true);
+    expect(outcome.denied.rpc).toMatchObject({
+      code: -32001,
+      data: { tenuo: { code: "TENUO_INVALID_POP" } },
+    });
+    expect(outcome.executed).toEqual(["/data/reports/q3.pdf"]);
+  });
+});

--- a/tenuo-ts/packages/mcp/test/example-v2.test.ts
+++ b/tenuo-ts/packages/mcp/test/example-v2.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { runMinimalExample } from "../examples/v2/main.ts";
 
+// `pnpm example:mcp:v2` runs this file to show the example's output.
+// Under `pnpm test` it stays quiet.
+const log = process.env.npm_lifecycle_event === "example:mcp:v2" ? console.log : () => undefined;
+
 describe("examples/v2", () => {
   it("allows the attached call and denies the swapped one without running the handler", async () => {
-    const outcome = await runMinimalExample();
+    const outcome = await runMinimalExample(log);
     expect(outcome.allowed).toEqual({ isError: false, text: "contents of /data/reports/q3.pdf" });
     expect(outcome.denied.isError).toBe(true);
     expect(outcome.denied.rpc).toMatchObject({

--- a/tenuo-ts/packages/mcp/tsconfig.json
+++ b/tenuo-ts/packages/mcp/tsconfig.json
@@ -14,8 +14,9 @@
     "noEmit": true,
     "types": ["node"],
     "paths": {
-      "@tenuo/core": ["../core/src/index.ts"]
+      "@tenuo/core": ["../core/src/index.ts"],
+      "@tenuo/mcp": ["./src/index.ts"]
     }
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "examples/**/*.ts"]
 }

--- a/tenuo-ts/packages/mcp/vitest.config.ts
+++ b/tenuo-ts/packages/mcp/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@tenuo/core": fileURLToPath(new URL("../core/src/index.ts", import.meta.url)),
+      "@tenuo/mcp": fileURLToPath(new URL("./src/index.ts", import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
Closes #570

## What

Adds `tenuo-ts/packages/mcp/examples/v2`, the smallest runnable picture of where Tenuo attaches and verifies MCP authority with the official `@modelcontextprotocol/client` and `@modelcontextprotocol/server` v2 packages.

- In-memory server and client via `InMemoryTransport.createLinkedPair()`; no network, no credentials.
- One `read_file` tool registered with `guardTools()` and a `/data` host ceiling.
- Client side: `tenuo.mcp.attach()` for a session limited to `/data/reports`.
- One allowed call (`/data/reports/q3.pdf`) and one denied call (same envelope, path swapped to a payroll file). The denied call returns `TENUO_INVALID_POP` / JSON-RPC `-32001`, and the recorded execution list shows the handler never ran.
- Both transports close in a `finally` block.

The example imports `@tenuo/core` and `@tenuo/mcp` by package name, as user code would. A vitest alias and a tsconfig `paths` entry map `@tenuo/mcp` to source so it runs and typechecks without a build.

## Wiring

- `pnpm example:mcp:v2` (workspace script, same pattern as `example:mcp` / `example:mcp:host`).
- `test/example-v2.test.ts` runs the example and asserts both outcomes so CI keeps it from rotting.
- Linked from the `@tenuo/mcp` README, the `tenuo-ts` README, and the contributor guide's example list. Changelog entry under Unreleased.

## Out of scope

Per the issue: the quarterly-close example is untouched, and no v1 adapter or FastMCP support is added.

## Verification

- `pnpm typecheck` passes for `@tenuo/core` and `@tenuo/mcp`.
- `pnpm --filter @tenuo/mcp test`: 21 tests pass (20 existing + the new one).
- `@tenuo/core` and `@tenuo/mcp` build; `@tenuo/mcp` pack smoke passes; `examples/` does not land in `dist`.

Example output:

```text
allowed  read_file /data/reports/q3.pdf -> contents of /data/reports/q3.pdf
denied   read_file /data/hr/payroll.csv -> TENUO_INVALID_POP (JSON-RPC -32001)
handler executed for: ["/data/reports/q3.pdf"]
```